### PR TITLE
feat(ui): add ordering flow components (Wave A)

### DIFF
--- a/packages/ui/src/components/CollapsibleSection/CollapsibleSection.tsx
+++ b/packages/ui/src/components/CollapsibleSection/CollapsibleSection.tsx
@@ -1,0 +1,95 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { cn } from '../../lib/cn';
+
+export interface CollapsibleSectionProps extends React.HTMLAttributes<HTMLDivElement> {
+  label: string;
+  preview?: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}
+
+export const CollapsibleSection = React.forwardRef<HTMLDivElement, CollapsibleSectionProps>(
+  (
+    {
+      label,
+      preview,
+      defaultOpen = false,
+      children,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    const [open, setOpen] = useState(defaultOpen);
+    const bodyRef = useRef<HTMLDivElement>(null);
+    const [maxHeight, setMaxHeight] = useState<string>(defaultOpen ? 'none' : '0px');
+
+    const updateMaxHeight = useCallback(() => {
+      if (bodyRef.current) {
+        setMaxHeight(open ? `${bodyRef.current.scrollHeight}px` : '0px');
+      }
+    }, [open]);
+
+    useEffect(() => {
+      updateMaxHeight();
+    }, [updateMaxHeight]);
+
+    const toggle = () => setOpen((prev) => !prev);
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'rounded-xl border border-stone-200 bg-white',
+          className
+        )}
+        {...props}
+      >
+        <button
+          type="button"
+          onClick={toggle}
+          className={cn(
+            'flex w-full items-center justify-between px-4 py-3',
+            'text-left transition-colors duration-150',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-violet-600/40',
+            'hover:bg-stone-50',
+            open ? 'rounded-t-xl' : 'rounded-xl'
+          )}
+          aria-expanded={open}
+        >
+          <span className="text-sm font-medium text-stone-900">{label}</span>
+          <div className="flex items-center gap-2">
+            {!open && preview && (
+              <span className="text-sm text-stone-500">{preview}</span>
+            )}
+            <svg
+              className={cn(
+                'h-4 w-4 text-stone-400 transition-transform duration-300',
+                open && 'rotate-180'
+              )}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </div>
+        </button>
+
+        <div
+          ref={bodyRef}
+          style={{ maxHeight }}
+          className="overflow-hidden transition-[max-height] duration-300 ease-in-out"
+        >
+          <div className="border-t border-stone-200 px-4 py-3">
+            {children}
+          </div>
+        </div>
+      </div>
+    );
+  }
+);
+
+CollapsibleSection.displayName = 'CollapsibleSection';

--- a/packages/ui/src/components/CollapsibleSection/index.ts
+++ b/packages/ui/src/components/CollapsibleSection/index.ts
@@ -1,0 +1,2 @@
+export { CollapsibleSection } from './CollapsibleSection';
+export type { CollapsibleSectionProps } from './CollapsibleSection';

--- a/packages/ui/src/components/ContentTypeCard/ContentTypeCard.tsx
+++ b/packages/ui/src/components/ContentTypeCard/ContentTypeCard.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export type ContentTypeCardBadgeColor = 'violet' | 'green';
+
+export interface ContentTypeCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  badge: string;
+  badgeColor?: ContentTypeCardBadgeColor;
+  title: string;
+  price: string;
+  pros: string[];
+  cancelPolicy?: string;
+  recommended?: boolean;
+  selected?: boolean;
+  onSelect?: () => void;
+}
+
+const badgeColorClasses: Record<ContentTypeCardBadgeColor, string> = {
+  violet: 'bg-violet-100 text-violet-700',
+  green: 'bg-emerald-100 text-emerald-700',
+};
+
+export const ContentTypeCard = React.forwardRef<HTMLDivElement, ContentTypeCardProps>(
+  (
+    {
+      badge,
+      badgeColor = 'violet',
+      title,
+      price,
+      pros,
+      cancelPolicy,
+      recommended = false,
+      selected = false,
+      onSelect,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <div
+        ref={ref}
+        role="button"
+        tabIndex={0}
+        onClick={onSelect}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onSelect?.();
+          }
+        }}
+        className={cn(
+          'relative flex flex-col gap-4 rounded-xl border p-6',
+          'cursor-pointer transition-all duration-200',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-violet-600/40',
+          selected
+            ? 'border-violet-600 bg-violet-50'
+            : 'border-stone-200 bg-white hover:shadow-lg',
+          className
+        )}
+        {...props}
+      >
+        {recommended && (
+          <span className="absolute -top-2.5 right-4 inline-flex rounded-full bg-violet-600 px-2.5 py-0.5 text-xs font-medium text-white">
+            Recommended
+          </span>
+        )}
+
+        <span
+          className={cn(
+            'inline-flex self-start rounded-full px-2.5 py-0.5 text-xs font-medium',
+            badgeColorClasses[badgeColor]
+          )}
+        >
+          {badge}
+        </span>
+
+        <div className="flex flex-col gap-1">
+          <h3 className="text-base font-semibold text-stone-900">{title}</h3>
+          <p className="text-sm text-stone-500">{price}</p>
+        </div>
+
+        <ul className="flex flex-col gap-2">
+          {pros.map((pro, index) => (
+            <li key={index} className="flex items-start gap-2 text-sm text-stone-600">
+              <svg
+                className="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-500"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2.5}
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+              {pro}
+            </li>
+          ))}
+        </ul>
+
+        {cancelPolicy && (
+          <p className="text-xs text-stone-400">{cancelPolicy}</p>
+        )}
+      </div>
+    );
+  }
+);
+
+ContentTypeCard.displayName = 'ContentTypeCard';

--- a/packages/ui/src/components/ContentTypeCard/index.ts
+++ b/packages/ui/src/components/ContentTypeCard/index.ts
@@ -1,0 +1,2 @@
+export { ContentTypeCard } from './ContentTypeCard';
+export type { ContentTypeCardProps, ContentTypeCardBadgeColor } from './ContentTypeCard';

--- a/packages/ui/src/components/GoalCard/GoalCard.tsx
+++ b/packages/ui/src/components/GoalCard/GoalCard.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export type GoalCardTagColor = 'violet' | 'green' | 'amber' | 'blue';
+
+export interface GoalCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  icon: string;
+  title: string;
+  subtitle: string;
+  tag: string;
+  tagColor?: GoalCardTagColor;
+  selected?: boolean;
+  onSelect?: () => void;
+}
+
+const tagColorClasses: Record<GoalCardTagColor, string> = {
+  violet: 'bg-violet-100 text-violet-700',
+  green: 'bg-emerald-100 text-emerald-700',
+  amber: 'bg-amber-100 text-amber-700',
+  blue: 'bg-blue-100 text-blue-700',
+};
+
+export const GoalCard = React.forwardRef<HTMLDivElement, GoalCardProps>(
+  (
+    {
+      icon,
+      title,
+      subtitle,
+      tag,
+      tagColor = 'violet',
+      selected = false,
+      onSelect,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <div
+        ref={ref}
+        role="button"
+        tabIndex={0}
+        onClick={onSelect}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onSelect?.();
+          }
+        }}
+        className={cn(
+          'flex flex-col items-center gap-3 rounded-xl border p-6 text-center',
+          'cursor-pointer transition-all duration-200',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-violet-600/40',
+          selected
+            ? 'border-violet-600 bg-violet-50 shadow-[0_0_0_1px_rgba(101,49,255,0.3)]'
+            : 'border-stone-200 bg-white hover:shadow-lg',
+          className
+        )}
+        {...props}
+      >
+        <span className="text-3xl" aria-hidden="true">{icon}</span>
+        <div className="flex flex-col gap-1">
+          <h3 className="text-sm font-semibold text-stone-900">{title}</h3>
+          <p className="text-xs text-stone-500">{subtitle}</p>
+        </div>
+        <span
+          className={cn(
+            'inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium',
+            tagColorClasses[tagColor]
+          )}
+        >
+          {tag}
+        </span>
+      </div>
+    );
+  }
+);
+
+GoalCard.displayName = 'GoalCard';

--- a/packages/ui/src/components/GoalCard/index.ts
+++ b/packages/ui/src/components/GoalCard/index.ts
@@ -1,0 +1,2 @@
+export { GoalCard } from './GoalCard';
+export type { GoalCardProps, GoalCardTagColor } from './GoalCard';

--- a/packages/ui/src/components/ScriptPreviewCard/ScriptPreviewCard.tsx
+++ b/packages/ui/src/components/ScriptPreviewCard/ScriptPreviewCard.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export interface ScriptSection {
+  label: string;
+  emoji: string;
+  timing: string;
+  content: string;
+}
+
+export interface ScriptPreviewCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  concept: string;
+  duration: string;
+  sections: ScriptSection[];
+}
+
+export const ScriptPreviewCard = React.forwardRef<HTMLDivElement, ScriptPreviewCardProps>(
+  (
+    {
+      concept,
+      duration,
+      sections,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'flex flex-col gap-4 rounded-xl border border-stone-200 bg-white p-6',
+          className
+        )}
+        {...props}
+      >
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-stone-900">{concept}</h3>
+          <span className="inline-flex rounded-full bg-stone-100 px-2.5 py-0.5 text-xs font-medium text-stone-600">
+            {duration}
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          {sections.map((section, index) => (
+            <div key={index} className="flex flex-col gap-1">
+              <div className="flex items-center gap-1.5">
+                <span className="text-sm" aria-hidden="true">{section.emoji}</span>
+                <span className="text-xs font-semibold uppercase tracking-wide text-stone-500">
+                  {section.label}
+                </span>
+                <span className="text-xs text-stone-400">{section.timing}</span>
+              </div>
+              <p className="pl-6 text-sm text-stone-600">{section.content}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+);
+
+ScriptPreviewCard.displayName = 'ScriptPreviewCard';

--- a/packages/ui/src/components/ScriptPreviewCard/index.ts
+++ b/packages/ui/src/components/ScriptPreviewCard/index.ts
@@ -1,0 +1,2 @@
+export { ScriptPreviewCard } from './ScriptPreviewCard';
+export type { ScriptPreviewCardProps, ScriptSection } from './ScriptPreviewCard';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -129,3 +129,19 @@ export type { SliderProps, SliderMark } from './components/Slider';
 // CollapsibleCard
 export { CollapsibleCard } from './components/CollapsibleCard';
 export type { CollapsibleCardProps } from './components/CollapsibleCard';
+
+// GoalCard
+export { GoalCard } from './components/GoalCard';
+export type { GoalCardProps, GoalCardTagColor } from './components/GoalCard';
+
+// ContentTypeCard
+export { ContentTypeCard } from './components/ContentTypeCard';
+export type { ContentTypeCardProps, ContentTypeCardBadgeColor } from './components/ContentTypeCard';
+
+// ScriptPreviewCard
+export { ScriptPreviewCard } from './components/ScriptPreviewCard';
+export type { ScriptPreviewCardProps, ScriptSection } from './components/ScriptPreviewCard';
+
+// CollapsibleSection
+export { CollapsibleSection } from './components/CollapsibleSection';
+export type { CollapsibleSectionProps } from './components/CollapsibleSection';


### PR DESCRIPTION
## Summary
- **GoalCard** — Clickable card with emoji icon, title, subtitle, and colored tag pill. Selected state with violet border + accent bg.
- **ContentTypeCard** — Selectable card with badge, title, price, pros list (checkmarks), cancel policy, and optional "Recommended" pill.
- **ScriptPreviewCard** — Read-only card showing script concept, duration badge, and sections (emoji + uppercase label + timing + content).
- **CollapsibleSection** — Expandable section with header label, preview value when collapsed, and smooth max-height CSS transition.

All 4 components follow the established pattern: `React.forwardRef`, TypeScript interfaces with exported types, `cn()` utility for class merging, Tailwind classes matching Canvas design system tokens.

## Files Changed
- `packages/ui/src/components/GoalCard/` (new)
- `packages/ui/src/components/ContentTypeCard/` (new)
- `packages/ui/src/components/ScriptPreviewCard/` (new)
- `packages/ui/src/components/CollapsibleSection/` (new)
- `packages/ui/src/index.ts` (barrel exports added)

## Test plan
- [ ] `npx tsc --noEmit` passes (0 new errors; 2 pre-existing in Button test unrelated)
- [ ] Import each component from `@amplify/ui` in a consuming app
- [ ] Verify GoalCard selected/unselected states toggle correctly
- [ ] Verify ContentTypeCard "Recommended" pill renders with `recommended` prop
- [ ] Verify ScriptPreviewCard renders sections with correct emoji/label/timing layout
- [ ] Verify CollapsibleSection expands/collapses with smooth animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)