### PR TITLE
feat: npm publishing via GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,16 @@ jobs:
         run: |
           for pkg in tokens-foundation tokens-brand tokens-atmosphere tokens-creator ui eslint-config; do
             cd packages/$pkg
-            npm publish --access restricted || true
+            OUTPUT=$(npm publish --access restricted 2>&1) && echo "$OUTPUT" || {
+              EXIT_CODE=$?
+              echo "$OUTPUT"
+              if echo "$OUTPUT" | grep -q 'EPUBLISHCONFLICT\|already been published\|You cannot publish over the previously published versions'; then
+                echo "Package already published at this version — skipping"
+              else
+                echo "::error::Publish failed for $pkg"
+                exit $EXIT_CODE
+              fi
+            }
             cd ../..
           done
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-validate:
     name: Build & Validate Tokens
@@ -18,6 +22,8 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          registry-url: https://npm.pkg.github.com
+          scope: '@amplify'
 
       - name: Install dependencies
         run: npm ci
@@ -58,6 +64,17 @@ jobs:
 
       - name: Build Storybook
         run: npm run build -w packages/storybook
+
+      - name: Publish packages
+        if: github.ref == 'refs/heads/main'
+        run: |
+          for pkg in tokens-foundation tokens-brand tokens-atmosphere tokens-creator ui eslint-config; do
+            cd packages/$pkg
+            npm publish --access restricted || true
+            cd ../..
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   secret-scan:
     name: Secret Scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,14 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build-and-validate:
     name: Build & Validate Tokens
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -68,6 +70,7 @@ jobs:
       - name: Publish packages
         if: github.ref == 'refs/heads/main'
         run: |
+          set -e
           for pkg in tokens-foundation tokens-brand tokens-atmosphere tokens-creator ui eslint-config; do
             echo "Publishing @amplify/$pkg..."
             (
@@ -83,8 +86,6 @@ jobs:
                 fi
               }
             )
-            # Propagate subshell failure
-            if [ $? -ne 0 ]; then exit 1; fi
           done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,18 +69,22 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           for pkg in tokens-foundation tokens-brand tokens-atmosphere tokens-creator ui eslint-config; do
-            cd packages/$pkg
-            OUTPUT=$(npm publish --access restricted 2>&1) && echo "$OUTPUT" || {
-              EXIT_CODE=$?
-              echo "$OUTPUT"
-              if echo "$OUTPUT" | grep -q 'EPUBLISHCONFLICT\|already been published\|You cannot publish over the previously published versions'; then
-                echo "Package already published at this version — skipping"
-              else
-                echo "::error::Publish failed for $pkg"
-                exit $EXIT_CODE
-              fi
-            }
-            cd ../..
+            echo "Publishing @amplify/$pkg..."
+            (
+              cd packages/$pkg
+              OUTPUT=$(npm publish --access restricted 2>&1) && echo "$OUTPUT" || {
+                EXIT_CODE=$?
+                echo "$OUTPUT"
+                if echo "$OUTPUT" | grep -q 'EPUBLISHCONFLICT\|already been published\|You cannot publish over the previously published versions'; then
+                  echo "Package already published at this version — skipping"
+                else
+                  echo "::error::Publish failed for $pkg"
+                  exit $EXIT_CODE
+                fi
+              }
+            )
+            # Propagate subshell failure
+            if [ $? -ne 0 ]; then exit 1; fi
           done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@amplify:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -7,5 +7,9 @@
   "peerDependencies": {
     "eslint": ">=8.0.0"
   },
-  "files": ["index.js", "rules/"]
+  "files": ["index.js", "rules/"],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  }
 }

--- a/packages/tokens-atmosphere/package.json
+++ b/packages/tokens-atmosphere/package.json
@@ -18,5 +18,9 @@
   "devDependencies": {
     "style-dictionary": "^4.3.0"
   },
-  "files": ["dist/", "tokens/"]
+  "files": ["dist/", "tokens/"],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  }
 }

--- a/packages/tokens-brand/package.json
+++ b/packages/tokens-brand/package.json
@@ -20,5 +20,9 @@
   "devDependencies": {
     "style-dictionary": "^4.3.0"
   },
-  "files": ["dist/", "tokens/"]
+  "files": ["dist/", "tokens/"],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  }
 }

--- a/packages/tokens-creator/package.json
+++ b/packages/tokens-creator/package.json
@@ -20,5 +20,9 @@
   "devDependencies": {
     "style-dictionary": "^4.3.0"
   },
-  "files": ["dist/", "tokens/", "scripts/"]
+  "files": ["dist/", "tokens/", "scripts/"],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  }
 }

--- a/packages/tokens-foundation/package.json
+++ b/packages/tokens-foundation/package.json
@@ -16,5 +16,9 @@
   "devDependencies": {
     "style-dictionary": "^4.3.0"
   },
-  "files": ["dist/", "tokens/"]
+  "files": ["dist/", "tokens/"],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,5 +37,9 @@
   "dependencies": {
     "clsx": "^2.1.0",
     "tailwind-merge": "^2.3.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
   }
 }


### PR DESCRIPTION
## Summary
- Add `publishConfig` (registry: npm.pkg.github.com, access: restricted) to all 6 publishable packages: tokens-foundation, tokens-brand, tokens-atmosphere, tokens-creator, ui, eslint-config
- Create `.npmrc` with @amplify scope pointing to GitHub Packages registry
- Add publish step to CI workflow that runs after build on push to main (uses `GITHUB_TOKEN`)
- Add `packages: write` permission and `registry-url`/`scope` to setup-node for proper auth

## How it works
- On push to main, after build + validation passes, CI loops through each package and runs `npm publish --access restricted`
- `|| true` ensures a version that already exists does not fail the pipeline — bump version in package.json to trigger a new publish
- Consumers install with: `npm install @amplify/tokens-foundation --registry=https://npm.pkg.github.com` (or add the same .npmrc to their repo)

## Test plan
- [ ] Verify CI passes on this PR (build + validate, no publish since not main)
- [ ] After merge, confirm packages appear at github.com/orgs/One-Impression/packages
- [ ] Test consuming a package from another repo with the .npmrc registry config

🤖 Generated with [Claude Code](https://claude.com/claude-code)