### PR TITLE
feat: Chip dark variant + dark mode token CSS

### DIFF
--- a/packages/ui/src/components/Chip/Chip.tsx
+++ b/packages/ui/src/components/Chip/Chip.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { cn } from '../../lib/cn';
 
-export type ChipVariant = 'default' | 'selected' | 'outline';
+export type ChipVariant = 'default' | 'selected' | 'outline' | 'dark';
 export type ChipSize = 'sm' | 'md';
 
 export interface ChipProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -19,6 +19,8 @@ const variantClasses: Record<ChipVariant, string> = {
     'border border-violet-600 bg-violet-600 text-white hover:bg-violet-700',
   outline:
     'border border-violet-200 bg-transparent text-violet-600 hover:bg-violet-50',
+  dark:
+    'border border-[var(--amp-semantic-text-primary)] bg-[var(--amp-semantic-text-primary)] text-[var(--amp-semantic-text-inverse)] hover:opacity-90',
 };
 
 const sizeClasses: Record<ChipSize, string> = {
@@ -77,7 +79,7 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
             className={cn(
               'flex-shrink-0 ml-0.5 rounded-full p-0.5 transition-colors',
               'hover:bg-black/10',
-              variant === 'selected' && 'hover:bg-white/20'
+              (variant === 'selected' || variant === 'dark') && 'hover:bg-white/20'
             )}
             aria-label="Remove"
           >

--- a/scripts/build-tokens.js
+++ b/scripts/build-tokens.js
@@ -276,8 +276,55 @@ export const spacing = ${JSON.stringify(spacing, null, 2)};
 `;
 }
 
+// 7. Dark mode CSS — loads dark semantic + dark product theme, outputs [data-theme="dark"] block
+function buildDarkCSS() {
+  const darkSemanticFile = join(semanticDir, 'colors-dark.json');
+  const darkThemeFile = join(packageDir, 'theme-dark.json');
+  const hasDarkSemantic = existsSync(darkSemanticFile);
+  const hasDarkTheme = pkg !== 'foundation' && existsSync(darkThemeFile);
+
+  if (!hasDarkSemantic && !hasDarkTheme) return '';
+
+  // Start from primitives (same base), overlay dark semantic + dark product theme
+  let darkTokens = loadJsonFiles(primitivesDir);
+  if (hasDarkSemantic) {
+    deepMerge(darkTokens, JSON.parse(readFileSync(darkSemanticFile, 'utf8')));
+  }
+  if (hasDarkTheme) {
+    deepMerge(darkTokens, JSON.parse(readFileSync(darkThemeFile, 'utf8')));
+  }
+
+  const darkResolved = resolveAll(darkTokens, darkTokens);
+  const darkFlat = flatten(darkResolved);
+
+  const lines = [
+    '',
+    '/* Dark mode overrides */',
+    '[data-theme="dark"] {',
+  ];
+  for (const [key, value] of Object.entries(darkFlat)) {
+    if (typeof value === 'string' || typeof value === 'number') {
+      lines.push(`  --${PREFIX}-${key}: ${value};`);
+    }
+  }
+  lines.push('}');
+  lines.push('');
+  lines.push('@media (prefers-color-scheme: dark) {');
+  lines.push('  :root:not([data-theme="light"]) {');
+  for (const [key, value] of Object.entries(darkFlat)) {
+    if (typeof value === 'string' || typeof value === 'number') {
+      lines.push(`    --${PREFIX}-${key}: ${value};`);
+    }
+  }
+  lines.push('  }');
+  lines.push('}');
+  return lines.join('\n');
+}
+
 // ── Write outputs ──
-writeFileSync(join(distDir, 'variables.css'), buildCSS());
+const lightCSS = buildCSS();
+const darkCSS = buildDarkCSS();
+writeFileSync(join(distDir, 'variables.css'), lightCSS + darkCSS);
 writeFileSync(join(distDir, 'variables.scss'), buildSCSS());
 writeFileSync(join(distDir, 'tokens.json'), buildJSON());
 writeFileSync(join(distDir, 'tokens.js'), buildJS());


### PR DESCRIPTION
## Summary
- Adds `variant="dark"` to `@amplify/ui` `<Chip>` component — dark background active state for filter tabs (e.g., brand ledger transaction filters)
- Updates `build-tokens.js` to generate `[data-theme="dark"]` and `@media (prefers-color-scheme: dark)` CSS blocks from `theme-dark.json` files
- Enables full dark mode support for all token packages (brand, foundation, atmosphere, creator)

## Context
Needed for the Brand Ledger page Canvas redesign — the ledger filter chips use a dark active state that didn't exist as a Chip variant. The dark mode token output was also missing from the build pipeline (dark theme JSON existed but wasn't compiled to CSS).

## Test plan
- [ ] `npm run build` passes (tokens + UI)
- [ ] `npm run typecheck` passes
- [ ] Verify `dist/variables.css` now contains `[data-theme="dark"]` block for brand/foundation
- [ ] Storybook: Chip component shows 4 variants (default, selected, outline, dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)