### PR TITLE
feat(release): cut Canvas v1.0.0 + ship @amplify/mcp-server (PR-A4, Wave 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,16 @@ jobs:
       - name: Build @amplify/ui
         run: npm run build -w packages/ui
 
+      - name: Build @amplify/mcp-server
+        run: npm run build -w packages/mcp-server
+
       - name: Validate cross-package consistency
         run: node scripts/validate-tokens.js
 
       - name: Verify build outputs
         run: |
           MISSING=""
-          for pkg in tokens-foundation tokens-brand tokens-creator tokens-atmosphere ui; do
+          for pkg in tokens-foundation tokens-brand tokens-creator tokens-atmosphere ui mcp-server; do
             DIR="packages/$pkg/dist"
             if [ ! -d "$DIR" ]; then
               MISSING="$MISSING\n  - packages/$pkg/dist/ (directory missing)"
@@ -71,7 +74,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           set -e
-          for pkg in tokens-foundation tokens-brand tokens-atmosphere tokens-creator ui eslint-config; do
+          for pkg in tokens-foundation tokens-brand tokens-atmosphere tokens-creator ui mcp-server eslint-config; do
             echo "Publishing @amplify/$pkg..."
             (
               cd packages/$pkg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Canvas Design System Changelog
+
+All notable changes to the public packages of `amplify-design-system`.
+
+## [1.0.0] — 2026-04-27
+
+### Added
+- **`@amplify/mcp-server`** — new package. MCP server exposing the Canvas design system to AI agents (Pixel, Claude Code) via stdio + HTTP transports. Five tools: `list_components`, `get_props`, `find_block`, `validate_usage`, `suggest_token`.
+- **`@amplify/ui` JSON contracts** — every build now emits `dist/contracts/<Component>.json` (per-component spec via TypeScript compiler API) and `dist/contracts.json` (manifest). Single source of truth replacing the previous regex extractors. Exposed via subpath exports: `@amplify/ui/contracts`, `@amplify/ui/contracts/*`.
+- **`@amplify/ui` LLM docs** — every build emits `dist/llms.txt` (root index, [llmstxt.org](https://llmstxt.org) spec), `dist/llms/<Component>.md` (per-component rule sheets), and `dist/llms.json` (flat mirror). Exposed via subpath exports: `@amplify/ui/llms.txt`, `@amplify/ui/llms.json`, `@amplify/ui/llms/*`.
+
+### Changed
+- **`@amplify/ui` 0.1.0 → 1.0.0** — first stable release. Component API surface (46 components), variants, and prop signatures are now stable; future breaking changes will follow semver and ship with codemods (planned, Wave 2).
+- CI publish loop now ships `@amplify/mcp-server` alongside the existing token packages, `@amplify/ui`, and `@amplify/eslint-config`.
+
+### Notes
+- This release closes Wave 1 of the Canvas 100x program. Pixel and Claude Code can now consume Canvas through a structured contract instead of carrying hardcoded component lists.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10799,7 +10799,7 @@
     },
     "packages/mcp-server": {
       "name": "@amplify/mcp-server",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "zod": "^3.23.8"
@@ -10917,7 +10917,7 @@
     },
     "packages/ui": {
       "name": "@amplify/ui",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "clsx": "^2.1.0",
         "tailwind-merge": "^2.3.0"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplify/mcp-server",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "MCP server exposing the Amplify Canvas design system to AI agents (Pixel, Claude Code).",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplify/ui",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Shared UI components for Amplify products — Brand, Creator, and Atmosphere",
   "type": "module",
   "main": "dist/index.js",
@@ -10,9 +10,26 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./contracts": {
+      "default": "./dist/contracts.json"
+    },
+    "./contracts/*": {
+      "default": "./dist/contracts/*.json"
+    },
+    "./llms.txt": {
+      "default": "./dist/llms.txt"
+    },
+    "./llms.json": {
+      "default": "./dist/llms.json"
+    },
+    "./llms/*": {
+      "default": "./dist/llms/*.md"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --external react --external react-dom",
     "prebuild": "node scripts/generate-contracts.mjs",


### PR DESCRIPTION
## Summary

Closes Wave 1 by promoting both `@amplify/ui` and the new `@amplify/mcp-server` to a stable, semver-managed **1.0.0** and wiring mcp-server into the publish pipeline. Downstream consumers (Pixel, Claude Code, atmosphere/brand/creator apps) can now install pinned versions from GitHub Packages.

## Changes

| Package | Before | After | Notes |
|---------|--------|-------|-------|
| `@amplify/ui` | 0.1.0 | **1.0.0** | First stable release |
| `@amplify/mcp-server` | 0.1.0 | **1.0.0** | First publish — added to CI publish loop |
| `@amplify/tokens-*` | 1.0.0 | 1.0.0 | Already published, unchanged |
| `@amplify/eslint-config` | 1.0.0 | 1.0.0 | Already published, unchanged |

**`@amplify/ui` exports map** — added five subpath entries for the new build artifacts so consumers can import without reaching into `dist/`:

```ts
import contract from '@amplify/ui/contracts/Button';   // dist/contracts/Button.json
import manifest from '@amplify/ui/contracts';          // dist/contracts.json
import llms from '@amplify/ui/llms.json';              // flat mirror
// also: '@amplify/ui/llms.txt', '@amplify/ui/llms/Button'
```

**CI workflow (`.github/workflows/ci.yml`)**:
- New step: `Build @amplify/mcp-server` (after `Build @amplify/ui`).
- `mcp-server` added to the `verify-build-outputs` directory check.
- `mcp-server` added to the publish loop alongside ui + tokens + eslint-config.

**`CHANGELOG.md`** — new file capturing the v1.0.0 surface for future versioning.

## Why 1.0.0 now

Wave 1 was a coherent, opinionated foundation: structured contracts, llms.txt, MCP server. Shipping all four PRs at 0.x signals "still in flux"; bumping to 1.0 commits to semver and is what downstream apps need to safely pin (`@amplify/ui@^1`). Future breaking changes will follow semver and ship with codemods (planned in Wave 2 Tier 5).

## Downstream install (after merge → CI publish runs)

```bash
npm install @amplify/ui@1 @amplify/tokens-atmosphere@1
npm install @amplify/mcp-server@1
```

## Test plan

- [x] `npm run build -w packages/ui` — clean (46 contracts, 46 llms docs)
- [x] `npm run build -w packages/mcp-server` — clean tsup + dts
- [x] `npm run test -w packages/mcp-server` — 9/9 pass via contracts source
- [x] `npm pack` (dry) — all expected artifacts present in tarball
- [ ] Reviewer to verify CI publish step succeeds for mcp-server on first merge (no version conflict — fresh package)

## Wave 1 — DONE after this merges

- [x] PR-A1 — MCP server (#36)
- [x] PR-A2 — llms.txt generator (#37)
- [x] PR-A3 — JSON contracts (#39)
- [x] PR-A4 — v1.0.0 + publish wiring (this)

## Wave 1 — Pixel + Atmosphere PRs (start next, parallelisable)

- [ ] PR-P1 — Pixel consumes MCP (kills hardcoded 43-component list)
- [ ] PR-P2 — brand-cascade opens real PRs
- [ ] PR-P3 — bidirectional token-sync (Pixel auto-PRs gaps back)
- [ ] PR-P4 — component-props-scanner covers brand + creator
- [ ] PR-AT1..AT4 — atmosphere installs Canvas + migrates Button → Card+Badge → Input+Dialog