### PR TITLE
docs(zenith): update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,11 +51,19 @@ packages/
   tokens-brand/       — Brand Platform tokens (purple primary, light/dark themes)
   tokens-atmosphere/  — Atmosphere tokens (gold accent, dark-first themes)
   tokens-creator/     — Creator App tokens (SDUI mappings, mobile-optimized)
-  ui/                 — Shared React components (Button, Badge, Card, EmptyState, Skeleton)
+  ui/                 — Shared React components (Button, Badge, Card, EmptyState, Skeleton,
+                        CollapsibleCard, CollapsibleSection, GoalCard, ContentTypeCard,
+                        ScriptPreviewCard)
   storybook/          — Component documentation and visual testing
   eslint-config/      — Design system lint rules (no-hardcoded-colors, no-raw-spacing, prefer-token-import)
   feature-flags/      — Feature flag utilities
 ```
+
+**Campaign wizard components** (`GoalCard`, `ContentTypeCard`, `ScriptPreviewCard`, `CollapsibleSection`) were added for the Brand campaign creation flow. Key props:
+- `GoalCard` — selectable card with icon, title, subtitle, and a colour-coded tag (`violet | green | amber | blue`)
+- `ContentTypeCard` — selectable pricing/feature card with badge, pros list, optional recommended flag, and badge colour (`violet | green`)
+- `ScriptPreviewCard` — read-only display card for a script concept with timed sections (`ScriptSection[]`)
+- `CollapsibleSection` — animated accordion wrapper with optional preview text shown when collapsed
 
 ## Token File Format
 


### PR DESCRIPTION
## Summary
- **Trigger:** commit `e55f8c9`
- **File updated:** `CLAUDE.md`
- **Confidence:** 🟡 0.73
- **Reason:** Four new UI components (GoalCard, ContentTypeCard, ScriptPreviewCard, CollapsibleSection) have been added to the design system's public API, which engineers working in this repo need to know about when building campaign creation wizard flows.

This is an automated documentation update by Zenith. Needs human review.

---
Generated by [Zenith AI CTO](https://github.com/one-impression/zenith-coding-agent)