### PR TITLE
feat: add CollapsibleNavGroup component to @amplify/ui

### DIFF
--- a/packages/ui/src/components/CollapsibleNavGroup/CollapsibleNavGroup.test.tsx
+++ b/packages/ui/src/components/CollapsibleNavGroup/CollapsibleNavGroup.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { CollapsibleNavGroup } from './CollapsibleNavGroup';
+
+afterEach(cleanup);
+
+describe('CollapsibleNavGroup', () => {
+  it('renders label and icon', () => {
+    render(
+      <CollapsibleNavGroup label="AI Creators" icon="🎬">
+        <div>child content</div>
+      </CollapsibleNavGroup>
+    );
+    expect(screen.getByText('AI Creators')).toBeDefined();
+  });
+
+  it('starts collapsed by default', () => {
+    const { container } = render(
+      <CollapsibleNavGroup label="Collapsed Group">
+        <div>hidden</div>
+      </CollapsibleNavGroup>
+    );
+    const button = screen.getByText('Collapsed Group').closest('button')!;
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+    expect(container.querySelector('[role="group"]')).toBe(null);
+  });
+
+  it('starts expanded when defaultExpanded is true', () => {
+    const { container } = render(
+      <CollapsibleNavGroup label="Expanded Group" defaultExpanded>
+        <div>visible</div>
+      </CollapsibleNavGroup>
+    );
+    const button = screen.getByText('Expanded Group').closest('button')!;
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+    expect(container.querySelector('[role="group"]')).not.toBe(null);
+  });
+
+  it('toggles on click', () => {
+    const { container } = render(
+      <CollapsibleNavGroup label="Toggle Group">
+        <div>content</div>
+      </CollapsibleNavGroup>
+    );
+    const button = screen.getByText('Toggle Group').closest('button')!;
+
+    fireEvent.click(button);
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+    expect(container.querySelector('[role="group"]')).not.toBe(null);
+
+    fireEvent.click(button);
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+    expect(container.querySelector('[role="group"]')).toBe(null);
+  });
+
+  it('shows count badge', () => {
+    render(
+      <CollapsibleNavGroup label="Count Group" count={5}>
+        <div>children</div>
+      </CollapsibleNavGroup>
+    );
+    expect(screen.getByText('5')).toBeDefined();
+  });
+
+  it('calls onToggle callback', () => {
+    const onToggle = vi.fn();
+    render(
+      <CollapsibleNavGroup label="Callback Group" onToggle={onToggle}>
+        <div>children</div>
+      </CollapsibleNavGroup>
+    );
+    const button = screen.getByText('Callback Group').closest('button')!;
+
+    fireEvent.click(button);
+    expect(onToggle).toHaveBeenCalledWith(true);
+
+    fireEvent.click(button);
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+
+  it('respects controlled expanded prop', () => {
+    const { container, rerender } = render(
+      <CollapsibleNavGroup label="Controlled Group" expanded={false}>
+        <div>content</div>
+      </CollapsibleNavGroup>
+    );
+    expect(container.querySelector('[role="group"]')).toBe(null);
+
+    rerender(
+      <CollapsibleNavGroup label="Controlled Group" expanded={true}>
+        <div>content</div>
+      </CollapsibleNavGroup>
+    );
+    expect(container.querySelector('[role="group"]')).not.toBe(null);
+  });
+});

--- a/packages/ui/src/components/CollapsibleNavGroup/CollapsibleNavGroup.tsx
+++ b/packages/ui/src/components/CollapsibleNavGroup/CollapsibleNavGroup.tsx
@@ -1,0 +1,109 @@
+import React, { useState, useId } from 'react';
+import { cn } from '../../lib/cn';
+
+export interface CollapsibleNavGroupProps {
+  /** Group label text */
+  label: string;
+  /** Optional icon (emoji or string) displayed before the label */
+  icon?: string;
+  /** Optional count badge shown to the right */
+  count?: number;
+  /** Whether the group starts expanded */
+  defaultExpanded?: boolean;
+  /** Controlled expanded state (overrides internal state) */
+  expanded?: boolean;
+  /** Callback when expanded state changes */
+  onToggle?: (expanded: boolean) => void;
+  /** Child navigation items rendered when expanded */
+  children: React.ReactNode;
+  /** Additional CSS class */
+  className?: string;
+}
+
+export const CollapsibleNavGroup: React.FC<CollapsibleNavGroupProps> = ({
+  label,
+  icon,
+  count,
+  defaultExpanded = false,
+  expanded: controlledExpanded,
+  onToggle,
+  children,
+  className,
+}) => {
+  const [internalExpanded, setInternalExpanded] = useState(defaultExpanded);
+  const isExpanded = controlledExpanded ?? internalExpanded;
+  const headingId = useId();
+  const groupId = useId();
+
+  const toggle = () => {
+    const next = !isExpanded;
+    if (controlledExpanded === undefined) {
+      setInternalExpanded(next);
+    }
+    onToggle?.(next);
+  };
+
+  return (
+    <div className={cn('w-full', className)}>
+      <button
+        id={headingId}
+        onClick={toggle}
+        aria-expanded={isExpanded}
+        aria-controls={groupId}
+        className={cn(
+          'flex items-center w-full pl-8 pr-4 py-1.5',
+          'text-[10px] font-semibold uppercase tracking-wider',
+          'text-[var(--amp-semantic-text-tertiary,var(--text-faint,#666))]',
+          'hover:text-[var(--amp-semantic-text-secondary,var(--text-muted,#999))]',
+          'transition-colors duration-150 cursor-pointer select-none',
+          'border-0 bg-transparent',
+        )}
+      >
+        {/* Chevron */}
+        <span
+          className="text-[8px] mr-1 inline-block w-2 text-center transition-transform duration-200"
+          style={{ transform: isExpanded ? 'rotate(0deg)' : 'rotate(-90deg)' }}
+          aria-hidden="true"
+        >
+          ▾
+        </span>
+
+        {/* Icon */}
+        {icon && (
+          <span className="opacity-70 mr-1" aria-hidden="true">
+            {icon}
+          </span>
+        )}
+
+        {/* Label */}
+        {label}
+
+        {/* Count */}
+        {count !== undefined && (
+          <span
+            className="ml-auto text-[9px] font-medium transition-colors duration-150"
+            style={{
+              color: isExpanded
+                ? 'var(--amp-semantic-accent, var(--accent-gold, #c9a96e))'
+                : undefined,
+            }}
+            aria-label={`${count} items`}
+          >
+            {count}
+          </span>
+        )}
+      </button>
+
+      {/* Children */}
+      {isExpanded && (
+        <div
+          id={groupId}
+          role="group"
+          aria-labelledby={headingId}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/ui/src/components/CollapsibleNavGroup/index.ts
+++ b/packages/ui/src/components/CollapsibleNavGroup/index.ts
@@ -1,0 +1,2 @@
+export { CollapsibleNavGroup } from './CollapsibleNavGroup';
+export type { CollapsibleNavGroupProps } from './CollapsibleNavGroup';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -109,3 +109,7 @@ export type { IconButtonProps, IconButtonVariant, IconButtonSize } from './compo
 // Separator
 export { Separator } from './components/Separator';
 export type { SeparatorProps, SeparatorOrientation } from './components/Separator';
+
+// CollapsibleNavGroup
+export { CollapsibleNavGroup } from './components/CollapsibleNavGroup';
+export type { CollapsibleNavGroupProps } from './components/CollapsibleNavGroup';


### PR DESCRIPTION
## Summary
- New `CollapsibleNavGroup` component in `@amplify/ui` for sidebar sub-section toggles
- Supports uncontrolled (`defaultExpanded`) and controlled (`expanded`) modes
- Chevron animation, count badge, semantic token colors, full ARIA support

## Usage
```tsx
import { CollapsibleNavGroup } from '@amplify/ui';

<CollapsibleNavGroup label="AI Creators" icon="🎬" count={3} defaultExpanded>
  <NavLink href="/campaigns/ai">Campaigns (AI)</NavLink>
  <NavLink href="/studio">Creator Studio</NavLink>
  <NavLink href="/pipeline">Video Pipeline</NavLink>
</CollapsibleNavGroup>
```

## Props
| Prop | Type | Default | Description |
|------|------|---------|-------------|
| label | string | required | Group label text |
| icon | string | - | Emoji/icon before label |
| count | number | - | Badge count |
| defaultExpanded | boolean | false | Initial state (uncontrolled) |
| expanded | boolean | - | Controlled state |
| onToggle | (expanded: boolean) => void | - | Change callback |
| children | ReactNode | required | Nav items |
| className | string | - | Additional CSS class |

## Test plan
- [x] 7 unit tests passing (vitest + jsdom)
- [ ] Renders label, icon, count
- [ ] Collapsed by default, expands on click
- [ ] Controlled mode works
- [ ] ARIA attributes correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)