### PR TITLE
feat(ui): add InsightBanner, FlexiSelector, ProductUrlInput, WalletCard

### DIFF
--- a/packages/ui/src/components/FlexiSelector/FlexiSelector.tsx
+++ b/packages/ui/src/components/FlexiSelector/FlexiSelector.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import { cn } from '../../lib/cn';
+
+export interface FlexiOption {
+  label: string;
+  subtitle?: string;
+  price?: string;
+}
+
+export interface FlexiSelectorProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
+  defaultLabel: string;
+  defaultDescription: string;
+  options: FlexiOption[];
+  onSelect?: (index: number | null) => void;
+  expandLabel?: string;
+}
+
+export const FlexiSelector = React.forwardRef<HTMLDivElement, FlexiSelectorProps>(
+  (
+    {
+      defaultLabel,
+      defaultDescription,
+      options,
+      onSelect,
+      expandLabel = 'Pick specific?',
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    const [expanded, setExpanded] = useState(false);
+    const [selected, setSelected] = useState<number | null>(null);
+
+    const isFlexible = selected === null;
+
+    const handleFlexibleClick = () => {
+      setSelected(null);
+      setExpanded(false);
+      onSelect?.(null);
+    };
+
+    const handleOptionClick = (index: number) => {
+      setSelected(index);
+      onSelect?.(index);
+    };
+
+    const handleExpandClick = () => {
+      setExpanded(true);
+    };
+
+    return (
+      <div ref={ref} className={cn('flex flex-col gap-3', className)} {...props}>
+        {/* Default flexible card */}
+        <button
+          type="button"
+          onClick={handleFlexibleClick}
+          className={cn(
+            'w-full rounded-lg border-2 px-4 py-3 text-left transition-all duration-150',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-600/40 focus-visible:ring-offset-2',
+            isFlexible
+              ? 'border-violet-600 bg-violet-50'
+              : 'border-stone-200 bg-white hover:bg-stone-50'
+          )}
+        >
+          <span className="block text-sm font-medium text-stone-900">
+            {defaultLabel}
+          </span>
+          <span className="block text-xs text-stone-500 mt-0.5">
+            {defaultDescription}
+          </span>
+        </button>
+
+        {/* Expand link */}
+        {!expanded && (
+          <button
+            type="button"
+            onClick={handleExpandClick}
+            className="self-start text-sm font-medium text-violet-600 hover:text-violet-700 transition-colors"
+          >
+            {expandLabel}
+          </button>
+        )}
+
+        {/* Option cards grid */}
+        {expanded && (
+          <div className="grid grid-cols-3 gap-3">
+            {options.map((option, index) => (
+              <button
+                key={index}
+                type="button"
+                onClick={() => handleOptionClick(index)}
+                className={cn(
+                  'flex flex-col rounded-lg border-2 px-3 py-3 text-left transition-all duration-150',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-600/40 focus-visible:ring-offset-2',
+                  selected === index
+                    ? 'border-violet-600 bg-violet-50'
+                    : 'border-stone-200 bg-white hover:bg-stone-50'
+                )}
+              >
+                <span className="text-sm font-medium text-stone-900">
+                  {option.label}
+                </span>
+                {option.subtitle && (
+                  <span className="text-xs text-stone-500 mt-0.5">
+                    {option.subtitle}
+                  </span>
+                )}
+                {option.price && (
+                  <span className="text-xs font-medium text-violet-600 mt-1">
+                    {option.price}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+FlexiSelector.displayName = 'FlexiSelector';

--- a/packages/ui/src/components/FlexiSelector/index.ts
+++ b/packages/ui/src/components/FlexiSelector/index.ts
@@ -1,0 +1,2 @@
+export { FlexiSelector } from './FlexiSelector';
+export type { FlexiSelectorProps, FlexiOption } from './FlexiSelector';

--- a/packages/ui/src/components/InsightBanner/InsightBanner.tsx
+++ b/packages/ui/src/components/InsightBanner/InsightBanner.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export interface InsightBannerProps extends React.HTMLAttributes<HTMLDivElement> {
+  icon?: string;
+  children: React.ReactNode;
+}
+
+export const InsightBanner = React.forwardRef<HTMLDivElement, InsightBannerProps>(
+  ({ icon = '\u{1F4A1}', children, className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'flex flex-row items-start gap-3 rounded-lg border border-violet-200 bg-violet-50 px-4 py-3',
+          className
+        )}
+        {...props}
+      >
+        <span className="flex-shrink-0 text-base" aria-hidden="true">
+          {icon}
+        </span>
+        <div className="text-sm text-violet-600">{children}</div>
+      </div>
+    );
+  }
+);
+
+InsightBanner.displayName = 'InsightBanner';

--- a/packages/ui/src/components/InsightBanner/index.ts
+++ b/packages/ui/src/components/InsightBanner/index.ts
@@ -1,0 +1,2 @@
+export { InsightBanner } from './InsightBanner';
+export type { InsightBannerProps } from './InsightBanner';

--- a/packages/ui/src/components/ProductUrlInput/ProductUrlInput.tsx
+++ b/packages/ui/src/components/ProductUrlInput/ProductUrlInput.tsx
@@ -1,0 +1,89 @@
+import React, { useState, useCallback } from 'react';
+import { cn } from '../../lib/cn';
+
+export interface ProductUrlInputProps {
+  placeholder?: string;
+  buttonLabel?: string;
+  onSubmit?: (url: string) => void;
+  className?: string;
+}
+
+export const ProductUrlInput = React.forwardRef<HTMLDivElement, ProductUrlInputProps>(
+  (
+    {
+      placeholder = 'Paste product URL...',
+      buttonLabel = 'Get Started',
+      onSubmit,
+      className,
+    },
+    ref
+  ) => {
+    const [value, setValue] = useState('');
+
+    const handleSubmit = useCallback(() => {
+      if (value.trim()) {
+        onSubmit?.(value.trim());
+      }
+    }, [value, onSubmit]);
+
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+          handleSubmit();
+        }
+      },
+      [handleSubmit]
+    );
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'flex items-center gap-2 rounded-2xl border border-stone-200 bg-white px-4 py-2 shadow-lg',
+          className
+        )}
+      >
+        {/* Link icon */}
+        <svg
+          className="h-5 w-5 flex-shrink-0 text-stone-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+          />
+        </svg>
+
+        <input
+          type="url"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className="min-w-0 flex-1 border-0 bg-transparent text-sm text-stone-900 placeholder:text-stone-400 focus:outline-none"
+        />
+
+        <button
+          type="button"
+          onClick={handleSubmit}
+          className={cn(
+            'flex-shrink-0 rounded-xl bg-violet-600 px-4 py-2 text-sm font-medium text-white transition-colors',
+            'hover:bg-violet-700',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-600/40 focus-visible:ring-offset-2',
+            'disabled:opacity-50 disabled:cursor-not-allowed'
+          )}
+          disabled={!value.trim()}
+        >
+          {buttonLabel}
+        </button>
+      </div>
+    );
+  }
+);
+
+ProductUrlInput.displayName = 'ProductUrlInput';

--- a/packages/ui/src/components/ProductUrlInput/index.ts
+++ b/packages/ui/src/components/ProductUrlInput/index.ts
@@ -1,0 +1,2 @@
+export { ProductUrlInput } from './ProductUrlInput';
+export type { ProductUrlInputProps } from './ProductUrlInput';

--- a/packages/ui/src/components/WalletCard/WalletCard.tsx
+++ b/packages/ui/src/components/WalletCard/WalletCard.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export interface WalletCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  balance: number;
+  currency?: string;
+  percentage?: number;
+  topupMessage?: string;
+  subtitle?: string;
+}
+
+function formatBalance(amount: number, currency: string): string {
+  return `${currency}${amount.toLocaleString('en-IN')}`;
+}
+
+export const WalletCard = React.forwardRef<HTMLDivElement, WalletCardProps>(
+  (
+    {
+      balance,
+      currency = '\u20B9',
+      percentage = 0,
+      topupMessage,
+      subtitle,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    const clampedPct = Math.max(0, Math.min(100, percentage));
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'flex flex-col gap-3 rounded-lg border border-violet-200 bg-violet-50 px-4 py-4',
+          className
+        )}
+        {...props}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium text-stone-600">
+            OI Money Balance
+          </span>
+          <span className="text-lg font-bold text-violet-600">
+            {formatBalance(balance, currency)}
+          </span>
+        </div>
+
+        {/* Progress bar */}
+        <div className="h-2 w-full overflow-hidden rounded-full bg-violet-200">
+          <div
+            className="h-full rounded-full bg-violet-600 transition-all duration-300"
+            style={{ width: `${clampedPct}%` }}
+            role="progressbar"
+            aria-valuenow={clampedPct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          />
+        </div>
+
+        {/* Topup message */}
+        {topupMessage && (
+          <p className="text-xs text-stone-500">{topupMessage}</p>
+        )}
+
+        {/* Subtitle */}
+        {subtitle && (
+          <p className="text-xs text-violet-600">{subtitle}</p>
+        )}
+      </div>
+    );
+  }
+);
+
+WalletCard.displayName = 'WalletCard';

--- a/packages/ui/src/components/WalletCard/index.ts
+++ b/packages/ui/src/components/WalletCard/index.ts
@@ -1,0 +1,2 @@
+export { WalletCard } from './WalletCard';
+export type { WalletCardProps } from './WalletCard';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -161,3 +161,19 @@ export type { PackageCardProps } from './components/PackageCard';
 // ScrapeAnimation
 export { ScrapeAnimation } from './components/ScrapeAnimation';
 export type { ScrapeAnimationProps, ScrapeStep, ScrapeStepStatus } from './components/ScrapeAnimation';
+
+// InsightBanner
+export { InsightBanner } from './components/InsightBanner';
+export type { InsightBannerProps } from './components/InsightBanner';
+
+// FlexiSelector
+export { FlexiSelector } from './components/FlexiSelector';
+export type { FlexiSelectorProps, FlexiOption } from './components/FlexiSelector';
+
+// ProductUrlInput
+export { ProductUrlInput } from './components/ProductUrlInput';
+export type { ProductUrlInputProps } from './components/ProductUrlInput';
+
+// WalletCard
+export { WalletCard } from './components/WalletCard';
+export type { WalletCardProps } from './components/WalletCard';


### PR DESCRIPTION
## Summary
- **InsightBanner** — accent-light banner with emoji icon + text content for contextual tips
- **FlexiSelector** — flexible/specific option picker with expandable grid, used for size/quality selection in ordering flow
- **ProductUrlInput** — composite input with link icon + URL field + primary CTA button for campaign creation entry point
- **WalletCard** — OI Money balance display with progress bar, topup message, and subtitle

## Details
All 4 components follow existing repo patterns: `React.forwardRef`, TypeScript interfaces with exported types, `cn()` utility, Tailwind classes with violet/stone palette. Barrel exports added to each component `index.ts` and to `packages/ui/src/index.ts`.

Type-check passes (only pre-existing Button.test.tsx errors remain).

## Test plan
- [ ] Verify type-check passes in CI
- [ ] Verify Storybook builds
- [ ] Visual review of each component in isolation
- [ ] Confirm barrel exports resolve correctly from `@amplify/ui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)