### PR TITLE
feat: add 4 design system enforcement ESLint rules (v2)

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -15,16 +15,24 @@
 const noHardcodedColors = require('./rules/no-hardcoded-colors');
 const noRawSpacing = require('./rules/no-raw-spacing');
 const preferTokenImport = require('./rules/prefer-token-import');
+const noInlineStyles = require('./rules/no-inline-styles');
+const noRawSurface = require('./rules/no-raw-surface');
+const noHardcodedRadius = require('./rules/no-hardcoded-radius');
+const noHardcodedTypography = require('./rules/no-hardcoded-typography');
 
 const plugin = {
   meta: {
     name: '@amplify/eslint-plugin',
-    version: '1.0.0',
+    version: '2.0.0',
   },
   rules: {
     'no-hardcoded-colors': noHardcodedColors,
     'no-raw-spacing': noRawSpacing,
     'prefer-token-import': preferTokenImport,
+    'no-inline-styles': noInlineStyles,
+    'no-raw-surface': noRawSurface,
+    'no-hardcoded-radius': noHardcodedRadius,
+    'no-hardcoded-typography': noHardcodedTypography,
   },
 };
 
@@ -37,6 +45,10 @@ module.exports = [
       '@amplify/no-hardcoded-colors': 'warn',
       '@amplify/no-raw-spacing': 'warn',
       '@amplify/prefer-token-import': 'warn',
+      '@amplify/no-inline-styles': 'warn',
+      '@amplify/no-raw-surface': 'warn',
+      '@amplify/no-hardcoded-radius': 'warn',
+      '@amplify/no-hardcoded-typography': 'warn',
     },
   },
 ];

--- a/packages/eslint-config/rules/no-hardcoded-radius.js
+++ b/packages/eslint-config/rules/no-hardcoded-radius.js
@@ -1,0 +1,63 @@
+/**
+ * @amplify/no-hardcoded-radius
+ *
+ * Flags Tailwind hardcoded border-radius classes. Use design token radii instead:
+ *   rounded-[var(--radius-card)]  — 16px, for cards and containers
+ *   rounded-[var(--radius-xs)]    — 6px, for small elements (tags, inputs)
+ *   rounded-full                  — pills and circles (allowed)
+ *   rounded-none                  — intentional removal (allowed)
+ *
+ * Flagged: rounded-sm, rounded-md, rounded-lg, rounded-xl, rounded-2xl, rounded-3xl,
+ *          rounded-[8px], rounded-[12px] etc.
+ */
+
+const HARDCODED_RADIUS = /\brounded-(sm|md|lg|xl|2xl|3xl)\b|\brounded-\[\d+px\]/;
+const EXEMPT = /\brounded-(full|none)\b/;
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Use design token border-radius instead of hardcoded Tailwind radius classes',
+    },
+    schema: [],
+    messages: {
+      noHardcodedRadius:
+        'Use design token radius: `rounded-[var(--radius-card)]` (16px) or `rounded-[var(--radius-xs)]` (6px). Avoid hardcoded rounded-lg/md/xl.',
+    },
+  },
+
+  create(context) {
+    const filename = context.filename || context.getFilename();
+    if (/components\/ui\//.test(filename)) return {};
+
+    return {
+      JSXAttribute(node) {
+        if (node.name.name !== 'className') return;
+        const value = node.value;
+        if (!value) return;
+
+        let classStr = '';
+        if (value.type === 'Literal' && typeof value.value === 'string') {
+          classStr = value.value;
+        } else if (value.type === 'JSXExpressionContainer' && value.expression.type === 'TemplateLiteral') {
+          classStr = value.expression.quasis.map((q) => q.value.raw).join('');
+        } else if (value.type === 'JSXExpressionContainer' && value.expression.type === 'CallExpression') {
+          // cn(...) calls — check string arguments
+          for (const arg of value.expression.arguments) {
+            if (arg.type === 'Literal' && typeof arg.value === 'string') {
+              classStr += ' ' + arg.value;
+            }
+          }
+        } else {
+          return;
+        }
+
+        if (!HARDCODED_RADIUS.test(classStr)) return;
+        if (EXEMPT.test(classStr) && !HARDCODED_RADIUS.test(classStr.replace(EXEMPT, ''))) return;
+
+        context.report({ node, messageId: 'noHardcodedRadius' });
+      },
+    };
+  },
+};

--- a/packages/eslint-config/rules/no-hardcoded-typography.js
+++ b/packages/eslint-config/rules/no-hardcoded-typography.js
@@ -1,0 +1,68 @@
+/**
+ * @amplify/no-hardcoded-typography
+ *
+ * Flags arbitrary pixel font sizes in Tailwind classes like text-[13px], text-[11px].
+ * Use Tailwind's built-in scale instead:
+ *   text-xs   — 12px
+ *   text-sm   — 14px
+ *   text-base — 16px
+ *   text-lg   — 18px
+ *   text-xl   — 20px
+ *   text-2xl  — 24px
+ *   text-3xl  — 30px
+ *
+ * Allowed:
+ *   text-[var(--typography-*)]  — token-based (allowed)
+ *   text-xs, text-sm, etc.     — standard Tailwind scale
+ */
+
+const HARDCODED_TEXT = /\btext-\[\d+px\]/;
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Use Tailwind text size scale instead of arbitrary pixel values',
+    },
+    schema: [],
+    messages: {
+      noHardcodedTypography:
+        'Use Tailwind text size classes (text-xs, text-sm, text-base, text-lg) instead of text-[Npx]. Arbitrary pixel sizes bypass the typography scale.',
+    },
+  },
+
+  create(context) {
+    const filename = context.filename || context.getFilename();
+    if (/components\/ui\//.test(filename)) return {};
+
+    return {
+      JSXAttribute(node) {
+        if (node.name.name !== 'className') return;
+        const value = node.value;
+        if (!value) return;
+
+        let classStr = '';
+        if (value.type === 'Literal' && typeof value.value === 'string') {
+          classStr = value.value;
+        } else if (value.type === 'JSXExpressionContainer' && value.expression.type === 'TemplateLiteral') {
+          classStr = value.expression.quasis.map((q) => q.value.raw).join('');
+        } else if (value.type === 'JSXExpressionContainer' && value.expression.type === 'CallExpression') {
+          for (const arg of value.expression.arguments) {
+            if (arg.type === 'Literal' && typeof arg.value === 'string') {
+              classStr += ' ' + arg.value;
+            }
+          }
+        } else {
+          return;
+        }
+
+        // Skip token-based: text-[var(--*)]
+        if (/text-\[var\(--/.test(classStr)) return;
+
+        if (HARDCODED_TEXT.test(classStr)) {
+          context.report({ node, messageId: 'noHardcodedTypography' });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-config/rules/no-inline-styles.js
+++ b/packages/eslint-config/rules/no-inline-styles.js
@@ -1,0 +1,65 @@
+/**
+ * @amplify/no-inline-styles
+ *
+ * Flags inline style={{}} objects in JSX. These bypass the design token system
+ * and can't be themed, audited, or updated globally.
+ *
+ * Allowed:
+ *   style={someVariable}          — pre-defined style objects (gradual migration)
+ *   style={{ width: `${pct}%` }}  — dynamic computed values
+ *   style={{ ['--custom']: val }} — CSS variable injection
+ *
+ * Flagged:
+ *   style={{ color: '#fff', padding: 10 }}  — literal values that should be Tailwind
+ */
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Discourage inline style objects in JSX — use Tailwind + design tokens',
+    },
+    schema: [],
+    messages: {
+      noInlineStyles:
+        'Avoid inline style={{}} with literal values. Use Tailwind classes with CSS variable tokens instead. See DESIGN_SYSTEM.md.',
+    },
+  },
+
+  create(context) {
+    return {
+      'JSXAttribute[name.name="style"]'(node) {
+        const value = node.value;
+        if (!value) return;
+
+        // style="string" — not JSX expression, skip
+        if (value.type === 'Literal') return;
+
+        // style={expression}
+        if (value.type === 'JSXExpressionContainer') {
+          const expr = value.expression;
+
+          // style={variable} or style={condition ? a : b} — skip (pre-defined objects)
+          if (expr.type !== 'ObjectExpression') return;
+
+          // style={{ ... }} — check if it has literal property values
+          const hasLiteralValues = expr.properties.some((prop) => {
+            if (prop.type !== 'Property') return false;
+            const val = prop.value;
+            // Literal string/number: style={{ color: '#fff', padding: 10 }}
+            if (val.type === 'Literal' && (typeof val.value === 'string' || typeof val.value === 'number')) {
+              // Allow CSS variable injection: style={{ ['--foo']: value }}
+              if (prop.computed) return false;
+              return true;
+            }
+            return false;
+          });
+
+          if (hasLiteralValues) {
+            context.report({ node, messageId: 'noInlineStyles' });
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-config/rules/no-raw-surface.js
+++ b/packages/eslint-config/rules/no-raw-surface.js
@@ -1,0 +1,66 @@
+/**
+ * @amplify/no-raw-surface
+ *
+ * Flags bg-[var(--surface-elevated/secondary/tertiary/overlay)] without a visible
+ * boundary (ring, border, or shadow). In light mode, elevated surfaces are white
+ * on a near-white background — cards become invisible without a border.
+ *
+ * Allowed:
+ *   bg-[var(--surface-elevated)] ring-1 ring-[var(--border-default)]
+ *   bg-[var(--surface-elevated)] border border-[var(--border-default)]
+ *   bg-[var(--surface-elevated)] shadow-sm
+ *   <Card> component (handles its own border)
+ *
+ * Flagged:
+ *   bg-[var(--surface-elevated)] p-5        — no visible boundary
+ */
+
+const SURFACE_TOKENS = ['surface-elevated', 'surface-secondary', 'surface-tertiary', 'surface-overlay'];
+const BOUNDARY_PATTERNS = /\b(ring-|border-|shadow-|border\b)/;
+const EXEMPT_SURFACES = ['surface-primary', 'surface-hover', 'surface-active', 'surface-backdrop', 'surface-hover-solid', 'surface-active-solid', 'surface-row-stripe'];
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Require visible boundary on elevated surface containers',
+    },
+    schema: [],
+    messages: {
+      noRawSurface:
+        'Surface container needs a visible boundary. Add `ring-1 ring-[var(--border-default)]` or use the <Card> component. Without a border, this card is invisible in light mode.',
+    },
+  },
+
+  create(context) {
+    // Skip files in components/ui/ — component definitions set their own styling
+    const filename = context.filename || context.getFilename();
+    if (/components\/ui\//.test(filename)) return {};
+
+    return {
+      JSXAttribute(node) {
+        if (node.name.name !== 'className') return;
+        const value = node.value;
+        if (!value) return;
+
+        let classStr = '';
+        if (value.type === 'Literal' && typeof value.value === 'string') {
+          classStr = value.value;
+        } else if (value.type === 'JSXExpressionContainer' && value.expression.type === 'TemplateLiteral') {
+          classStr = value.expression.quasis.map((q) => q.value.raw).join('');
+        } else {
+          return;
+        }
+
+        // Check if className contains a flagged surface token
+        const hasFlaggedSurface = SURFACE_TOKENS.some((token) => classStr.includes(`var(--${token})`));
+        if (!hasFlaggedSurface) return;
+
+        // Check if className also has a boundary
+        if (BOUNDARY_PATTERNS.test(classStr)) return;
+
+        context.report({ node, messageId: 'noRawSurface' });
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary
Adds 4 new ESLint rules to `@amplify/eslint-config` that catch the highest-impact design system violations at lint time. All set to `warn` — existing code keeps building, new violations get flagged.

### New rules

| Rule | Catches | Prevents |
|------|---------|----------|
| `no-inline-styles` | `style={{}}` with literal values | Bypassing design tokens entirely |
| `no-raw-surface` | `bg-[var(--surface-*)]` without ring/border/shadow | Invisible cards in light mode |
| `no-hardcoded-radius` | `rounded-lg/md/xl` etc. | Inconsistent corners |
| `no-hardcoded-typography` | `text-[13px]`, `text-[11px]` | Typography outside scale |

### Existing rules (unchanged)
- `no-hardcoded-colors` — hex colors in JSX
- `no-raw-spacing` — raw pixel values in style props
- `prefer-token-import` — legacy import paths

**Total: 7 rules** covering all major design system violation classes.

### Smart exceptions
- `src/components/ui/` files exempted (component definitions set their own styling)
- `style={variable}` allowed (pre-defined style objects for gradual migration)
- `rounded-full` / `rounded-none` allowed (intentional)
- `text-[var(--*)]` allowed (token-based)
- `surface-primary/hover/active` exempted from boundary check (page bg, interaction states)

## Test plan
- [x] All 7 rules load: `node -e "require('./rules/no-inline-styles')"` etc.
- [ ] Atmosphere `npm run lint` shows new warnings for existing violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)