### PR TITLE
feat: brand-ledger component enhancements + dark mode tokens

### DIFF
--- a/packages/ui/src/components/Chip/Chip.tsx
+++ b/packages/ui/src/components/Chip/Chip.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { cn } from '../../lib/cn';
 
-export type ChipVariant = 'default' | 'selected' | 'outline';
+export type ChipVariant = 'default' | 'selected' | 'outline' | 'dark';
 export type ChipSize = 'sm' | 'md';
 
 export interface ChipProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -19,6 +19,8 @@ const variantClasses: Record<ChipVariant, string> = {
     'border border-violet-600 bg-violet-600 text-white hover:bg-violet-700',
   outline:
     'border border-violet-200 bg-transparent text-violet-600 hover:bg-violet-50',
+  dark:
+    'border border-[var(--amp-semantic-text-primary)] bg-[var(--amp-semantic-text-primary)] text-[var(--amp-semantic-text-inverse)] hover:opacity-90',
 };
 
 const sizeClasses: Record<ChipSize, string> = {
@@ -77,7 +79,7 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
             className={cn(
               'flex-shrink-0 ml-0.5 rounded-full p-0.5 transition-colors',
               'hover:bg-black/10',
-              variant === 'selected' && 'hover:bg-white/20'
+              (variant === 'selected' || variant === 'dark') && 'hover:bg-white/20'
             )}
             aria-label="Remove"
           >

--- a/packages/ui/src/components/CollapsibleCard/CollapsibleCard.tsx
+++ b/packages/ui/src/components/CollapsibleCard/CollapsibleCard.tsx
@@ -1,0 +1,102 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { cn } from '../../lib/cn';
+
+export interface CollapsibleCardProps {
+  /** Content always visible (the clickable header) */
+  header: React.ReactNode;
+  /** Content shown when expanded */
+  children: React.ReactNode;
+  /** Controlled mode: externally managed open state */
+  open?: boolean;
+  /** Default open state (uncontrolled mode) */
+  defaultOpen?: boolean;
+  /** Callback when open state changes */
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
+}
+
+export const CollapsibleCard: React.FC<CollapsibleCardProps> = ({
+  header,
+  children,
+  open: controlledOpen,
+  defaultOpen = false,
+  onOpenChange,
+  className,
+}) => {
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const isControlled = controlledOpen !== undefined;
+  const isOpen = isControlled ? controlledOpen : internalOpen;
+
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [height, setHeight] = useState<number | undefined>(defaultOpen ? undefined : 0);
+
+  useEffect(() => {
+    if (!contentRef.current) return;
+    if (isOpen) {
+      setHeight(contentRef.current.scrollHeight);
+      const timer = setTimeout(() => setHeight(undefined), 200);
+      return () => clearTimeout(timer);
+    } else {
+      setHeight(contentRef.current.scrollHeight);
+      requestAnimationFrame(() => setHeight(0));
+    }
+  }, [isOpen]);
+
+  const toggle = () => {
+    const next = !isOpen;
+    if (!isControlled) {
+      setInternalOpen(next);
+    }
+    onOpenChange?.(next);
+  };
+
+  return (
+    <div
+      className={cn(
+        'rounded-[16px] border border-[var(--amp-semantic-border-default)] bg-[var(--amp-semantic-bg-surface)]',
+        'overflow-hidden transition-shadow duration-150',
+        'hover:shadow-[0_4px_12px_rgba(29,37,45,0.10)]',
+        className
+      )}
+    >
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={isOpen}
+        onClick={toggle}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(); } }}
+        className="cursor-pointer"
+      >
+        <div className="flex items-center justify-between px-6 py-4">
+          <div className="flex-1">{header}</div>
+          <div
+            className={cn(
+              'w-7 h-7 rounded-[8px] flex items-center justify-center flex-shrink-0 transition-all duration-200',
+              isOpen
+                ? 'bg-[var(--amp-semantic-accent-light)] text-[var(--amp-semantic-accent)]'
+                : 'bg-[var(--amp-semantic-bg-sunken)] text-[var(--amp-semantic-text-muted)]'
+            )}
+          >
+            <svg
+              className={cn('w-3.5 h-3.5 transition-transform duration-200', isOpen && 'rotate-180')}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div
+        ref={contentRef}
+        style={{ height: height !== undefined ? `${height}px` : 'auto', overflow: 'hidden', transition: 'height 200ms ease' }}
+      >
+        <div className="border-t border-[var(--amp-semantic-border-default)]">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/ui/src/components/CollapsibleCard/index.ts
+++ b/packages/ui/src/components/CollapsibleCard/index.ts
@@ -1,0 +1,2 @@
+export { CollapsibleCard } from './CollapsibleCard';
+export type { CollapsibleCardProps } from './CollapsibleCard';

--- a/packages/ui/src/components/DataTable/DataTable.tsx
+++ b/packages/ui/src/components/DataTable/DataTable.tsx
@@ -6,6 +6,12 @@ export interface DataTableColumn<T> {
   header: string;
   render?: (item: T) => React.ReactNode;
   sortable?: boolean;
+  /** Text alignment for this column */
+  align?: 'left' | 'center' | 'right';
+  /** Additional class for the header cell */
+  headerClassName?: string;
+  /** Minimum width (e.g., '200px') */
+  minWidth?: string;
 }
 
 export interface DataTableProps<T> {
@@ -14,6 +20,10 @@ export interface DataTableProps<T> {
   rowKey?: keyof T | ((item: T) => string);
   loading?: boolean;
   emptyMessage?: string;
+  /** Make the first column sticky on horizontal scroll */
+  stickyFirstColumn?: boolean;
+  /** Return a className for a specific row (e.g., for totals row styling) */
+  rowClassName?: (item: T, index: number) => string | undefined;
   className?: string;
 }
 
@@ -25,6 +35,8 @@ export function DataTable<T extends Record<string, unknown>>({
   rowKey,
   loading = false,
   emptyMessage = 'No data available',
+  stickyFirstColumn = false,
+  rowClassName,
   className,
 }: DataTableProps<T>) {
   const [sortKey, setSortKey] = useState<string | null>(null);
@@ -53,6 +65,14 @@ export function DataTable<T extends Record<string, unknown>>({
     });
   }, [data, sortKey, sortDir]);
 
+  const alignClass = (align?: string) =>
+    align === 'right' ? 'text-right' : align === 'center' ? 'text-center' : 'text-left';
+
+  const stickyClass = (colIdx: number) =>
+    stickyFirstColumn && colIdx === 0
+      ? 'sticky left-0 z-[1] bg-inherit'
+      : '';
+
   if (loading) {
     return (
       <div className={cn('rounded-[16px] border border-[var(--amp-semantic-border-default)] overflow-hidden', className)}>
@@ -65,75 +85,87 @@ export function DataTable<T extends Record<string, unknown>>({
 
   return (
     <div className={cn('rounded-[16px] border border-[var(--amp-semantic-border-default)] overflow-hidden', className)}>
-      <table className="w-full border-collapse">
-        <thead>
-          <tr className="bg-[var(--amp-semantic-bg-sunken)]">
-            {columns.map((col) => (
-              <th
-                key={col.key}
-                className={cn(
-                  'px-4 py-3 text-left text-[12px] font-semibold uppercase tracking-wide text-[var(--amp-semantic-text-secondary)]',
-                  col.sortable && 'cursor-pointer select-none hover:text-[var(--amp-semantic-text-primary)]'
-                )}
-                onClick={col.sortable ? () => handleSort(col.key) : undefined}
-                aria-sort={sortKey === col.key ? (sortDir === 'asc' ? 'ascending' : 'descending') : undefined}
-              >
-                <span className="inline-flex items-center gap-1">
-                  {col.header}
-                  {col.sortable && sortKey === col.key && (
-                    <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d={sortDir === 'asc' ? 'M5 15l7-7 7 7' : 'M19 9l-7 7-7-7'}
-                      />
-                    </svg>
+      <div className={stickyFirstColumn ? 'overflow-x-auto' : ''}>
+        <table className="w-full border-collapse">
+          <thead>
+            <tr className="bg-[var(--amp-semantic-bg-sunken)]">
+              {columns.map((col, colIdx) => (
+                <th
+                  key={col.key}
+                  style={col.minWidth ? { minWidth: col.minWidth } : undefined}
+                  className={cn(
+                    'px-4 py-3 text-[12px] font-semibold uppercase tracking-wide text-[var(--amp-semantic-text-secondary)]',
+                    alignClass(col.align),
+                    stickyClass(colIdx),
+                    col.sortable && 'cursor-pointer select-none hover:text-[var(--amp-semantic-text-primary)]',
+                    col.headerClassName
                   )}
-                </span>
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {sortedData.length === 0 ? (
-            <tr>
-              <td
-                colSpan={columns.length}
-                className="px-4 py-8 text-center text-[14px] text-[var(--amp-semantic-text-muted)]"
-              >
-                {emptyMessage}
-              </td>
+                  onClick={col.sortable ? () => handleSort(col.key) : undefined}
+                  aria-sort={sortKey === col.key ? (sortDir === 'asc' ? 'ascending' : 'descending') : undefined}
+                >
+                  <span className="inline-flex items-center gap-1">
+                    {col.header}
+                    {col.sortable && sortKey === col.key && (
+                      <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d={sortDir === 'asc' ? 'M5 15l7-7 7 7' : 'M19 9l-7 7-7-7'}
+                        />
+                      </svg>
+                    )}
+                  </span>
+                </th>
+              ))}
             </tr>
-          ) : (
-            sortedData.map((row, idx) => {
-              const key = rowKey
-                ? typeof rowKey === 'function'
-                  ? rowKey(row)
-                  : String(row[rowKey])
-                : idx;
-              return (
-              <tr
-                key={key}
-                className={cn(
-                  'border-t border-[var(--amp-semantic-border-default)]',
-                  'hover:bg-[var(--amp-semantic-bg-raised)] transition-colors duration-100',
-                  idx % 2 === 1 && 'bg-[var(--amp-semantic-bg-sunken)]/30'
-                )}
-              >
-                {columns.map((col) => (
-                  <td
-                    key={col.key}
-                    className="px-4 py-3 text-[14px] text-[var(--amp-semantic-text-primary)]"
-                  >
-                    {col.render ? col.render(row) : (row[col.key] as React.ReactNode)}
-                  </td>
-                ))}
+          </thead>
+          <tbody>
+            {sortedData.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={columns.length}
+                  className="px-4 py-8 text-center text-[14px] text-[var(--amp-semantic-text-muted)]"
+                >
+                  {emptyMessage}
+                </td>
               </tr>
-              );
-            })
-          )}
-        </tbody>
-      </table>
+            ) : (
+              sortedData.map((row, idx) => {
+                const key = rowKey
+                  ? typeof rowKey === 'function'
+                    ? rowKey(row)
+                    : String(row[rowKey])
+                  : idx;
+                const customRowClass = rowClassName?.(row, idx);
+                return (
+                  <tr
+                    key={key}
+                    className={cn(
+                      'border-t border-[var(--amp-semantic-border-default)]',
+                      'hover:bg-[var(--amp-semantic-bg-raised)] transition-colors duration-100',
+                      idx % 2 === 1 && 'bg-[var(--amp-semantic-bg-sunken)]/30',
+                      customRowClass
+                    )}
+                  >
+                    {columns.map((col, colIdx) => (
+                      <td
+                        key={col.key}
+                        className={cn(
+                          'px-4 py-3 text-[14px] text-[var(--amp-semantic-text-primary)]',
+                          alignClass(col.align),
+                          stickyClass(colIdx)
+                        )}
+                      >
+                        {col.render ? col.render(row) : (row[col.key] as React.ReactNode)}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/components/MetricCard/MetricCard.tsx
+++ b/packages/ui/src/components/MetricCard/MetricCard.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { cn } from '../../lib/cn';
 
+export type MetricCardIconVariant = 'accent' | 'success' | 'warning' | 'error' | 'info';
+
 export interface MetricCardProps {
   label: string;
   value: string | number;
@@ -8,8 +10,18 @@ export interface MetricCardProps {
   trendLabel?: string;
   subtitle?: string;
   icon?: React.ReactNode;
+  /** Color variant for the icon background. Defaults to 'accent' (violet). */
+  iconVariant?: MetricCardIconVariant;
   className?: string;
 }
+
+const iconVariantClasses: Record<MetricCardIconVariant, string> = {
+  accent: 'bg-[var(--amp-semantic-accent-light)] text-[var(--amp-semantic-accent)]',
+  success: 'bg-[var(--amp-semantic-status-success-bg)] text-[var(--amp-semantic-status-success)]',
+  warning: 'bg-[var(--amp-semantic-status-warning-bg)] text-[var(--amp-semantic-status-warning)]',
+  error: 'bg-[var(--amp-semantic-status-error-bg)] text-[var(--amp-semantic-status-error)]',
+  info: 'bg-[var(--amp-semantic-status-info-bg)] text-[var(--amp-semantic-status-info)]',
+};
 
 export const MetricCard: React.FC<MetricCardProps> = ({
   label,
@@ -18,6 +30,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
   trendLabel,
   subtitle,
   icon,
+  iconVariant = 'accent',
   className,
 }) => {
   const isPositive = trend !== undefined && trend >= 0;
@@ -75,7 +88,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
           )}
         </div>
         {icon && (
-          <div className="w-10 h-10 rounded-[12px] bg-[var(--amp-semantic-accent-light)] flex items-center justify-center text-[var(--amp-semantic-accent)]">
+          <div className={cn('w-10 h-10 rounded-[12px] flex items-center justify-center', iconVariantClasses[iconVariant])}>
             {icon}
           </div>
         )}

--- a/packages/ui/src/components/MetricCard/index.ts
+++ b/packages/ui/src/components/MetricCard/index.ts
@@ -1,2 +1,2 @@
 export { MetricCard } from './MetricCard';
-export type { MetricCardProps } from './MetricCard';
+export type { MetricCardProps, MetricCardIconVariant } from './MetricCard';

--- a/packages/ui/src/components/StatusTag/StatusTag.tsx
+++ b/packages/ui/src/components/StatusTag/StatusTag.tsx
@@ -6,6 +6,8 @@ export type StatusTagSize = 'sm' | 'md';
 
 export interface StatusTagProps {
   status: StatusTagStatus;
+  /** Override the default label text for this status */
+  label?: string;
   size?: StatusTagSize;
   pulse?: boolean;
   className?: string;
@@ -57,6 +59,7 @@ const sizeClasses: Record<StatusTagSize, string> = {
 
 export const StatusTag: React.FC<StatusTagProps> = ({
   status,
+  label: labelOverride,
   size = 'md',
   pulse = false,
   className,
@@ -80,7 +83,7 @@ export const StatusTag: React.FC<StatusTagProps> = ({
           pulse && 'animate-pulse'
         )}
       />
-      {config.label}
+      {labelOverride ?? config.label}
     </span>
   );
 };

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -10,13 +10,32 @@ export interface Tab {
 export interface TabsProps {
   tabs: Tab[];
   defaultTab?: string;
+  /** Controlled mode: externally managed active tab */
+  activeTab?: string;
+  /** Callback when tab changes (works in both controlled and uncontrolled mode) */
+  onTabChange?: (tabId: string) => void;
   className?: string;
 }
 
-export const Tabs: React.FC<TabsProps> = ({ tabs, defaultTab, className }) => {
-  const [activeTab, setActiveTab] = useState(defaultTab || tabs[0]?.id || '');
+export const Tabs: React.FC<TabsProps> = ({
+  tabs,
+  defaultTab,
+  activeTab: controlledTab,
+  onTabChange,
+  className,
+}) => {
+  const [internalTab, setInternalTab] = useState(defaultTab || tabs[0]?.id || '');
+  const isControlled = controlledTab !== undefined;
+  const currentTab = isControlled ? controlledTab : internalTab;
 
-  const activeContent = tabs.find((t) => t.id === activeTab)?.content;
+  const handleTabClick = (tabId: string) => {
+    if (!isControlled) {
+      setInternalTab(tabId);
+    }
+    onTabChange?.(tabId);
+  };
+
+  const activeContent = tabs.find((t) => t.id === currentTab)?.content;
 
   return (
     <div className={cn('w-full', className)}>
@@ -28,20 +47,20 @@ export const Tabs: React.FC<TabsProps> = ({ tabs, defaultTab, className }) => {
           <button
             key={tab.id}
             role="tab"
-            aria-selected={activeTab === tab.id}
+            aria-selected={currentTab === tab.id}
             aria-controls={`tabpanel-${tab.id}`}
             id={`tab-${tab.id}`}
-            onClick={() => setActiveTab(tab.id)}
+            onClick={() => handleTabClick(tab.id)}
             className={cn(
               'px-4 py-2.5 text-[14px] font-medium transition-colors duration-150 relative',
               'hover:text-[var(--amp-semantic-text-primary)]',
-              activeTab === tab.id
+              currentTab === tab.id
                 ? 'text-[var(--amp-semantic-accent)]'
                 : 'text-[var(--amp-semantic-text-secondary)]'
             )}
           >
             {tab.label}
-            {activeTab === tab.id && (
+            {currentTab === tab.id && (
               <span className="absolute bottom-0 left-0 right-0 h-[2px] bg-[var(--amp-semantic-accent)]" />
             )}
           </button>
@@ -49,8 +68,8 @@ export const Tabs: React.FC<TabsProps> = ({ tabs, defaultTab, className }) => {
       </div>
       <div
         role="tabpanel"
-        id={`tabpanel-${activeTab}`}
-        aria-labelledby={`tab-${activeTab}`}
+        id={`tabpanel-${currentTab}`}
+        aria-labelledby={`tab-${currentTab}`}
         className="pt-4"
       >
         {activeContent}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -60,7 +60,7 @@ export type { DataTableProps, DataTableColumn } from './components/DataTable';
 
 // MetricCard
 export { MetricCard } from './components/MetricCard';
-export type { MetricCardProps } from './components/MetricCard';
+export type { MetricCardProps, MetricCardIconVariant } from './components/MetricCard';
 
 // Tabs
 export { Tabs } from './components/Tabs';
@@ -125,3 +125,7 @@ export type { ChipProps, ChipVariant, ChipSize } from './components/Chip';
 // Slider
 export { Slider } from './components/Slider';
 export type { SliderProps, SliderMark } from './components/Slider';
+
+// CollapsibleCard
+export { CollapsibleCard } from './components/CollapsibleCard';
+export type { CollapsibleCardProps } from './components/CollapsibleCard';

--- a/scripts/build-tokens.js
+++ b/scripts/build-tokens.js
@@ -276,8 +276,46 @@ export const spacing = ${JSON.stringify(spacing, null, 2)};
 `;
 }
 
+// 7. Dark mode CSS — loads dark semantic + dark product theme, outputs [data-theme="dark"] block
+function buildDarkCSS() {
+  const darkSemanticFile = join(semanticDir, 'colors-dark.json');
+  const darkThemeFile = join(packageDir, 'theme-dark.json');
+  const hasDarkSemantic = existsSync(darkSemanticFile);
+  const hasDarkTheme = pkg !== 'foundation' && existsSync(darkThemeFile);
+
+  if (!hasDarkSemantic && !hasDarkTheme) return '';
+
+  let darkTokens = loadJsonFiles(primitivesDir);
+  if (hasDarkSemantic) {
+    deepMerge(darkTokens, JSON.parse(readFileSync(darkSemanticFile, 'utf8')));
+  }
+  if (hasDarkTheme) {
+    deepMerge(darkTokens, JSON.parse(readFileSync(darkThemeFile, 'utf8')));
+  }
+
+  const darkResolved = resolveAll(darkTokens, darkTokens);
+  const darkFlat = flatten(darkResolved);
+
+  const lines = ['', '/* Dark mode overrides */', '[data-theme="dark"] {'];
+  for (const [key, value] of Object.entries(darkFlat)) {
+    if (typeof value === 'string' || typeof value === 'number') {
+      lines.push(`  --${PREFIX}-${key}: ${value};`);
+    }
+  }
+  lines.push('}', '', '@media (prefers-color-scheme: dark) {', '  :root:not([data-theme="light"]) {');
+  for (const [key, value] of Object.entries(darkFlat)) {
+    if (typeof value === 'string' || typeof value === 'number') {
+      lines.push(`    --${PREFIX}-${key}: ${value};`);
+    }
+  }
+  lines.push('  }', '}');
+  return lines.join('\n');
+}
+
 // ── Write outputs ──
-writeFileSync(join(distDir, 'variables.css'), buildCSS());
+const lightCSS = buildCSS();
+const darkCSS = buildDarkCSS();
+writeFileSync(join(distDir, 'variables.css'), lightCSS + darkCSS);
 writeFileSync(join(distDir, 'variables.scss'), buildSCSS());
 writeFileSync(join(distDir, 'tokens.json'), buildJSON());
 writeFileSync(join(distDir, 'tokens.js'), buildJS());


### PR DESCRIPTION
## Summary
Component updates needed for the Brand Ledger Canvas redesign. All changes are additive (new optional props), no breaking changes.

**@amplify/ui component updates:**
- **Tabs**: controlled mode via `activeTab` + `onTabChange` props (uncontrolled still works)
- **StatusTag**: `label` prop override — e.g., `<StatusTag status="warning" label="Ongoing" />`
- **MetricCard**: `iconVariant` prop — `accent` (default), `success`, `warning`, `error`, `info`
- **DataTable**: `stickyFirstColumn`, `rowClassName`, column `align`/`minWidth`/`headerClassName`
- **Chip**: `dark` variant for filter tabs with dark background active state

**New component:**
- **CollapsibleCard**: expand/collapse with smooth height animation, controlled + uncontrolled modes, keyboard accessible

**Token build:**
- `build-tokens.js` now generates `[data-theme="dark"]` + `@media (prefers-color-scheme: dark)` CSS blocks

Supersedes #26 (Chip dark variant is included here).

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes
- [ ] Tabs: controlled mode works with external state
- [ ] StatusTag: custom label renders correctly
- [ ] MetricCard: all 5 icon variants render with correct colors
- [ ] DataTable: sticky first column works on horizontal scroll
- [ ] CollapsibleCard: expand/collapse animates smoothly
- [ ] Chip: dark variant renders correctly in light and dark mode
- [ ] Token build: `dist/variables.css` includes dark mode block

🤖 Generated with [Claude Code](https://claude.com/claude-code)