### PR TITLE
docs: add README and CLAUDE.md with Pixel cross-references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# Claude Code Instructions — amplify-design-system
+
+## What This Repo Is
+
+This is the **build system** for One Impression's unified design tokens and shared UI components. It produces npm packages consumed by 3 products (Brand, Creator, Atmosphere).
+
+## What This Repo Is NOT
+
+This repo does NOT handle design governance, auditing, or intelligence. That is **Pixel Agent** (`pixel-agent` repo, deployed at pixel.amplify.club).
+
+Before building anything related to:
+- Token drift detection → already in Pixel (`token-sync.ts`)
+- Design review / PR compliance → already in Pixel (`pr-reviewer.ts`)
+- Accessibility auditing → already in Pixel (`accessibility-auditor.ts`)
+- Theme management → already in Pixel (`theme-manager.ts`)
+- Brand cascade → already in Pixel (`brand-cascade.ts`)
+- Design mockups → already in Pixel (`design-generator.ts`)
+- Component registry/tracking → already in Pixel (`design-system-manager.ts`)
+- Visual regression → already in Pixel (`visual-comparison.ts`)
+- Cross-product dependency analysis → already in Pixel (`cross-product-deps.ts`)
+- Design governance / approval workflows → already in Pixel (`design-governance.ts`)
+- Motion design system → already in Pixel (`motion-system.ts`)
+
+**Check Pixel first. Do not duplicate.**
+
+## Pixel ↔ This Repo Integration
+
+Pixel reads from this repo via GitHub API:
+- `packages/tokens-foundation/tokens/*.json` — primitives
+- `packages/tokens-brand/tokens/*.json` — brand tokens
+- `packages/tokens-atmosphere/tokens/*.json` — atmosphere tokens
+- `packages/tokens-creator/tokens/*.json` — creator tokens
+
+Pixel's `token-sync.ts` compares these canonical files against what's deployed in product repos. When drift is found, Pixel raises alerts and can auto-cascade fixes.
+
+## Build Commands
+
+```bash
+npm install          # Install workspace dependencies
+npm run build        # Build all packages (tokens + UI + storybook)
+npm run validate     # Cross-package consistency check
+npm run storybook    # Launch Storybook at port 6006
+```
+
+## Package Structure
+
+```
+packages/
+  tokens-foundation/  — Shared primitives (spacing, radii, shadows, typography, z-index, breakpoints)
+  tokens-brand/       — Brand Platform tokens (purple primary, light/dark themes)
+  tokens-atmosphere/  — Atmosphere tokens (gold accent, dark-first themes)
+  tokens-creator/     — Creator App tokens (SDUI mappings, mobile-optimized)
+  ui/                 — Shared React components (Button, Badge, Card, EmptyState, Skeleton)
+  storybook/          — Component documentation and visual testing
+  eslint-config/      — Design system lint rules (no-hardcoded-colors, no-raw-spacing, prefer-token-import)
+  feature-flags/      — Feature flag utilities
+```
+
+## Token File Format
+
+Current format (pre-W3C migration):
+```json
+{ "value": "#6531FF", "type": "color" }
+```
+
+Style Dictionary v4.3 builds these into CSS variables, SCSS, JSON, JS, and Tailwind presets.
+
+## CI/CD
+
+- `figma-sync.yml` — Tokens Studio → build → validate → auto-PR
+- `ci.yml` — Build all packages, validate consistency, secret scan
+- `sdui-sync-check.yml` — Validates creator tokens vs api-gateway ColorType enum
+
+## Rules
+
+1. **No hardcoded colors** in UI components — use CSS variables only
+2. **No design governance logic here** — that's Pixel's job
+3. **All token changes** should go through Figma sync or direct PR (Pixel will cascade)
+4. **ESLint rules** exist in `packages/eslint-config/rules/` but are NOT enforced in product repos yet

--- a/README.md
+++ b/README.md
@@ -1,0 +1,103 @@
+# Amplify Design System
+
+Federated design tokens and shared UI components for all One Impression products.
+
+## Architecture
+
+```
+                    +-----------------------+
+                    |   Pixel Agent (CDO)   |
+                    |  pixel.amplify.club   |
+                    |                       |
+                    |  - Token governance   |
+                    |  - Drift detection    |
+                    |  - Design review      |
+                    |  - Brand cascade      |
+                    |  - A11y auditing      |
+                    |  - Mockup generation  |
+                    |  - Theme management   |
+                    +----------+------------+
+                               |
+                    reads/syncs via GitHub API
+                               |
+                    +----------v------------+
+                    | amplify-design-system  |  <-- YOU ARE HERE
+                    |     (this repo)        |
+                    |                        |
+                    |  - Token source files  |
+                    |  - Style Dictionary    |
+                    |  - npm packages        |
+                    |  - UI components       |
+                    |  - ESLint rules        |
+                    |  - Storybook           |
+                    |  - Figma sync          |
+                    +----------+-------------+
+                               |
+                    npm install @amplify/tokens-*
+                               |
+          +--------------------+--------------------+
+          |                    |                    |
+  +-------v------+   +--------v-------+   +-------v--------+
+  |    Brand     |   |   Creator App  |   |  Atmosphere    |
+  | one-dashboard|   |  one_club_app  |   | odin-agent/web |
+  |    -web      |   |                |   |                |
+  +--------------+   +----------------+   +----------------+
+```
+
+## This repo is the BUILD SYSTEM. Pixel is the BRAIN.
+
+| This repo does | Pixel does |
+|----------------|------------|
+| Stores token JSON source files | Governs token changes (approval workflows) |
+| Builds CSS/JS/RN output via Style Dictionary | Detects token drift (Pixel vs code) |
+| Publishes npm packages (@amplify/*) | Cascades brand changes across products |
+| Houses React UI components | Reviews PR design compliance |
+| Runs Storybook for component docs | Audits accessibility (WCAG 2.1 AA) |
+| Provides ESLint rules | Generates design mockups & handoff specs |
+| Syncs with Figma (Tokens Studio) | Manages themes (dark, light, high-contrast) |
+
+**Do NOT rebuild governance, auditing, or design intelligence here.** That lives in [pixel-agent](https://github.com/One-Impression/pixel-agent).
+
+## Packages
+
+| Package | Purpose | Consumer |
+|---------|---------|----------|
+| `@amplify/tokens-foundation` | Shared primitives (spacing, radii, shadows, typography) | All products |
+| `@amplify/tokens-brand` | Brand platform colors & theme | one-dashboard-web |
+| `@amplify/tokens-atmosphere` | Atmosphere dashboard colors & theme | odin-agent/web |
+| `@amplify/tokens-creator` | Creator app colors & SDUI mapping | one_club_app |
+| `@amplify/ui` | Shared React UI components | Web products |
+| `@amplify/eslint-config` | Design system lint rules | All products |
+| `@amplify/feature-flags` | Feature flag utilities | All products |
+
+## Token Flow
+
+1. Designer updates tokens in **Figma** (Tokens Studio plugin)
+2. Tokens Studio pushes JSON to `tokens-studio/*` branch on this repo
+3. **GitHub Actions** builds all packages, validates, creates PR
+4. On merge: npm publish + **Pixel** detects update via scheduled drift check
+5. Pixel runs brand cascade → identifies affected products → generates fix PRs
+6. Products `npm update @amplify/tokens-*` to adopt changes
+
+## Pixel Integration Points
+
+- **Token sync**: `pixel-agent/src/services/token-sync.ts` reads from `packages/tokens-*/tokens/` via GitHub API
+- **Drift detection**: Pixel compares this repo's tokens against live product code every 6 hours
+- **Brand cascade**: When tokens change here, Pixel propagates to all 3 products
+- **PR review**: Pixel checks product PRs for design system compliance
+
+## Development
+
+```bash
+npm install          # Install all workspace deps
+npm run build        # Build all token packages + UI
+npm run storybook    # Launch Storybook (port 6006)
+npm run validate     # Cross-package consistency check
+```
+
+## Related Repos
+
+- [pixel-agent](https://github.com/One-Impression/pixel-agent) — AI Chief Design Officer (governance, auditing, intelligence)
+- [one-dashboard-web](https://github.com/One-Impression/one-dashboard-web) — Brand Platform (consumer)
+- [one_club_app](https://github.com/One-Impression/one_club_app) — Creator App (consumer)
+- [odin-agent](https://github.com/One-Impression/odin-agent) — Atmosphere Dashboard (consumer)


### PR DESCRIPTION
## Summary
- Adds README.md with architecture diagram showing Pixel ↔ monorepo relationship
- Adds CLAUDE.md so AI agents know to check Pixel before proposing design governance features
- Fixes critical discoverability gap: monorepo had zero documentation pointing to Pixel's 34 existing services

## Why
During unified design system planning, ~60% of proposed features were already built in Pixel but undiscoverable because this repo had no README or CLAUDE.md.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] CLAUDE.md lists all Pixel services accurately
- [ ] Architecture diagram is readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)