### PR TITLE
feat(contracts): TS-API JSON contracts as single source of truth (PR-A3, Wave 1)

### DIFF
--- a/packages/mcp-server/src/data/components.ts
+++ b/packages/mcp-server/src/data/components.ts
@@ -5,17 +5,60 @@ import { extractFromSource, type ExtractedComponent } from '../lib/extract-props
 
 const here = dirname(fileURLToPath(import.meta.url));
 
-const candidateRoots = [
+interface ContractEntry {
+  name: string;
+  contract: string;
+}
+
+interface ContractsManifest {
+  componentCount: number;
+  components: ContractEntry[];
+}
+
+interface PropContract {
+  name: string;
+  type: string;
+  optional: boolean;
+  default?: string;
+  enumValues?: string[] | null;
+}
+
+interface ComponentContract {
+  name: string;
+  filePath: string;
+  kind: string;
+  variants: string[] | null;
+  sizes: string[] | null;
+  props: PropContract[];
+  inherits?: { from: string[]; propCount: number };
+  subcomponents: string[];
+}
+
+const candidateContractsManifests = [
+  resolve(here, '../../../ui/dist/contracts.json'),
+  resolve(here, '../../../../ui/dist/contracts.json'),
+  resolve(process.cwd(), 'packages/ui/dist/contracts.json'),
+  resolve(process.cwd(), 'node_modules/@amplify/ui/dist/contracts.json'),
+];
+
+const candidateComponentRoots = [
   resolve(here, '../../../ui/src/components'),
   resolve(here, '../../../../ui/src/components'),
   resolve(process.cwd(), 'packages/ui/src/components'),
 ];
 
+const findContractsManifest = (): string | null => {
+  for (const path of candidateContractsManifests) {
+    if (existsSync(path)) return path;
+  }
+  return null;
+};
+
 const findComponentsRoot = (): string => {
-  for (const root of candidateRoots) {
+  for (const root of candidateComponentRoots) {
     if (existsSync(root) && statSync(root).isDirectory()) return root;
   }
-  throw new Error(`Could not locate packages/ui/src/components. Tried: ${candidateRoots.join(', ')}`);
+  throw new Error(`Could not locate packages/ui/src/components. Tried: ${candidateComponentRoots.join(', ')}`);
 };
 
 const findIndexFile = (componentDir: string, name: string): string | null => {
@@ -26,10 +69,43 @@ const findIndexFile = (componentDir: string, name: string): string | null => {
   return null;
 };
 
-let cache: ExtractedComponent[] | null = null;
+const contractToExtracted = (c: ComponentContract, filePath: string): ExtractedComponent => {
+  return {
+    name: c.name,
+    filePath,
+    variants: c.variants ?? undefined,
+    sizes: c.sizes ?? undefined,
+    props: c.props.map((p) => ({
+      name: p.name,
+      type: p.type,
+      optional: p.optional,
+      defaultValue: p.default,
+      enumValues: p.enumValues ?? undefined,
+    })),
+    hasForwardRef: c.kind === 'forwardRef',
+    subcomponents: c.subcomponents,
+  };
+};
 
-export const loadComponentCatalog = (): ExtractedComponent[] => {
-  if (cache) return cache;
+const loadFromContracts = (manifestPath: string): ExtractedComponent[] => {
+  const manifestDir = dirname(manifestPath);
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as ContractsManifest;
+  const out: ExtractedComponent[] = [];
+  for (const entry of manifest.components) {
+    const contractPath = resolve(manifestDir, entry.contract);
+    if (!existsSync(contractPath)) continue;
+    try {
+      const contract = JSON.parse(readFileSync(contractPath, 'utf8')) as ComponentContract;
+      out.push(contractToExtracted(contract, contractPath));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[canvas-mcp] skip malformed contract "${entry.name}": ${msg}`);
+    }
+  }
+  return out;
+};
+
+const loadFromFilesystem = (): ExtractedComponent[] => {
   const root = findComponentsRoot();
   const dirs = readdirSync(root).filter((d) => statSync(join(root, d)).isDirectory());
   const out: ExtractedComponent[] = [];
@@ -43,6 +119,21 @@ export const loadComponentCatalog = (): ExtractedComponent[] => {
       console.error(`[canvas-mcp] skip unparseable component "${dir}": ${msg}`);
     }
   }
+  return out;
+};
+
+let cache: ExtractedComponent[] | null = null;
+
+/**
+ * Load the component catalog. Prefers JSON contracts emitted by
+ * `packages/ui` build (proper TS-API extraction, captures inherited props
+ * and JSDoc) — falls back to filesystem regex extraction so the server
+ * works in development before the first build.
+ */
+export const loadComponentCatalog = (): ExtractedComponent[] => {
+  if (cache) return cache;
+  const manifestPath = findContractsManifest();
+  const out = manifestPath ? loadFromContracts(manifestPath) : loadFromFilesystem();
   cache = out.sort((a, b) => a.name.localeCompare(b.name));
   return cache;
 };

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,6 +15,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --external react --external react-dom",
+    "prebuild": "node scripts/generate-contracts.mjs",
     "postbuild": "node ../../scripts/generate-llms-docs.mjs",
     "dev": "tsup src/index.ts --format esm --dts --external react --external react-dom --watch",
     "lint": "eslint src/",

--- a/packages/ui/scripts/generate-contracts.mjs
+++ b/packages/ui/scripts/generate-contracts.mjs
@@ -1,0 +1,371 @@
+#!/usr/bin/env node
+/**
+ * Generate JSON component contracts from @amplify/ui source.
+ *
+ * Uses the real TypeScript compiler API (vs. the regex extractors in
+ * scripts/generate-llms-docs.mjs and packages/mcp-server) so resolved
+ * types, JSDoc descriptions, defaults, and inherited props are all
+ * captured accurately. Output is the single source of truth that the
+ * llms-docs generator and the MCP server now consume — kills the three
+ * parallel extraction implementations.
+ *
+ * Outputs (under packages/ui/dist/):
+ *   - contracts/<Component>.json   — full per-component contract
+ *   - contracts.json               — manifest (component name → contract path + summary)
+ *
+ * Run via `npm run prebuild -w packages/ui` (or just `npm run build -w packages/ui`).
+ */
+import ts from 'typescript';
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync, mkdirSync } from 'node:fs';
+import { join, resolve, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const uiRoot = resolve(here, '..');
+const repoRoot = resolve(uiRoot, '../..');
+const componentsDir = resolve(uiRoot, 'src/components');
+const distDir = resolve(uiRoot, 'dist');
+const contractsDir = resolve(distDir, 'contracts');
+
+const log = (msg) => process.stdout.write(`[contracts] ${msg}\n`);
+const warn = (msg) => process.stderr.write(`[contracts] ${msg}\n`);
+const summary = (event, fields) =>
+  process.stdout.write(JSON.stringify({ level: 'info', event, ...fields }) + '\n');
+
+const findEntryFile = (dir, name) => {
+  for (const candidate of [`${name}.tsx`, 'index.tsx', `${name}.ts`, 'index.ts']) {
+    const full = join(dir, candidate);
+    if (existsSync(full)) return full;
+  }
+  return null;
+};
+
+const extractJsDoc = (symbol) => {
+  if (!symbol) return undefined;
+  const docs = symbol.getDocumentationComment(undefined);
+  const text = ts.displayPartsToString(docs).trim();
+  return text || undefined;
+};
+
+/**
+ * Get literal values from a union type, filtering out `undefined` (which
+ * appears on every optional prop). Returns null if any non-literal,
+ * non-undefined member exists.
+ */
+const literalUnionValues = (type) => {
+  if (!type.isUnion()) return null;
+  const values = [];
+  for (const t of type.types) {
+    if (t.flags & ts.TypeFlags.Undefined) continue;
+    if (t.isStringLiteral()) values.push(t.value);
+    else if (t.isNumberLiteral()) values.push(t.value);
+    else return null;
+  }
+  return values.length > 0 ? values : null;
+};
+
+const stringifyType = (checker, type, location) => {
+  return checker.typeToString(
+    type,
+    location,
+    ts.TypeFormatFlags.NoTruncation | ts.TypeFormatFlags.UseAliasDefinedOutsideCurrentScope
+  );
+};
+
+/**
+ * Walk a forwardRef call and pull default values from the destructuring
+ * pattern of its render function: `({ variant = 'primary', ... }, ref) => ...`.
+ */
+const extractDefaultsFromForwardRef = (sourceFile) => {
+  const defaults = new Map();
+  const visit = (node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'forwardRef' &&
+      node.arguments.length >= 1
+    ) {
+      const renderFn = node.arguments[0];
+      if (
+        (ts.isArrowFunction(renderFn) || ts.isFunctionExpression(renderFn)) &&
+        renderFn.parameters.length >= 1 &&
+        ts.isObjectBindingPattern(renderFn.parameters[0].name)
+      ) {
+        for (const element of renderFn.parameters[0].name.elements) {
+          if (element.initializer && ts.isIdentifier(element.name)) {
+            const text = element.initializer.getText(sourceFile);
+            defaults.set(element.name.text, text);
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return defaults;
+};
+
+/**
+ * Find subcomponent exports (CardHeader, CardTitle, etc.) — anything
+ * exported from the same file whose name starts with the component name
+ * or matches conventional suffixes.
+ */
+const findSubcomponents = (sourceFile, componentName) => {
+  const out = [];
+  const visit = (node) => {
+    if (
+      (ts.isVariableStatement(node) || ts.isFunctionDeclaration(node)) &&
+      node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      if (ts.isFunctionDeclaration(node) && node.name) {
+        const name = node.name.text;
+        if (name !== componentName && /(Header|Title|Description|Content|Footer|Body|Item|Trigger|Group)$/.test(name)) {
+          out.push(name);
+        }
+      }
+      if (ts.isVariableStatement(node)) {
+        for (const decl of node.declarationList.declarations) {
+          if (ts.isIdentifier(decl.name)) {
+            const name = decl.name.text;
+            if (name !== componentName && /(Header|Title|Description|Content|Footer|Body|Item|Trigger|Group)$/.test(name)) {
+              out.push(name);
+            }
+          }
+        }
+      }
+    }
+  };
+  ts.forEachChild(sourceFile, visit);
+  return out;
+};
+
+/**
+ * Detect whether the component is built with React.forwardRef.
+ */
+const detectKind = (sourceFile, componentName) => {
+  let kind = 'function';
+  const visit = (node) => {
+    if (
+      ts.isVariableStatement(node) &&
+      node.declarationList.declarations.some(
+        (d) => ts.isIdentifier(d.name) && d.name.text === componentName && d.initializer
+      )
+    ) {
+      const init = node.declarationList.declarations.find(
+        (d) => ts.isIdentifier(d.name) && d.name.text === componentName
+      ).initializer;
+      if (
+        init &&
+        ts.isCallExpression(init) &&
+        ts.isPropertyAccessExpression(init.expression) &&
+        init.expression.name.text === 'forwardRef'
+      ) {
+        kind = 'forwardRef';
+      }
+    }
+  };
+  ts.forEachChild(sourceFile, visit);
+  return kind;
+};
+
+const buildProgram = (entries) => {
+  const tsconfigPath = resolve(uiRoot, 'tsconfig.json');
+  const config = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+  const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, uiRoot);
+  return ts.createProgram({
+    rootNames: entries,
+    options: {
+      ...parsed.options,
+      noEmit: true,
+      skipLibCheck: true,
+    },
+  });
+};
+
+const extractContract = (program, checker, filePath, componentName) => {
+  const sourceFile = program.getSourceFile(filePath);
+  if (!sourceFile) return null;
+
+  const propsInterfaceName = `${componentName}Props`;
+  let propsSymbol = null;
+  const aliases = new Map();
+
+  for (const stmt of sourceFile.statements) {
+    if (
+      ts.isInterfaceDeclaration(stmt) &&
+      stmt.name.text === propsInterfaceName &&
+      stmt.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      propsSymbol = checker.getSymbolAtLocation(stmt.name);
+    }
+    if (
+      ts.isTypeAliasDeclaration(stmt) &&
+      stmt.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      const aliasName = stmt.name.text;
+      const aliasType = checker.getTypeAtLocation(stmt.type);
+      const values = literalUnionValues(aliasType);
+      if (values) aliases.set(aliasName, values);
+    }
+  }
+
+  const defaults = extractDefaultsFromForwardRef(sourceFile);
+  const subcomponents = findSubcomponents(sourceFile, componentName);
+  const kind = detectKind(sourceFile, componentName);
+
+  // Locate the Props interface declaration's source range so we can
+  // distinguish own props (declared in the interface body) from inherited
+  // ones (from `extends ButtonHTMLAttributes<...>`). Inherited HTML
+  // attributes flood the output and aren't useful for LLM agents — we
+  // capture them as a count + parent type list rather than expanding.
+  const propsInterfaceDecl = sourceFile.statements.find(
+    (s) =>
+      ts.isInterfaceDeclaration(s) &&
+      s.name.text === propsInterfaceName &&
+      s.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+  );
+
+  const inheritsFrom = [];
+  if (propsInterfaceDecl?.heritageClauses) {
+    for (const clause of propsInterfaceDecl.heritageClauses) {
+      for (const t of clause.types) {
+        inheritsFrom.push(t.getText(sourceFile));
+      }
+    }
+  }
+
+  const ownProps = [];
+  const inheritedPropNames = [];
+  if (propsSymbol) {
+    const declaredType = checker.getDeclaredTypeOfSymbol(propsSymbol);
+    for (const prop of declaredType.getProperties()) {
+      const decl = prop.declarations?.[0];
+      if (!decl) continue;
+      const isOwn =
+        propsInterfaceDecl &&
+        decl.getSourceFile() === sourceFile &&
+        decl.getStart() >= propsInterfaceDecl.getStart() &&
+        decl.getEnd() <= propsInterfaceDecl.getEnd();
+      if (!isOwn) {
+        inheritedPropNames.push(prop.name);
+        continue;
+      }
+      const propType = checker.getTypeOfSymbolAtLocation(prop, decl);
+      const typeString = stringifyType(checker, propType, decl);
+      const literalValues = literalUnionValues(propType);
+      const optional = !!(prop.flags & ts.SymbolFlags.Optional);
+      const description = extractJsDoc(prop);
+      const defaultRaw = defaults.get(prop.name);
+      const defaultValue = defaultRaw ? defaultRaw.replace(/^['"]|['"]$/g, '') : undefined;
+      ownProps.push({
+        name: prop.name,
+        type: typeString,
+        optional,
+        default: defaultValue,
+        enumValues: literalValues,
+        description,
+      });
+    }
+  }
+
+  return {
+    name: componentName,
+    filePath: relative(repoRoot, filePath),
+    kind,
+    variants: aliases.get(`${componentName}Variant`) ?? null,
+    sizes: aliases.get(`${componentName}Size`) ?? null,
+    props: ownProps,
+    inherits: {
+      from: inheritsFrom,
+      propCount: inheritedPropNames.length,
+    },
+    subcomponents,
+    declaresPropsInterface: !!propsSymbol,
+  };
+};
+
+const main = () => {
+  if (!existsSync(componentsDir)) {
+    warn(`components dir not found, skipping contract generation: ${componentsDir}`);
+    return;
+  }
+  if (!existsSync(distDir)) mkdirSync(distDir, { recursive: true });
+  if (!existsSync(contractsDir)) mkdirSync(contractsDir, { recursive: true });
+
+  const dirs = readdirSync(componentsDir).filter((d) => statSync(join(componentsDir, d)).isDirectory());
+  const entries = [];
+  const componentMap = new Map();
+  for (const dir of dirs) {
+    const file = findEntryFile(join(componentsDir, dir), dir);
+    if (!file) continue;
+    entries.push(file);
+    componentMap.set(file, dir);
+  }
+
+  const program = buildProgram(entries);
+  const checker = program.getTypeChecker();
+
+  const contracts = [];
+  const failures = [];
+  const suspicious = [];
+
+  for (const [filePath, name] of componentMap) {
+    let contract;
+    try {
+      contract = extractContract(program, checker, filePath, name);
+    } catch (err) {
+      failures.push({ name, reason: err instanceof Error ? err.message : String(err) });
+      continue;
+    }
+    if (!contract) {
+      failures.push({ name, reason: 'no source file in program' });
+      continue;
+    }
+    if (contract.declaresPropsInterface && contract.props.length === 0) {
+      suspicious.push(name);
+    }
+    writeFileSync(join(contractsDir, `${name}.json`), JSON.stringify(contract, null, 2));
+    contracts.push(contract);
+  }
+
+  contracts.sort((a, b) => a.name.localeCompare(b.name));
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    tsVersion: ts.version,
+    componentCount: contracts.length,
+    components: contracts.map((c) => ({
+      name: c.name,
+      contract: `contracts/${c.name}.json`,
+      filePath: c.filePath,
+      kind: c.kind,
+      variants: c.variants,
+      sizes: c.sizes,
+      propCount: c.props.length,
+      subcomponents: c.subcomponents,
+    })),
+  };
+  writeFileSync(join(distDir, 'contracts.json'), JSON.stringify(manifest, null, 2));
+
+  log(`wrote ${contracts.length} contracts → ${contractsDir}`);
+  log(`wrote manifest → ${distDir}/contracts.json`);
+  if (failures.length) {
+    warn(`${failures.length} components failed:`);
+    for (const f of failures) warn(`  - ${f.name}: ${f.reason}`);
+  }
+  if (suspicious.length) {
+    warn(`${suspicious.length} components declare a Props interface but yielded zero props: ${suspicious.join(', ')}`);
+  }
+  summary('contracts_generated', {
+    componentCount: contracts.length,
+    failureCount: failures.length,
+    suspiciousCount: suspicious.length,
+    tsVersion: ts.version,
+  });
+};
+
+try {
+  main();
+} catch (err) {
+  warn(`unexpected failure: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
+}

--- a/scripts/generate-llms-docs.mjs
+++ b/scripts/generate-llms-docs.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
- * Generate LLM-readable design system docs:
- *   - packages/ui/dist/llms.txt          (root index, llmstxt.org spec)
- *   - packages/ui/dist/llms/<Component>.md  (per-component rules + props)
- *   - packages/ui/dist/llms.json         (machine-readable mirror)
+ * Generate LLM-readable design system docs from the JSON contracts produced
+ * by packages/ui/scripts/generate-contracts.mjs. Reads the contracts (single
+ * source of truth) — no parallel regex extraction.
  *
- * Reads packages/ui/src/components/ at build time. Optional per-component
- * semantic overrides at packages/ui/src/components/<Name>/<Name>.llm.md
- * are merged in verbatim under the "Guidance" section.
+ * Outputs (under packages/ui/dist/):
+ *   - llms.txt          — root index, llmstxt.org spec
+ *   - llms/<Name>.md    — per-component rules
+ *   - llms.json         — flattened machine-readable mirror (legacy compat)
+ *
+ * Optional per-component semantic overrides at
+ * packages/ui/src/components/<Name>/<Name>.llm.md get merged in verbatim
+ * under a "Guidance" section.
  */
-import { readFileSync, writeFileSync, readdirSync, mkdirSync, existsSync, statSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -17,146 +21,31 @@ const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '..');
 const componentsDir = resolve(repoRoot, 'packages/ui/src/components');
 const distDir = resolve(repoRoot, 'packages/ui/dist');
+const contractsDir = resolve(distDir, 'contracts');
+const manifestPath = resolve(distDir, 'contracts.json');
 const docsDir = resolve(distDir, 'llms');
 
-// Build-script logging: human-readable progress to stdout/stderr (low blast
-// radius, runs once per build). The final summary line is structured JSON
-// so log aggregators (CloudWatch, Datadog) can index doc-gen runs.
 const log = (msg) => process.stdout.write(`[llms-docs] ${msg}\n`);
 const warn = (msg) => process.stderr.write(`[llms-docs] ${msg}\n`);
 const summary = (event, fields) =>
   process.stdout.write(JSON.stringify({ level: 'info', event, ...fields }) + '\n');
 
-const TYPE_ALIAS_RE = /export\s+type\s+(\w+)\s*=\s*([^;]+);/g;
-const INTERFACE_HEADER_RE = /export\s+interface\s+(\w+Props)(?:<[^>]*>)?(?:\s+extends\s+[^{]+)?\s*\{/g;
-const PROP_LINE_RE = /^\s*(\w+)(\??):\s*([^;]+);?\s*$/;
-const FORWARD_REF_RE = /React\.forwardRef\s*</;
-const SUBCOMPONENT_RE = /export\s+(?:const|function)\s+(\w+(?:Header|Title|Description|Content|Footer|Body|Item|Trigger|Group))/g;
-const DEFAULT_VALUE_RE = /(\w+)\s*=\s*([^,\n}]+?)(?:[,\n}])/g;
-
 /**
- * Extract the interface body using brace-depth counting so nested types
- * (e.g. `defaultValue?: { label: string; value: string }`) don't truncate
- * the match early. Returns null if no Props interface is found or braces
- * are unbalanced.
+ * Strip ` | undefined` (TS auto-adds it to every optional prop) and escape
+ * `|` for markdown table cells.
  */
-const extractInterfaceBody = (source) => {
-  INTERFACE_HEADER_RE.lastIndex = 0;
-  const headerMatch = INTERFACE_HEADER_RE.exec(source);
-  if (!headerMatch) return null;
-  const start = headerMatch.index + headerMatch[0].length;
-  let depth = 1;
-  for (let i = start; i < source.length; i++) {
-    const ch = source[i];
-    if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) return source.slice(start, i);
-    }
-  }
-  return null;
-};
-
-/**
- * Split an interface body into prop declarations, respecting brace depth so
- * a multi-line nested object type stays on one logical "line".
- */
-const splitPropDeclarations = (body) => {
-  const out = [];
-  let buf = '';
-  let depth = 0;
-  for (const ch of body) {
-    if (ch === '{' || ch === '<' || ch === '(') depth++;
-    else if (ch === '}' || ch === '>' || ch === ')') depth = Math.max(0, depth - 1);
-    if ((ch === ';' || ch === '\n') && depth === 0) {
-      const trimmed = buf.trim();
-      if (trimmed) out.push(trimmed);
-      buf = '';
-      continue;
-    }
-    buf += ch;
-  }
-  if (buf.trim()) out.push(buf.trim());
-  return out;
-};
-
-const extractEnum = (typeBody) => {
-  const stripped = typeBody.trim();
-  if (!stripped.includes('|')) return null;
-  const values = stripped.split('|').map((v) => v.trim().replace(/^['"]|['"]$/g, ''));
-  if (values.every((v) => /^[\w-]+$/.test(v))) return values;
-  return null;
-};
-
-const extractFromSource = (filePath, name) => {
-  const source = readFileSync(filePath, 'utf8');
-  const aliases = new Map();
-  TYPE_ALIAS_RE.lastIndex = 0;
-  let m;
-  while ((m = TYPE_ALIAS_RE.exec(source)) !== null) {
-    const enumValues = extractEnum(m[2]);
-    if (enumValues) aliases.set(m[1], enumValues);
-  }
-  const variants = aliases.get(`${name}Variant`) ?? null;
-  const sizes = aliases.get(`${name}Size`) ?? null;
-  const props = [];
-  const body = extractInterfaceBody(source);
-  if (body) {
-    for (const decl of splitPropDeclarations(body)) {
-      // Match: `name?: type` (type may span multiple lines, no semicolon since splitter strips it)
-      const propMatch = /^(\w+)(\??):\s*([\s\S]+)$/.exec(decl);
-      if (!propMatch) continue;
-      const [, propName, optional, type] = propMatch;
-      const cleanType = type.trim();
-      props.push({
-        name: propName,
-        type: cleanType,
-        optional: optional === '?',
-        enumValues: aliases.get(cleanType) ?? extractEnum(cleanType),
-      });
-    }
-  }
-  const defaultsBlockMatch = source.match(/\(\s*\{([^}]+?)\},\s*ref\s*\)/s);
-  if (defaultsBlockMatch) {
-    DEFAULT_VALUE_RE.lastIndex = 0;
-    let dv;
-    while ((dv = DEFAULT_VALUE_RE.exec(defaultsBlockMatch[1])) !== null) {
-      const prop = props.find((p) => p.name === dv[1]);
-      if (prop) prop.defaultValue = dv[2].trim().replace(/^['"]|['"]$/g, '');
-    }
-  }
-  const subcomponents = [];
-  SUBCOMPONENT_RE.lastIndex = 0;
-  let sub;
-  while ((sub = SUBCOMPONENT_RE.exec(source)) !== null) {
-    if (sub[1] !== name) subcomponents.push(sub[1]);
-  }
-  return {
-    name,
-    variants,
-    sizes,
-    props,
-    hasForwardRef: FORWARD_REF_RE.test(source),
-    subcomponents,
-    declaresPropsInterface: /export\s+interface\s+\w+Props\b/.test(source),
-  };
-};
-
-const findComponentFile = (dir, name) => {
-  for (const candidate of [`${name}.tsx`, 'index.tsx', `${name}.ts`, 'index.ts']) {
-    const full = join(dir, candidate);
-    if (existsSync(full)) return full;
-  }
-  return null;
+const formatType = (type, optional) => {
+  let cleaned = optional ? type.replace(/\s*\|\s*undefined\b/g, '') : type;
+  return cleaned.replace(/\|/g, '\\|');
 };
 
 const renderProps = (props) => {
-  if (props.length === 0) return '_(no props beyond standard HTML attributes)_';
+  if (props.length === 0) return '_(no own props beyond inherited HTML attributes)_';
   const lines = ['| Name | Type | Required | Default | Allowed values |', '|------|------|----------|---------|----------------|'];
   for (const p of props) {
     const allowed = p.enumValues ? p.enumValues.map((v) => `\`${v}\``).join(', ') : '—';
-    const def = p.defaultValue ? `\`${p.defaultValue}\`` : '—';
-    lines.push(`| \`${p.name}\` | \`${p.type}\` | ${p.optional ? 'no' : 'yes'} | ${def} | ${allowed} |`);
+    const def = p.default ? `\`${p.default}\`` : '—';
+    lines.push(`| \`${p.name}\` | \`${formatType(p.type, p.optional)}\` | ${p.optional ? 'no' : 'yes'} | ${def} | ${allowed} |`);
   }
   return lines.join('\n');
 };
@@ -171,18 +60,24 @@ const renderExample = (c) => {
 const renderComponentDoc = (c, override) => {
   const sections = [];
   sections.push(`# ${c.name}`);
-  sections.push(`> Auto-extracted from \`packages/ui/src/components/${c.name}/\`. Do not edit by hand — regenerated on every build.`);
+  sections.push(`> Auto-extracted from \`${c.filePath}\`. Do not edit by hand — regenerated on every build.`);
 
   if (c.variants) sections.push(`## Variants\n\n${c.variants.map((v) => `- \`${v}\``).join('\n')}`);
   if (c.sizes) sections.push(`## Sizes\n\n${c.sizes.map((s) => `- \`${s}\``).join('\n')}`);
 
   sections.push(`## Props\n\n${renderProps(c.props)}`);
 
+  if (c.inherits?.from?.length) {
+    sections.push(
+      `## Inherited props\n\nExtends \`${c.inherits.from.join('`, `')}\` — adds ${c.inherits.propCount} standard HTML/React attributes (omitted from this doc).`
+    );
+  }
+
   if (c.subcomponents.length > 0) {
     sections.push(`## Subcomponents\n\n${c.subcomponents.map((s) => `- \`${s}\``).join('\n')}`);
   }
 
-  sections.push(`## Forward ref\n\n${c.hasForwardRef ? `Yes — accepts \`ref\` and forwards to the underlying element.` : `No.`}`);
+  sections.push(`## Forward ref\n\n${c.kind === 'forwardRef' ? `Yes — accepts \`ref\` and forwards to the underlying element.` : `No.`}`);
 
   sections.push(`## Example\n\n${renderExample(c)}`);
 
@@ -196,46 +91,25 @@ const renderComponentDoc = (c, override) => {
 };
 
 const main = () => {
-  // Soft no-op when run in a context without the UI components dir (e.g.
-  // a partial build, storybook-only build). This script is hooked into
-  // the @amplify/ui build but should never hard-fail the parent build —
-  // dist/ artifacts must still be produced.
-  if (!existsSync(componentsDir)) {
-    warn(`components dir not found, skipping doc generation: ${componentsDir}`);
+  if (!existsSync(manifestPath)) {
+    warn(`contracts manifest not found at ${manifestPath} — run packages/ui prebuild first`);
     return;
   }
-  if (!existsSync(distDir)) mkdirSync(distDir, { recursive: true });
   if (!existsSync(docsDir)) mkdirSync(docsDir, { recursive: true });
 
-  const dirs = readdirSync(componentsDir).filter((d) => statSync(join(componentsDir, d)).isDirectory());
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
   const components = [];
-  const failures = [];
-  const suspicious = [];
-
-  for (const dir of dirs) {
-    const filePath = findComponentFile(join(componentsDir, dir), dir);
-    if (!filePath) {
-      failures.push({ name: dir, reason: 'no entry .tsx/.ts file found' });
+  for (const entry of manifest.components) {
+    const contractPath = resolve(distDir, entry.contract);
+    if (!existsSync(contractPath)) {
+      warn(`contract missing for ${entry.name}: ${contractPath}`);
       continue;
     }
-    let extracted;
-    try {
-      extracted = extractFromSource(filePath, dir);
-    } catch (err) {
-      failures.push({ name: dir, reason: err instanceof Error ? err.message : String(err) });
-      continue;
-    }
-    // Safety net: a Props interface that yields zero props is almost always
-    // an extraction failure (regex truncation, unusual syntax, etc.) rather
-    // than a genuine zero-prop component. Surface as a warning.
-    if (extracted.declaresPropsInterface && extracted.props.length === 0) {
-      suspicious.push(dir);
-    }
-    const overridePath = join(componentsDir, dir, `${dir}.llm.md`);
+    const contract = JSON.parse(readFileSync(contractPath, 'utf8'));
+    const overridePath = join(componentsDir, contract.name, `${contract.name}.llm.md`);
     const override = existsSync(overridePath) ? readFileSync(overridePath, 'utf8') : null;
-    const md = renderComponentDoc(extracted, override);
-    writeFileSync(join(docsDir, `${dir}.md`), md);
-    components.push(extracted);
+    writeFileSync(join(docsDir, `${contract.name}.md`), renderComponentDoc(contract, override));
+    components.push(contract);
   }
 
   components.sort((a, b) => a.name.localeCompare(b.name));
@@ -251,12 +125,12 @@ const main = () => {
   lines.push('## Components');
   lines.push('');
   for (const c of components) {
-    const summary = [
+    const summaryStr = [
       c.variants ? `${c.variants.length} variants` : null,
       c.sizes ? `${c.sizes.length} sizes` : null,
       `${c.props.length} props`,
     ].filter(Boolean).join(', ');
-    lines.push(`- [${c.name}](llms/${c.name}.md): ${summary}`);
+    lines.push(`- [${c.name}](llms/${c.name}.md): ${summaryStr}`);
   }
   lines.push('');
   lines.push('## Tokens');
@@ -269,11 +143,13 @@ const main = () => {
   lines.push('## Programmatic access');
   lines.push('');
   lines.push('- MCP server: `@amplify/mcp-server` exposes the same data via stdio + HTTP transports.');
-  lines.push('- JSON mirror: `dist/llms.json` for tools that prefer structured data.');
+  lines.push('- JSON contracts: `dist/contracts/<Component>.json` — TS-API-extracted, single source of truth.');
+  lines.push('- JSON mirror: `dist/llms.json` for tools that prefer flattened structured data.');
 
   writeFileSync(join(distDir, 'llms.txt'), lines.join('\n') + '\n');
 
-  // llms.json — machine-readable mirror
+  // llms.json — flattened mirror (legacy compatibility for consumers that
+  // already read this file). Now sourced from contracts.
   const json = {
     generatedAt: new Date().toISOString(),
     componentCount: components.length,
@@ -282,7 +158,8 @@ const main = () => {
       variants: c.variants,
       sizes: c.sizes,
       props: c.props,
-      hasForwardRef: c.hasForwardRef,
+      inherits: c.inherits,
+      kind: c.kind,
       subcomponents: c.subcomponents,
     })),
   };
@@ -291,21 +168,11 @@ const main = () => {
   log(`wrote ${components.length} component docs → ${docsDir}`);
   log(`wrote llms.txt → ${distDir}/llms.txt`);
   log(`wrote llms.json → ${distDir}/llms.json`);
-  if (failures.length) {
-    warn(`${failures.length} components skipped:`);
-    for (const f of failures) warn(`  - ${f.name}: ${f.reason}`);
-  }
-  if (suspicious.length) {
-    warn(`${suspicious.length} components declare a Props interface but yielded zero props (likely regex truncation): ${suspicious.join(', ')}`);
-  }
   summary('llms_docs_generated', {
     componentCount: components.length,
-    failureCount: failures.length,
-    suspiciousCount: suspicious.length,
   });
 };
 
-// Never hard-fail the parent build — surface errors loudly but exit 0.
 try {
   main();
 } catch (err) {


### PR DESCRIPTION
## Summary

Third leg of Wave 1 Tier 1. Replaces the parallel regex extractors (one in `mcp-server`, one in `scripts/generate-llms-docs.mjs`) with a single TypeScript-compiler-API-based extractor that emits structured JSON contracts on every `@amplify/ui` build. Every downstream tool (Pixel, Claude Code, llms-docs, MCP server) now reads the same source of truth.

## What's in here

**New: `packages/ui/scripts/generate-contracts.mjs`**

Uses `typescript` (already in devDeps) — real type checker, real heritage clause walking, real JSDoc extraction. Outputs:

| Artifact | Purpose |
|----------|---------|
| `dist/contracts/<Name>.json` | Per-component spec — variants, sizes, **own** props (typed via TS checker, with JSDoc + defaults), **inherited** HTML attribute summary, subcomponents, kind |
| `dist/contracts.json` | Manifest — name → contract path + summary |

Wired via `prebuild` lifecycle so contracts exist before both tsup compile and the postbuild llms-docs generator.

**`scripts/generate-llms-docs.mjs` refactored** — deletes 80+ lines of inline regex, reads contracts. Adds proper `| undefined` stripping on optional props and markdown table escaping for pipe chars. Surfaces inherited prop counts as a separate doc section.

**`packages/mcp-server/src/data/components.ts` updated** — prefers contracts when available; falls back to regex extraction so the server still works in dev before the first build. Same `ExtractedComponent` shape — zero downstream API change. 9/9 smoke tests still pass.

## Why TS API beats regex

| Issue | Regex | TS API |
|-------|-------|--------|
| Generic `DataTableProps<T>` | Needed special regex case | Just works |
| Inherited HTML attrs | Silently merged into own props (52KB Button.json) | Detected via heritage clause; reported as count + parent type list (1.4KB Button.json) |
| Optional union like `ButtonVariant \| undefined` | enumValues null | enumValues correctly extracted (filter undefined) |
| JSDoc descriptions | Not extracted | Captured per prop (extension point reserved) |

## Sample contract output

`dist/contracts/Button.json`:
```json
{
  "name": "Button",
  "kind": "forwardRef",
  "variants": ["primary", "secondary", "ghost", "destructive", "outline"],
  "sizes": ["sm", "md", "lg"],
  "props": [
    { "name": "variant", "type": "ButtonVariant | undefined",
      "optional": true, "default": "primary",
      "enumValues": ["primary", "secondary", "ghost", "destructive", "outline"] },
    ...
  ],
  "inherits": {
    "from": ["Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'style'>"],
    "propCount": 287
  },
  "subcomponents": [],
  "declaresPropsInterface": true
}
```

## Test plan

- [x] `npm run build -w packages/ui` runs full chain (prebuild contracts → tsup → postbuild llms-docs) — all clean, 46 contracts, 0 failures
- [x] `npm run test -w packages/mcp-server` — 9/9 pass via contracts path
- [x] `npm run build -w packages/mcp-server` — clean, dts emitted
- [x] Spot check: Button, Card, DataTable (generic), Stepper all extract correctly
- [x] Type checker captures inherited prop counts (Button: 287, Card: 277)
- [ ] Reviewer to verify a fresh clone + `npm install && npm run build -w packages/ui` produces contracts

## Wave 1 progress

- [x] PR-A1 — MCP server (#36 merged)
- [x] PR-A2 — llms.txt generator (#37 merged)
- [x] PR-A3 — JSON contracts (this)
- [ ] PR-A4 — Bump `@amplify/ui` to 1.0.0 + lock exports map for publish
- [ ] PR-P1..P4, PR-AT1..AT4