### PR TITLE
feat(ui): add RecoReason, AddonTeaser, PackageCard, ScrapeAnimation

### DIFF
--- a/packages/ui/src/components/AddonTeaser/AddonTeaser.tsx
+++ b/packages/ui/src/components/AddonTeaser/AddonTeaser.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export interface AddonItem {
+  icon: string;
+  label: string;
+  badge?: string;
+}
+
+export interface AddonTeaserProps extends React.HTMLAttributes<HTMLDivElement> {
+  title: string;
+  items: AddonItem[];
+}
+
+export const AddonTeaser = React.forwardRef<HTMLDivElement, AddonTeaserProps>(
+  ({ title, items, className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'rounded-lg border border-dashed border-stone-300 bg-stone-50 px-4 py-3',
+          className
+        )}
+        {...props}
+      >
+        <p className="text-sm font-semibold text-stone-700 mb-2">{title}</p>
+        <div className="flex flex-col gap-1.5">
+          {items.map((item, idx) => (
+            <div key={idx} className="flex items-center gap-2 text-sm text-stone-600">
+              <span className="shrink-0" aria-hidden="true">
+                {item.icon}
+              </span>
+              <span>{item.label}</span>
+              {item.badge && (
+                <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+                  {item.badge}
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+);
+AddonTeaser.displayName = 'AddonTeaser';

--- a/packages/ui/src/components/AddonTeaser/index.ts
+++ b/packages/ui/src/components/AddonTeaser/index.ts
@@ -1,0 +1,2 @@
+export { AddonTeaser } from './AddonTeaser';
+export type { AddonTeaserProps, AddonItem } from './AddonTeaser';

--- a/packages/ui/src/components/PackageCard/PackageCard.tsx
+++ b/packages/ui/src/components/PackageCard/PackageCard.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export interface PackageCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  name: string;
+  description: string;
+  price: string;
+  selected?: boolean;
+  onSelect?: () => void;
+}
+
+export const PackageCard = React.forwardRef<HTMLDivElement, PackageCardProps>(
+  ({ name, description, price, selected = false, onSelect, className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        role="button"
+        tabIndex={0}
+        aria-pressed={selected}
+        onClick={onSelect}
+        onKeyDown={(e) => {
+          if ((e.key === 'Enter' || e.key === ' ') && onSelect) {
+            e.preventDefault();
+            onSelect();
+          }
+        }}
+        className={cn(
+          'flex flex-row items-center justify-between rounded-xl px-4 py-3 cursor-pointer transition-all duration-150',
+          selected
+            ? 'border-2 border-[var(--amp-semantic-border-accent,#6531FF)] bg-[var(--amp-semantic-bg-accent-subtle,#F3EEFF)] shadow-md'
+            : 'border border-stone-200 bg-white hover:shadow-md',
+          className
+        )}
+        {...props}
+      >
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <span className="text-sm font-semibold text-stone-900">{name}</span>
+          <span className="text-xs text-stone-500">{description}</span>
+        </div>
+        <span
+          className={cn(
+            'text-sm font-bold shrink-0 ml-4',
+            selected
+              ? 'text-[var(--amp-semantic-text-accent,#6531FF)]'
+              : 'text-stone-900'
+          )}
+        >
+          {price}
+        </span>
+      </div>
+    );
+  }
+);
+PackageCard.displayName = 'PackageCard';

--- a/packages/ui/src/components/PackageCard/index.ts
+++ b/packages/ui/src/components/PackageCard/index.ts
@@ -1,0 +1,2 @@
+export { PackageCard } from './PackageCard';
+export type { PackageCardProps } from './PackageCard';

--- a/packages/ui/src/components/RecoReason/RecoReason.tsx
+++ b/packages/ui/src/components/RecoReason/RecoReason.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export interface RecoReasonProps extends React.HTMLAttributes<HTMLDivElement> {
+  icon?: string;
+  children: React.ReactNode;
+}
+
+export const RecoReason = React.forwardRef<HTMLDivElement, RecoReasonProps>(
+  ({ icon = '\uD83C\uDFAF', children, className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'flex flex-row items-start gap-2 rounded-lg bg-green-50 border border-green-200 px-3 py-2.5 text-sm text-green-600',
+          className
+        )}
+        {...props}
+      >
+        <span className="shrink-0 leading-5" aria-hidden="true">
+          {icon}
+        </span>
+        <div className="min-w-0">{children}</div>
+      </div>
+    );
+  }
+);
+RecoReason.displayName = 'RecoReason';

--- a/packages/ui/src/components/RecoReason/index.ts
+++ b/packages/ui/src/components/RecoReason/index.ts
@@ -1,0 +1,2 @@
+export { RecoReason } from './RecoReason';
+export type { RecoReasonProps } from './RecoReason';

--- a/packages/ui/src/components/ScrapeAnimation/ScrapeAnimation.tsx
+++ b/packages/ui/src/components/ScrapeAnimation/ScrapeAnimation.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export type ScrapeStepStatus = 'pending' | 'active' | 'done';
+
+export interface ScrapeStep {
+  label: string;
+  status: ScrapeStepStatus;
+}
+
+export interface ScrapeAnimationProps extends React.HTMLAttributes<HTMLDivElement> {
+  steps: ScrapeStep[];
+}
+
+const spinnerStyle: React.CSSProperties = {
+  width: 16,
+  height: 16,
+  border: '2px solid #d6d3d1',
+  borderTop: '2px solid #6531FF',
+  borderRadius: '50%',
+  animation: 'amp-scrape-spin 0.8s linear infinite',
+};
+
+const keyframesId = 'amp-scrape-spin-keyframes';
+
+export const ScrapeAnimation = React.forwardRef<HTMLDivElement, ScrapeAnimationProps>(
+  ({ steps, className, ...props }, ref) => {
+    return (
+      <div ref={ref} className={cn('flex flex-col gap-2', className)} {...props}>
+        {/* Inject keyframes once */}
+        <style
+          dangerouslySetInnerHTML={{
+            __html: `@keyframes amp-scrape-spin{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}`,
+          }}
+          data-id={keyframesId}
+        />
+        {steps.map((step, idx) => (
+          <div
+            key={idx}
+            className={cn(
+              'flex items-center gap-2.5 text-sm',
+              step.status === 'pending' && 'opacity-30 text-stone-400',
+              step.status === 'active' && 'text-stone-700',
+              step.status === 'done' && 'text-green-600'
+            )}
+          >
+            {/* Status indicator */}
+            {step.status === 'pending' && (
+              <span className="inline-block w-4 h-4 rounded-full bg-stone-300" />
+            )}
+            {step.status === 'active' && <span style={spinnerStyle} />}
+            {step.status === 'done' && (
+              <span className="inline-flex items-center justify-center w-4 h-4 text-xs font-bold text-green-600">
+                &#x2713;
+              </span>
+            )}
+            <span>{step.label}</span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+);
+ScrapeAnimation.displayName = 'ScrapeAnimation';

--- a/packages/ui/src/components/ScrapeAnimation/ScrapeAnimation.tsx
+++ b/packages/ui/src/components/ScrapeAnimation/ScrapeAnimation.tsx
@@ -15,8 +15,8 @@ export interface ScrapeAnimationProps extends React.HTMLAttributes<HTMLDivElemen
 const spinnerStyle: React.CSSProperties = {
   width: 16,
   height: 16,
-  border: '2px solid #d6d3d1',
-  borderTop: '2px solid #6531FF',
+  border: '2px solid var(--amp-semantic-border-default, #d6d3d1)',
+  borderTop: '2px solid var(--amp-semantic-accent, #6531FF)',
   borderRadius: '50%',
   animation: 'amp-scrape-spin 0.8s linear infinite',
 };

--- a/packages/ui/src/components/ScrapeAnimation/index.ts
+++ b/packages/ui/src/components/ScrapeAnimation/index.ts
@@ -1,0 +1,2 @@
+export { ScrapeAnimation } from './ScrapeAnimation';
+export type { ScrapeAnimationProps, ScrapeStep, ScrapeStepStatus } from './ScrapeAnimation';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -145,3 +145,19 @@ export type { ScriptPreviewCardProps, ScriptSection } from './components/ScriptP
 // CollapsibleSection
 export { CollapsibleSection } from './components/CollapsibleSection';
 export type { CollapsibleSectionProps } from './components/CollapsibleSection';
+
+// RecoReason
+export { RecoReason } from './components/RecoReason';
+export type { RecoReasonProps } from './components/RecoReason';
+
+// AddonTeaser
+export { AddonTeaser } from './components/AddonTeaser';
+export type { AddonTeaserProps, AddonItem } from './components/AddonTeaser';
+
+// PackageCard
+export { PackageCard } from './components/PackageCard';
+export type { PackageCardProps } from './components/PackageCard';
+
+// ScrapeAnimation
+export { ScrapeAnimation } from './components/ScrapeAnimation';
+export type { ScrapeAnimationProps, ScrapeStep, ScrapeStepStatus } from './components/ScrapeAnimation';


### PR DESCRIPTION
## Summary
- **RecoReason** — Green-themed recommendation banner (icon + rich text, success-subtle styling)
- **AddonTeaser** — Dashed-border container listing available add-ons with optional amber badge pills
- **PackageCard** — Selectable horizontal card for package/pricing selection with accent highlight on select
- **ScrapeAnimation** — Vertical step list with pending/active(spinner)/done(checkmark) states for loading flows

All 4 components follow existing patterns (forwardRef, cn utility, HTMLAttributes extension) and are barrel-exported from `@amplify/ui`.

## Context
Feature components for the brand ordering flow — recommendations, add-ons, package selection, and scrape loading animation.

## Test plan
- [ ] `npx tsc --noEmit` passes (no new errors)
- [ ] Storybook visual check for each component
- [ ] Verify barrel exports resolve correctly in consuming app

🤖 Generated with [Claude Code](https://claude.com/claude-code)