### PR TITLE
feat(ui): add ActionFooter, PricePill, StepPill, TrustBar

### DIFF
--- a/packages/ui/src/components/ActionFooter/ActionFooter.tsx
+++ b/packages/ui/src/components/ActionFooter/ActionFooter.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export interface ActionFooterProps extends React.HTMLAttributes<HTMLDivElement> {
+  onBack?: () => void;
+  onNext?: () => void;
+  backLabel?: string;
+  nextLabel?: string;
+  showBack?: boolean;
+  showKeyboardHints?: boolean;
+  nextDisabled?: boolean;
+}
+
+export const ActionFooter = React.forwardRef<HTMLDivElement, ActionFooterProps>(
+  (
+    {
+      onBack,
+      onNext,
+      backLabel = '\u2190 Back',
+      nextLabel = 'Save & Continue \u2192',
+      showBack = true,
+      showKeyboardHints = true,
+      nextDisabled = false,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'fixed bottom-0 left-0 right-0 z-50',
+          'flex items-center justify-between px-6 py-3',
+          'bg-white/[0.92] backdrop-blur-sm border-t border-[var(--amp-semantic-border-default,#e5e5e5)]',
+          className
+        )}
+        {...props}
+      >
+        {/* Keyboard hints */}
+        <div className="flex items-center gap-2">
+          {showKeyboardHints && (
+            <span className="text-xs text-[var(--amp-semantic-text-muted,#a3a3a3)] hidden sm:flex items-center gap-1.5">
+              <kbd className="inline-flex items-center justify-center min-w-[1.5rem] h-5 px-1.5 rounded border border-[var(--amp-semantic-border-default,#e5e5e5)] bg-[var(--amp-semantic-bg-sunken,#f5f5f5)] text-[10px] font-mono">
+                Enter
+              </kbd>
+              <span>Continue</span>
+              <span className="mx-1">&middot;</span>
+              <kbd className="inline-flex items-center justify-center min-w-[1.5rem] h-5 px-1.5 rounded border border-[var(--amp-semantic-border-default,#e5e5e5)] bg-[var(--amp-semantic-bg-sunken,#f5f5f5)] text-[10px] font-mono">
+                &uarr;
+              </kbd>
+              <kbd className="inline-flex items-center justify-center min-w-[1.5rem] h-5 px-1.5 rounded border border-[var(--amp-semantic-border-default,#e5e5e5)] bg-[var(--amp-semantic-bg-sunken,#f5f5f5)] text-[10px] font-mono">
+                &darr;
+              </kbd>
+              <span>Navigate</span>
+            </span>
+          )}
+        </div>
+
+        {/* Buttons */}
+        <div className="flex items-center gap-3">
+          {showBack && onBack && (
+            <button
+              type="button"
+              onClick={onBack}
+              className={cn(
+                'px-4 py-2 rounded-lg text-sm font-medium transition-colors',
+                'text-[var(--amp-semantic-text-default,#171717)] bg-transparent',
+                'hover:bg-[var(--amp-semantic-bg-sunken,#f5f5f5)]',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--amp-semantic-accent,#6531FF)]/40'
+              )}
+            >
+              {backLabel}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onNext}
+            disabled={nextDisabled}
+            className={cn(
+              'px-6 py-2.5 rounded-lg text-sm font-medium transition-colors',
+              'bg-[var(--amp-semantic-accent,#6531FF)] text-white',
+              'hover:opacity-90',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--amp-semantic-accent,#6531FF)]/40',
+              'disabled:opacity-50 disabled:cursor-not-allowed'
+            )}
+          >
+            {nextLabel}
+          </button>
+        </div>
+      </div>
+    );
+  }
+);
+
+ActionFooter.displayName = 'ActionFooter';

--- a/packages/ui/src/components/ActionFooter/index.ts
+++ b/packages/ui/src/components/ActionFooter/index.ts
@@ -1,0 +1,2 @@
+export { ActionFooter } from './ActionFooter';
+export type { ActionFooterProps } from './ActionFooter';

--- a/packages/ui/src/components/PricePill/PricePill.tsx
+++ b/packages/ui/src/components/PricePill/PricePill.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export interface PricePillProps extends React.HTMLAttributes<HTMLDivElement> {
+  label?: string;
+  amount: string;
+  visible?: boolean;
+}
+
+export const PricePill = React.forwardRef<HTMLDivElement, PricePillProps>(
+  ({ label = 'Est.', amount, visible = true, className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'fixed bottom-[60px] left-1/2 -translate-x-1/2 z-50',
+          'inline-flex items-center gap-1.5 px-4 py-2',
+          'rounded-full border border-[var(--amp-semantic-border-default,#e5e5e5)]',
+          'bg-white shadow-lg',
+          'transition-all duration-300 ease-in-out',
+          visible
+            ? 'opacity-100 translate-y-0'
+            : 'opacity-0 translate-y-2 pointer-events-none',
+          className
+        )}
+        aria-live="polite"
+        {...props}
+      >
+        <span className="text-sm text-[var(--amp-semantic-text-muted,#a3a3a3)]">
+          {label}
+        </span>
+        <span className="text-sm font-semibold text-[var(--amp-semantic-accent,#6531FF)]">
+          {amount}
+        </span>
+      </div>
+    );
+  }
+);
+
+PricePill.displayName = 'PricePill';

--- a/packages/ui/src/components/PricePill/index.ts
+++ b/packages/ui/src/components/PricePill/index.ts
@@ -1,0 +1,2 @@
+export { PricePill } from './PricePill';
+export type { PricePillProps } from './PricePill';

--- a/packages/ui/src/components/StepPill/StepPill.tsx
+++ b/packages/ui/src/components/StepPill/StepPill.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export type StepPillStatus = 'pending' | 'active' | 'done';
+
+export interface StepPillItem {
+  label: string;
+  status: StepPillStatus;
+}
+
+export interface StepPillProps extends React.HTMLAttributes<HTMLDivElement> {
+  steps: StepPillItem[];
+  onStepClick?: (index: number) => void;
+}
+
+export const StepPill = React.forwardRef<HTMLDivElement, StepPillProps>(
+  ({ steps, onStepClick, className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        role="navigation"
+        aria-label="Step progress"
+        className={cn('flex items-center gap-2', className)}
+        {...props}
+      >
+        {steps.map((step, index) => {
+          const handleClick = onStepClick
+            ? () => onStepClick(index)
+            : undefined;
+
+          return (
+            <button
+              key={index}
+              type="button"
+              onClick={handleClick}
+              aria-current={step.status === 'active' ? 'step' : undefined}
+              className={cn(
+                'px-3 py-1.5 rounded-full text-xs font-medium transition-colors border',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--amp-semantic-accent,#6531FF)]/40',
+                step.status === 'pending' &&
+                  'border-[var(--amp-semantic-border-default,#e5e5e5)] text-[var(--amp-semantic-text-muted,#a3a3a3)] bg-transparent',
+                step.status === 'active' &&
+                  'border-[var(--amp-semantic-accent,#6531FF)] bg-[var(--amp-semantic-accent,#6531FF)] text-white font-semibold',
+                step.status === 'done' &&
+                  'border-green-600 bg-green-50 text-green-600'
+              )}
+            >
+              {step.label}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+);
+
+StepPill.displayName = 'StepPill';

--- a/packages/ui/src/components/StepPill/index.ts
+++ b/packages/ui/src/components/StepPill/index.ts
@@ -1,0 +1,2 @@
+export { StepPill } from './StepPill';
+export type { StepPillProps, StepPillItem, StepPillStatus } from './StepPill';

--- a/packages/ui/src/components/TrustBar/TrustBar.tsx
+++ b/packages/ui/src/components/TrustBar/TrustBar.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export interface TrustItem {
+  icon: string;
+  label: string;
+}
+
+export interface TrustBarProps extends React.HTMLAttributes<HTMLDivElement> {
+  items: TrustItem[];
+}
+
+export const TrustBar = React.forwardRef<HTMLDivElement, TrustBarProps>(
+  ({ items, className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'flex items-center justify-center gap-6',
+          'border-t border-[var(--amp-semantic-border-default,#e5e5e5)] pt-3',
+          className
+        )}
+        {...props}
+      >
+        {items.map((item, index) => (
+          <span
+            key={index}
+            className="inline-flex items-center gap-1.5 text-xs text-[var(--amp-semantic-text-muted,#a3a3a3)]"
+          >
+            <span aria-hidden="true">{item.icon}</span>
+            <span>{item.label}</span>
+          </span>
+        ))}
+      </div>
+    );
+  }
+);
+
+TrustBar.displayName = 'TrustBar';

--- a/packages/ui/src/components/TrustBar/index.ts
+++ b/packages/ui/src/components/TrustBar/index.ts
@@ -1,0 +1,2 @@
+export { TrustBar } from './TrustBar';
+export type { TrustBarProps, TrustItem } from './TrustBar';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -177,3 +177,19 @@ export type { ProductUrlInputProps } from './components/ProductUrlInput';
 // WalletCard
 export { WalletCard } from './components/WalletCard';
 export type { WalletCardProps } from './components/WalletCard';
+
+// ActionFooter
+export { ActionFooter } from './components/ActionFooter';
+export type { ActionFooterProps } from './components/ActionFooter';
+
+// PricePill
+export { PricePill } from './components/PricePill';
+export type { PricePillProps } from './components/PricePill';
+
+// StepPill
+export { StepPill } from './components/StepPill';
+export type { StepPillProps, StepPillItem, StepPillStatus } from './components/StepPill';
+
+// TrustBar
+export { TrustBar } from './components/TrustBar';
+export type { TrustBarProps, TrustItem } from './components/TrustBar';


### PR DESCRIPTION
## Summary
- **ActionFooter**: Fixed bottom navigation bar with back/next buttons, keyboard hints, ghost/primary button variants
- **PricePill**: Floating price indicator pill positioned above ActionFooter with show/hide animation
- **StepPill**: Horizontal pill-based step indicator with pending/active/done states
- **TrustBar**: Static trust signals row with emoji icons and muted text

All components follow existing patterns (forwardRef, cn utility, CSS variable tokens with fallbacks), barrel-exported from `packages/ui/src/index.ts`.

## Test plan
- [ ] Verify `npm run build` passes
- [ ] Verify each component renders correctly in Storybook
- [ ] Verify ActionFooter keyboard hints hide on mobile (sm: breakpoint)
- [ ] Verify PricePill animation transitions smoothly on `visible` toggle
- [ ] Verify StepPill status variants match spec colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)