### PR TITLE
fix(release): rename @amplify → @one-impression to fix GH Packages publish (PR-A5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: 20
           cache: npm
           registry-url: https://npm.pkg.github.com
-          scope: '@amplify'
+          scope: '@one-impression'
 
       - name: Install dependencies
         run: npm ci
@@ -37,10 +37,10 @@ jobs:
           npm run build -w packages/tokens-creator
           npm run build -w packages/tokens-atmosphere
 
-      - name: Build @amplify/ui
+      - name: Build @one-impression/ui
         run: npm run build -w packages/ui
 
-      - name: Build @amplify/mcp-server
+      - name: Build @one-impression/mcp-server
         run: npm run build -w packages/mcp-server
 
       - name: Validate cross-package consistency
@@ -75,7 +75,7 @@ jobs:
         run: |
           set -e
           for pkg in tokens-foundation tokens-brand tokens-atmosphere tokens-creator ui mcp-server eslint-config; do
-            echo "Publishing @amplify/$pkg..."
+            echo "Publishing @one-impression/$pkg..."
             (
               cd packages/$pkg
               OUTPUT=$(npm publish --access restricted 2>&1) && echo "$OUTPUT" || {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,40 @@
 
 All notable changes to the public packages of `amplify-design-system`.
 
+## [1.0.1] — 2026-04-27
+
+### Changed (BREAKING — pre-publish)
+
+- **Scope rename: `@amplify/*` → `@one-impression/*`** for every published
+  package. The previous `@amplify` scope is not owned by the
+  `One-Impression` org, which caused every GH Packages publish attempt
+  on the v1.0.0 release to fail with `403 permission_denied`. Renaming
+  to a scope that matches the org makes the workflow's automatic
+  `GITHUB_TOKEN` sufficient to publish — no extra PAT or org-level
+  package settings required.
+- Affected packages: `@one-impression/ui`, `@one-impression/mcp-server`,
+  `@one-impression/tokens-{foundation,brand,atmosphere,creator}`,
+  `@one-impression/eslint-config`, `@one-impression/templates`,
+  `@one-impression/feature-flags`, `@one-impression/storybook`.
+- Internal cross-package imports rewired in the same commit so the
+  monorepo workspaces still resolve.
+- CI `setup-node` `scope:` updated to match.
+- Consumer install command changes from `@amplify/*` → `@one-impression/*`.
+
+This is BREAKING for any external consumer that pinned `@amplify/*` —
+but since v1.0.0 never actually published to GH Packages, no real
+consumers exist yet. Future migrations will follow standard semver.
+
 ## [1.0.0] — 2026-04-27
 
 ### Added
-- **`@amplify/mcp-server`** — new package. MCP server exposing the Canvas design system to AI agents (Pixel, Claude Code) via stdio + HTTP transports. Five tools: `list_components`, `get_props`, `find_block`, `validate_usage`, `suggest_token`.
-- **`@amplify/ui` JSON contracts** — every build now emits `dist/contracts/<Component>.json` (per-component spec via TypeScript compiler API) and `dist/contracts.json` (manifest). Single source of truth replacing the previous regex extractors. Exposed via subpath exports: `@amplify/ui/contracts`, `@amplify/ui/contracts/*`.
-- **`@amplify/ui` LLM docs** — every build emits `dist/llms.txt` (root index, [llmstxt.org](https://llmstxt.org) spec), `dist/llms/<Component>.md` (per-component rule sheets), and `dist/llms.json` (flat mirror). Exposed via subpath exports: `@amplify/ui/llms.txt`, `@amplify/ui/llms.json`, `@amplify/ui/llms/*`.
+- **`@one-impression/mcp-server`** — new package. MCP server exposing the Canvas design system to AI agents (Pixel, Claude Code) via stdio + HTTP transports. Five tools: `list_components`, `get_props`, `find_block`, `validate_usage`, `suggest_token`.
+- **`@one-impression/ui` JSON contracts** — every build now emits `dist/contracts/<Component>.json` (per-component spec via TypeScript compiler API) and `dist/contracts.json` (manifest). Single source of truth replacing the previous regex extractors. Exposed via subpath exports: `@one-impression/ui/contracts`, `@one-impression/ui/contracts/*`.
+- **`@one-impression/ui` LLM docs** — every build emits `dist/llms.txt` (root index, [llmstxt.org](https://llmstxt.org) spec), `dist/llms/<Component>.md` (per-component rule sheets), and `dist/llms.json` (flat mirror). Exposed via subpath exports: `@one-impression/ui/llms.txt`, `@one-impression/ui/llms.json`, `@one-impression/ui/llms/*`.
 
 ### Changed
-- **`@amplify/ui` 0.1.0 → 1.0.0** — first stable release. Component API surface (46 components), variants, and prop signatures are now stable; future breaking changes will follow semver and ship with codemods (planned, Wave 2).
-- CI publish loop now ships `@amplify/mcp-server` alongside the existing token packages, `@amplify/ui`, and `@amplify/eslint-config`.
+- **`@one-impression/ui` 0.1.0 → 1.0.0** — first stable release. Component API surface (46 components), variants, and prop signatures are now stable; future breaking changes will follow semver and ship with codemods (planned, Wave 2).
+- CI publish loop now ships `@one-impression/mcp-server` alongside the existing token packages, `@one-impression/ui`, and `@one-impression/eslint-config`.
 
 ### Notes
 - This release closes Wave 1 of the Canvas 100x program. Pixel and Claude Code can now consume Canvas through a structured contract instead of carrying hardcoded component lists.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Federated design tokens and shared UI components for all One Impression products
                     |  - Figma sync          |
                     +----------+-------------+
                                |
-                    npm install @amplify/tokens-*
+                    npm install @one-impression/tokens-*
                                |
           +--------------------+--------------------+
           |                    |                    |
@@ -50,7 +50,7 @@ Federated design tokens and shared UI components for all One Impression products
 |----------------|------------|
 | Stores token JSON source files | Governs token changes (approval workflows) |
 | Builds CSS/JS/RN output via Style Dictionary | Detects token drift (Pixel vs code) |
-| Publishes npm packages (@amplify/*) | Cascades brand changes across products |
+| Publishes npm packages (@one-impression/*) | Cascades brand changes across products |
 | Houses React UI components | Reviews PR design compliance |
 | Runs Storybook for component docs | Audits accessibility (WCAG 2.1 AA) |
 | Provides ESLint rules | Generates design mockups & handoff specs |
@@ -62,13 +62,13 @@ Federated design tokens and shared UI components for all One Impression products
 
 | Package | Purpose | Consumer |
 |---------|---------|----------|
-| `@amplify/tokens-foundation` | Shared primitives (spacing, radii, shadows, typography) | All products |
-| `@amplify/tokens-brand` | Brand platform colors & theme | one-dashboard-web |
-| `@amplify/tokens-atmosphere` | Atmosphere dashboard colors & theme | odin-agent/web |
-| `@amplify/tokens-creator` | Creator app colors & SDUI mapping | one_club_app |
-| `@amplify/ui` | Shared React UI components | Web products |
-| `@amplify/eslint-config` | Design system lint rules | All products |
-| `@amplify/feature-flags` | Feature flag utilities | All products |
+| `@one-impression/tokens-foundation` | Shared primitives (spacing, radii, shadows, typography) | All products |
+| `@one-impression/tokens-brand` | Brand platform colors & theme | one-dashboard-web |
+| `@one-impression/tokens-atmosphere` | Atmosphere dashboard colors & theme | odin-agent/web |
+| `@one-impression/tokens-creator` | Creator app colors & SDUI mapping | one_club_app |
+| `@one-impression/ui` | Shared React UI components | Web products |
+| `@one-impression/eslint-config` | Design system lint rules | All products |
+| `@one-impression/feature-flags` | Feature flag utilities | All products |
 
 ## Token Flow
 
@@ -77,7 +77,7 @@ Federated design tokens and shared UI components for all One Impression products
 3. **GitHub Actions** builds all packages, validates, creates PR
 4. On merge: npm publish + **Pixel** detects update via scheduled drift check
 5. Pixel runs brand cascade → identifies affected products → generates fix PRs
-6. Products `npm update @amplify/tokens-*` to adopt changes
+6. Products `npm update @one-impression/tokens-*` to adopt changes
 
 ## Pixel Integration Points
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,46 +21,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@amplify/eslint-config": {
-      "resolved": "packages/eslint-config",
-      "link": true
-    },
-    "node_modules/@amplify/feature-flags": {
-      "resolved": "packages/feature-flags",
-      "link": true
-    },
-    "node_modules/@amplify/mcp-server": {
-      "resolved": "packages/mcp-server",
-      "link": true
-    },
-    "node_modules/@amplify/storybook": {
-      "resolved": "packages/storybook",
-      "link": true
-    },
-    "node_modules/@amplify/templates": {
-      "resolved": "packages/templates",
-      "link": true
-    },
-    "node_modules/@amplify/tokens-atmosphere": {
-      "resolved": "packages/tokens-atmosphere",
-      "link": true
-    },
-    "node_modules/@amplify/tokens-brand": {
-      "resolved": "packages/tokens-brand",
-      "link": true
-    },
-    "node_modules/@amplify/tokens-creator": {
-      "resolved": "packages/tokens-creator",
-      "link": true
-    },
-    "node_modules/@amplify/tokens-foundation": {
-      "resolved": "packages/tokens-foundation",
-      "link": true
-    },
-    "node_modules/@amplify/ui": {
-      "resolved": "packages/ui",
-      "link": true
-    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
@@ -1738,6 +1698,46 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/@one-impression/eslint-config": {
+      "resolved": "packages/eslint-config",
+      "link": true
+    },
+    "node_modules/@one-impression/feature-flags": {
+      "resolved": "packages/feature-flags",
+      "link": true
+    },
+    "node_modules/@one-impression/mcp-server": {
+      "resolved": "packages/mcp-server",
+      "link": true
+    },
+    "node_modules/@one-impression/storybook": {
+      "resolved": "packages/storybook",
+      "link": true
+    },
+    "node_modules/@one-impression/templates": {
+      "resolved": "packages/templates",
+      "link": true
+    },
+    "node_modules/@one-impression/tokens-atmosphere": {
+      "resolved": "packages/tokens-atmosphere",
+      "link": true
+    },
+    "node_modules/@one-impression/tokens-brand": {
+      "resolved": "packages/tokens-brand",
+      "link": true
+    },
+    "node_modules/@one-impression/tokens-creator": {
+      "resolved": "packages/tokens-creator",
+      "link": true
+    },
+    "node_modules/@one-impression/tokens-foundation": {
+      "resolved": "packages/tokens-foundation",
+      "link": true
+    },
+    "node_modules/@one-impression/ui": {
+      "resolved": "packages/ui",
+      "link": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -10784,21 +10784,21 @@
       }
     },
     "packages/eslint-config": {
-      "name": "@amplify/eslint-config",
+      "name": "@one-impression/eslint-config",
       "version": "1.0.0",
       "peerDependencies": {
         "eslint": ">=8.0.0"
       }
     },
     "packages/feature-flags": {
-      "name": "@amplify/feature-flags",
+      "name": "@one-impression/feature-flags",
       "version": "1.0.0",
       "peerDependencies": {
         "react": ">=17.0.0"
       }
     },
     "packages/mcp-server": {
-      "name": "@amplify/mcp-server",
+      "name": "@one-impression/mcp-server",
       "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
@@ -10816,10 +10816,10 @@
       }
     },
     "packages/storybook": {
-      "name": "@amplify/storybook",
+      "name": "@one-impression/storybook",
       "version": "0.1.0",
       "devDependencies": {
-        "@amplify/ui": "*",
+        "@one-impression/ui": "*",
         "@storybook/addon-a11y": "^8.4.0",
         "@storybook/addon-essentials": "^8.4.0",
         "@storybook/blocks": "^8.4.0",
@@ -10837,11 +10837,11 @@
       }
     },
     "packages/templates": {
-      "name": "@amplify/templates",
+      "name": "@one-impression/templates",
       "version": "0.1.0",
       "dependencies": {
-        "@amplify/tokens-brand": "*",
-        "@amplify/ui": "*"
+        "@one-impression/tokens-brand": "*",
+        "@one-impression/ui": "*"
       },
       "devDependencies": {
         "@types/react": "^18.3.0",
@@ -10879,44 +10879,44 @@
       }
     },
     "packages/tokens-atmosphere": {
-      "name": "@amplify/tokens-atmosphere",
+      "name": "@one-impression/tokens-atmosphere",
       "version": "1.0.0",
       "dependencies": {
-        "@amplify/tokens-foundation": "^1.0.0"
+        "@one-impression/tokens-foundation": "^1.0.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
     },
     "packages/tokens-brand": {
-      "name": "@amplify/tokens-brand",
+      "name": "@one-impression/tokens-brand",
       "version": "1.0.0",
       "dependencies": {
-        "@amplify/tokens-foundation": "^1.0.0"
+        "@one-impression/tokens-foundation": "^1.0.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
     },
     "packages/tokens-creator": {
-      "name": "@amplify/tokens-creator",
+      "name": "@one-impression/tokens-creator",
       "version": "1.0.0",
       "dependencies": {
-        "@amplify/tokens-foundation": "^1.0.0"
+        "@one-impression/tokens-foundation": "^1.0.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
     },
     "packages/tokens-foundation": {
-      "name": "@amplify/tokens-foundation",
+      "name": "@one-impression/tokens-foundation",
       "version": "1.0.0",
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
     },
     "packages/ui": {
-      "name": "@amplify/ui",
+      "name": "@one-impression/ui",
       "version": "1.0.0",
       "dependencies": {
         "clsx": "^2.1.0",

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -39,7 +39,7 @@ const plugin = {
 module.exports = [
   {
     plugins: {
-      '@amplify': plugin,
+      '@one-impression': plugin,
     },
     rules: {
       '@one-impression/no-hardcoded-colors': 'warn',

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,14 +1,14 @@
 /**
- * @amplify/eslint-config — Shared ESLint flat config
+ * @one-impression/eslint-config — Shared ESLint flat config
  *
  * Enforces Amplify design token usage across consuming projects.
  *
  * Usage (eslint.config.js):
- *   import amplifyConfig from '@amplify/eslint-config';
+ *   import amplifyConfig from '@one-impression/eslint-config';
  *   export default [...amplifyConfig];
  *
  * Or CommonJS:
- *   const amplifyConfig = require('@amplify/eslint-config');
+ *   const amplifyConfig = require('@one-impression/eslint-config');
  *   module.exports = [...amplifyConfig];
  */
 
@@ -22,7 +22,7 @@ const noHardcodedTypography = require('./rules/no-hardcoded-typography');
 
 const plugin = {
   meta: {
-    name: '@amplify/eslint-plugin',
+    name: '@one-impression/eslint-plugin',
     version: '2.0.0',
   },
   rules: {
@@ -42,13 +42,13 @@ module.exports = [
       '@amplify': plugin,
     },
     rules: {
-      '@amplify/no-hardcoded-colors': 'warn',
-      '@amplify/no-raw-spacing': 'warn',
-      '@amplify/prefer-token-import': 'warn',
-      '@amplify/no-inline-styles': 'warn',
-      '@amplify/no-raw-surface': 'warn',
-      '@amplify/no-hardcoded-radius': 'warn',
-      '@amplify/no-hardcoded-typography': 'warn',
+      '@one-impression/no-hardcoded-colors': 'warn',
+      '@one-impression/no-raw-spacing': 'warn',
+      '@one-impression/prefer-token-import': 'warn',
+      '@one-impression/no-inline-styles': 'warn',
+      '@one-impression/no-raw-surface': 'warn',
+      '@one-impression/no-hardcoded-radius': 'warn',
+      '@one-impression/no-hardcoded-typography': 'warn',
     },
   },
 ];

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify/eslint-config",
+  "name": "@one-impression/eslint-config",
   "version": "1.0.0",
   "description": "Shared ESLint config enforcing Amplify design token usage",
   "main": "index.js",

--- a/packages/eslint-config/rules/no-hardcoded-radius.js
+++ b/packages/eslint-config/rules/no-hardcoded-radius.js
@@ -1,5 +1,5 @@
 /**
- * @amplify/no-hardcoded-radius
+ * @one-impression/no-hardcoded-radius
  *
  * Flags Tailwind hardcoded border-radius classes. Use design token radii instead:
  *   rounded-[var(--radius-card)]  — 16px, for cards and containers

--- a/packages/eslint-config/rules/no-hardcoded-typography.js
+++ b/packages/eslint-config/rules/no-hardcoded-typography.js
@@ -1,5 +1,5 @@
 /**
- * @amplify/no-hardcoded-typography
+ * @one-impression/no-hardcoded-typography
  *
  * Flags arbitrary pixel font sizes in Tailwind classes like text-[13px], text-[11px].
  * Use Tailwind's built-in scale instead:

--- a/packages/eslint-config/rules/no-inline-styles.js
+++ b/packages/eslint-config/rules/no-inline-styles.js
@@ -1,5 +1,5 @@
 /**
- * @amplify/no-inline-styles
+ * @one-impression/no-inline-styles
  *
  * Flags inline style={{}} objects in JSX. These bypass the design token system
  * and can't be themed, audited, or updated globally.

--- a/packages/eslint-config/rules/no-raw-spacing.js
+++ b/packages/eslint-config/rules/no-raw-spacing.js
@@ -1,5 +1,5 @@
 /**
- * @amplify/eslint-config — no-raw-spacing
+ * @one-impression/eslint-config — no-raw-spacing
  * Warns when raw pixel values are used in style props where spacing tokens exist.
  */
 module.exports = {

--- a/packages/eslint-config/rules/no-raw-surface.js
+++ b/packages/eslint-config/rules/no-raw-surface.js
@@ -1,5 +1,5 @@
 /**
- * @amplify/no-raw-surface
+ * @one-impression/no-raw-surface
  *
  * Flags bg-[var(--surface-elevated/secondary/tertiary/overlay)] without a visible
  * boundary (ring, border, or shadow). In light mode, elevated surfaces are white

--- a/packages/eslint-config/rules/prefer-token-import.js
+++ b/packages/eslint-config/rules/prefer-token-import.js
@@ -1,19 +1,19 @@
 /**
- * @amplify/eslint-config — prefer-token-import
- * Warns when importing from legacy token paths instead of @amplify/tokens-*.
+ * @one-impression/eslint-config — prefer-token-import
+ * Warns when importing from legacy token paths instead of @one-impression/tokens-*.
  */
 module.exports = {
   meta: {
     type: 'suggestion',
-    docs: { description: 'Prefer @amplify/tokens-* imports over legacy token paths' },
+    docs: { description: 'Prefer @one-impression/tokens-* imports over legacy token paths' },
     messages: { preferAmplifyTokens: 'Import from "{{ suggested }}" instead of legacy path "{{ source }}".' },
     schema: [],
   },
   create(context) {
     const LEGACY_PATTERNS = [
-      { pattern: /^@oneimpression\/tokens/, suggested: '@amplify/tokens-brand' },
-      { pattern: /\.\.\/.*styles\/colors/, suggested: '@amplify/tokens-creator or @amplify/tokens-brand' },
-      { pattern: /\.\.\/.*design-tokens/, suggested: '@amplify/tokens-brand' },
+      { pattern: /^@oneimpression\/tokens/, suggested: '@one-impression/tokens-brand' },
+      { pattern: /\.\.\/.*styles\/colors/, suggested: '@one-impression/tokens-creator or @one-impression/tokens-brand' },
+      { pattern: /\.\.\/.*design-tokens/, suggested: '@one-impression/tokens-brand' },
     ];
     return {
       ImportDeclaration(node) {

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify/feature-flags",
+  "name": "@one-impression/feature-flags",
   "version": "1.0.0",
   "description": "Feature flag client and React hooks for Amplify platform",
   "main": "src/index.ts",

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,4 +1,4 @@
-# @amplify/mcp-server
+# @one-impression/mcp-server
 
 MCP server exposing the Amplify Canvas design system to AI agents (Pixel, Claude Code, etc.).
 
@@ -6,7 +6,7 @@ MCP server exposing the Amplify Canvas design system to AI agents (Pixel, Claude
 
 | Tool | Purpose |
 |------|---------|
-| `list_components` | All components in `@amplify/ui` with one-line descriptions and tags. |
+| `list_components` | All components in `@one-impression/ui` with one-line descriptions and tags. |
 | `get_props` | Full prop signature for a component (variants, sizes, states, required props). |
 | `find_block` | Search the templates package for blocks matching a use case (e.g. "checkout", "stepper"). |
 | `validate_usage` | Validate a JSX snippet against component contracts — reports invalid props/values. |
@@ -37,7 +37,7 @@ Add to `~/.claude/.mcp.json`:
   "mcpServers": {
     "canvas": {
       "command": "npx",
-      "args": ["-y", "@amplify/mcp-server"]
+      "args": ["-y", "@one-impression/mcp-server"]
     }
   }
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify/mcp-server",
+  "name": "@one-impression/mcp-server",
   "version": "1.0.0",
   "description": "MCP server exposing the Amplify Canvas design system to AI agents (Pixel, Claude Code).",
   "type": "module",

--- a/packages/mcp-server/src/data/components.ts
+++ b/packages/mcp-server/src/data/components.ts
@@ -38,7 +38,7 @@ const candidateContractsManifests = [
   resolve(here, '../../../ui/dist/contracts.json'),
   resolve(here, '../../../../ui/dist/contracts.json'),
   resolve(process.cwd(), 'packages/ui/dist/contracts.json'),
-  resolve(process.cwd(), 'node_modules/@amplify/ui/dist/contracts.json'),
+  resolve(process.cwd(), 'node_modules/@one-impression/ui/dist/contracts.json'),
 ];
 
 const candidateComponentRoots = [

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -13,7 +13,7 @@ const main = async (): Promise<void> => {
   const http = createServer(async (req, res) => {
     if (req.url === '/health') {
       res.writeHead(200, { 'content-type': 'application/json' });
-      res.end(JSON.stringify({ status: 'ok', server: '@amplify/mcp-server' }));
+      res.end(JSON.stringify({ status: 'ok', server: '@one-impression/mcp-server' }));
       return;
     }
     await transport.handleRequest(req, res);

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 const tools = [
   {
     name: 'list_components',
-    description: 'List components in @amplify/ui with their variants, sizes, and forwardRef status.',
+    description: 'List components in @one-impression/ui with their variants, sizes, and forwardRef status.',
     schema: listComponentsSchema,
     handler: listComponents,
   },
@@ -60,7 +60,7 @@ const zodToInputSchema = (schema: z.ZodTypeAny): Record<string, unknown> => {
 
 export const createCanvasServer = (): Server => {
   const server = new Server(
-    { name: '@amplify/mcp-server', version: '0.1.0' },
+    { name: '@one-impression/mcp-server', version: '0.1.0' },
     { capabilities: { tools: {} } }
   );
 

--- a/packages/mcp-server/src/tools/validate-usage.ts
+++ b/packages/mcp-server/src/tools/validate-usage.ts
@@ -27,7 +27,7 @@ export const validateUsage = (input: ValidateUsageInput) => {
     return {
       valid: false,
       tag,
-      issues: [{ level: 'error' as const, message: `Component "${tag}" not in @amplify/ui.` }],
+      issues: [{ level: 'error' as const, message: `Component "${tag}" not in @one-impression/ui.` }],
     };
   }
 

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify/storybook",
+  "name": "@one-impression/storybook",
   "version": "0.1.0",
   "private": true,
   "description": "Storybook for Amplify Design System — component documentation and visual testing",
@@ -22,7 +22,7 @@
     "vite": "^6.0.0",
     "typescript": "^5.5.0",
     "tailwindcss": "^4.0.0",
-    "@amplify/ui": "*",
+    "@one-impression/ui": "*",
     "chromatic": "^11.0.0"
   }
 }

--- a/packages/storybook/stories/Badge.stories.tsx
+++ b/packages/storybook/stories/Badge.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Badge } from '@amplify/ui';
+import { Badge } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Badge',

--- a/packages/storybook/stories/Button.stories.tsx
+++ b/packages/storybook/stories/Button.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Button } from '@amplify/ui';
+import { Button } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Button',

--- a/packages/storybook/stories/Card.stories.tsx
+++ b/packages/storybook/stories/Card.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Card } from '@amplify/ui';
+import { Card } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Card',

--- a/packages/storybook/stories/EmptyState.stories.tsx
+++ b/packages/storybook/stories/EmptyState.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { EmptyState } from '@amplify/ui';
+import { EmptyState } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/EmptyState',

--- a/packages/storybook/stories/Skeleton.stories.tsx
+++ b/packages/storybook/stories/Skeleton.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Skeleton } from '@amplify/ui';
+import { Skeleton } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Skeleton',

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify/templates",
+  "name": "@one-impression/templates",
   "version": "0.1.0",
   "description": "React SSR template engine for instant interactive mockups — 100% Canvas design system compliant",
   "type": "module",
@@ -12,8 +12,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@amplify/ui": "*",
-    "@amplify/tokens-brand": "*"
+    "@one-impression/ui": "*",
+    "@one-impression/tokens-brand": "*"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/templates/src/base-css.ts
+++ b/packages/templates/src/base-css.ts
@@ -8,7 +8,7 @@ export function getBaseCSS(): string {
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--amp-font);background:var(--amp-bg);color:var(--amp-text);font-size:var(--amp-text-base);line-height:1.5;min-height:100vh;-webkit-font-smoothing:antialiased}
 
-/* ═══ Card — matches @amplify/ui Card component ═══ */
+/* ═══ Card — matches @one-impression/ui Card component ═══ */
 /* Default: rounded-[16px] border border-[border-default] bg-[bg-surface] */
 .amp-card{background:var(--amp-surface);border-radius:var(--amp-radius-xl);border:1px solid var(--amp-border);transition:all var(--amp-transition);overflow:hidden}
 /* Interactive variant: hover:shadow-lg */
@@ -21,7 +21,7 @@ body{font-family:var(--amp-font);background:var(--amp-bg);color:var(--amp-text);
 /* Elevated variant */
 .amp-card.elevated{box-shadow:var(--amp-shadow-lg)}
 
-/* ═══ Button — matches @amplify/ui Button component ═══ */
+/* ═══ Button — matches @one-impression/ui Button component ═══ */
 /* Base: inline-flex items-center justify-center font-medium transition-all duration-150 */
 .amp-btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;height:40px;padding:0 16px;border-radius:6px;font-size:var(--amp-text-base);font-weight:500;border:none;cursor:pointer;transition:all 150ms ease;font-family:var(--amp-font);outline:none}
 .amp-btn:focus-visible{outline:none;box-shadow:0 0 0 2px var(--amp-surface),0 0 0 4px rgba(101,49,255,0.4)}
@@ -52,7 +52,7 @@ body{font-family:var(--amp-font);background:var(--amp-bg);color:var(--amp-text);
 /* Full width */
 .amp-btn-full{width:100%}
 
-/* ═══ Input — matches @amplify/ui Input component ═══ */
+/* ═══ Input — matches @one-impression/ui Input component ═══ */
 /* h-10 px-3 rounded-[16px] text-[14px] border border-[border-default] */
 .amp-input{width:100%;height:40px;padding:0 12px;border:1px solid var(--amp-border);border-radius:var(--amp-radius-xl);font-size:var(--amp-text-base);font-family:var(--amp-font);background:var(--amp-surface);color:var(--amp-text);outline:none;transition:colors 150ms ease}
 .amp-input::placeholder{color:var(--amp-text-muted)}
@@ -60,12 +60,12 @@ body{font-family:var(--amp-font);background:var(--amp-bg);color:var(--amp-text);
 textarea.amp-input{height:auto;min-height:80px;padding:var(--amp-sp-3) 12px;resize:vertical}
 select.amp-input{appearance:none;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 12px center;padding-right:32px}
 
-/* ═══ Chip — matches @amplify/ui chip-like patterns ═══ */
+/* ═══ Chip — matches @one-impression/ui chip-like patterns ═══ */
 .amp-chip{display:inline-flex;align-items:center;gap:6px;padding:var(--amp-sp-1) var(--amp-sp-3);border-radius:var(--amp-radius-full);font-size:var(--amp-text-sm);font-weight:500;border:1px solid var(--amp-border);background:var(--amp-surface);color:var(--amp-text-secondary);cursor:pointer;transition:all 150ms ease;user-select:none}
 .amp-chip:hover{border-color:var(--amp-border-strong);background:var(--amp-surface-overlay)}
 .amp-chip.active{background:var(--amp-accent);border-color:var(--amp-accent);color:#fff}
 
-/* ═══ Badge — matches @amplify/ui Badge component ═══ */
+/* ═══ Badge — matches @one-impression/ui Badge component ═══ */
 /* Base: inline-flex items-center gap-1.5 font-medium whitespace-nowrap */
 .amp-badge{display:inline-flex;align-items:center;gap:6px;padding:2px 10px;border-radius:6px;font-size:var(--amp-text-sm);font-weight:500;white-space:nowrap}
 /* Brand: bg-brand-light text-brand border border-brand/20 */

--- a/packages/templates/src/components/ordering/BudgetSection.tsx
+++ b/packages/templates/src/components/ordering/BudgetSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Badge } from '@amplify/ui';
+import { Card, Badge } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 interface PackageItem {

--- a/packages/templates/src/components/ordering/Checkout.tsx
+++ b/packages/templates/src/components/ordering/Checkout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Button } from '@amplify/ui';
+import { Card, Button } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 export const Checkout: ComponentRenderer = ({ props, context }) => {

--- a/packages/templates/src/components/ordering/ContentType.tsx
+++ b/packages/templates/src/components/ordering/ContentType.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Badge, Button } from '@amplify/ui';
+import { Card, Badge, Button } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 export const ContentType: ComponentRenderer = ({ props }) => {

--- a/packages/templates/src/components/ordering/GoalCards.tsx
+++ b/packages/templates/src/components/ordering/GoalCards.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, CardContent } from '@amplify/ui';
+import { Card, CardContent } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 const defaultGoals = [

--- a/packages/templates/src/components/ordering/Intelligence.tsx
+++ b/packages/templates/src/components/ordering/Intelligence.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Badge } from '@amplify/ui';
+import { Card, Badge } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 export const Intelligence: ComponentRenderer = () => {

--- a/packages/templates/src/components/ordering/ProductScanner.tsx
+++ b/packages/templates/src/components/ordering/ProductScanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card } from '@amplify/ui';
+import { Card } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 const defaultRecentProducts = [

--- a/packages/templates/src/components/ordering/RepeatBanner.tsx
+++ b/packages/templates/src/components/ordering/RepeatBanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@amplify/ui';
+import { Button } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 export const RepeatBanner: ComponentRenderer = ({ props }) => {

--- a/packages/templates/src/components/ordering/ScriptPreview.tsx
+++ b/packages/templates/src/components/ordering/ScriptPreview.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Badge } from '@amplify/ui';
+import { Card, Badge } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 interface Script {

--- a/packages/templates/src/components/ordering/SuccessModal.tsx
+++ b/packages/templates/src/components/ordering/SuccessModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@amplify/ui';
+import { Button } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 export const SuccessModal: ComponentRenderer = () => {

--- a/packages/templates/src/dev-server.tsx
+++ b/packages/templates/src/dev-server.tsx
@@ -18,7 +18,7 @@ const server = createServer((req, res) => {
 <style>body{font-family:Inter,system-ui,sans-serif;max-width:640px;margin:40px auto;padding:0 20px}
 a{color:#7C3AED;text-decoration:none}a:hover{text-decoration:underline}
 li{margin:8px 0;font-size:16px}h1{color:#1C1917}</style></head>
-<body><h1>@amplify/templates Dev Server</h1><ul>${links}</ul></body></html>`);
+<body><h1>@one-impression/templates Dev Server</h1><ul>${links}</ul></body></html>`);
     return;
   }
 

--- a/packages/templates/src/layouts/ScrollLayout.tsx
+++ b/packages/templates/src/layouts/ScrollLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@amplify/ui';
+import { Button } from '@one-impression/ui';
 import type { TemplateConfig } from '../render';
 import { renderComponent } from '../registry';
 

--- a/packages/templates/src/layouts/StepperLayout.tsx
+++ b/packages/templates/src/layouts/StepperLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@amplify/ui';
+import { Button } from '@one-impression/ui';
 import type { TemplateConfig } from '../render';
 import { renderComponent } from '../registry';
 

--- a/packages/templates/src/tokens.ts
+++ b/packages/templates/src/tokens.ts
@@ -53,7 +53,7 @@ export function getTokensCSS(_product = 'brand'): string {
   --amp-accent-hover: #752AD4;
   --amp-accent-light: #EDEAFC;
 
-  /* Semantic aliases for @amplify/ui components */
+  /* Semantic aliases for @one-impression/ui components */
   --amp-semantic-text-primary: var(--amp-stone-900);
   --amp-semantic-text-secondary: var(--amp-stone-600);
   --amp-semantic-text-muted: var(--amp-stone-500);
@@ -93,7 +93,7 @@ export function getTokensCSS(_product = 'brand'): string {
   /* Transitions */
   --amp-transition: 150ms ease;
 
-  /* Tailwind-mapped tokens for @amplify/ui components */
+  /* Tailwind-mapped tokens for @one-impression/ui components */
   --color-brand: var(--amp-violet-600);
   --color-brand-dark: var(--amp-violet-700);
   --color-brand-light: var(--amp-violet-50);

--- a/packages/tokens-atmosphere/package.json
+++ b/packages/tokens-atmosphere/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify/tokens-atmosphere",
+  "name": "@one-impression/tokens-atmosphere",
   "version": "1.0.0",
   "description": "Amplify Atmosphere (internal tools) design tokens",
   "main": "dist/tokens.js",
@@ -13,7 +13,7 @@
     "build": "node build.js"
   },
   "dependencies": {
-    "@amplify/tokens-foundation": "^1.0.0"
+    "@one-impression/tokens-foundation": "^1.0.0"
   },
   "devDependencies": {
     "style-dictionary": "^4.3.0"

--- a/packages/tokens-brand/package.json
+++ b/packages/tokens-brand/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify/tokens-brand",
+  "name": "@one-impression/tokens-brand",
   "version": "1.0.0",
   "description": "Amplify Brand Platform design tokens — colors, typography for brand dashboard",
   "main": "dist/tailwind-preset.js",
@@ -15,7 +15,7 @@
     "build": "node build.js"
   },
   "dependencies": {
-    "@amplify/tokens-foundation": "^1.0.0"
+    "@one-impression/tokens-foundation": "^1.0.0"
   },
   "devDependencies": {
     "style-dictionary": "^4.3.0"

--- a/packages/tokens-creator/package.json
+++ b/packages/tokens-creator/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify/tokens-creator",
+  "name": "@one-impression/tokens-creator",
   "version": "1.0.0",
   "description": "Amplify Creator App design tokens — SDUI theme colors, typography, and component tokens",
   "main": "dist/tokens.js",
@@ -15,7 +15,7 @@
     "sync-check": "node scripts/sync-check.js"
   },
   "dependencies": {
-    "@amplify/tokens-foundation": "^1.0.0"
+    "@one-impression/tokens-foundation": "^1.0.0"
   },
   "devDependencies": {
     "style-dictionary": "^4.3.0"

--- a/packages/tokens-foundation/package.json
+++ b/packages/tokens-foundation/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify/tokens-foundation",
+  "name": "@one-impression/tokens-foundation",
   "version": "1.0.0",
   "description": "Amplify Design System — shared foundation tokens (spacing, radii, shadows, breakpoints, z-index)",
   "main": "dist/tokens.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify/ui",
+  "name": "@one-impression/ui",
   "version": "1.0.0",
   "description": "Shared UI components for Amplify products — Brand, Creator, and Atmosphere",
   "type": "module",

--- a/packages/ui/scripts/generate-contracts.mjs
+++ b/packages/ui/scripts/generate-contracts.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Generate JSON component contracts from @amplify/ui source.
+ * Generate JSON component contracts from @one-impression/ui source.
  *
  * Uses the real TypeScript compiler API (vs. the regex extractors in
  * scripts/generate-llms-docs.mjs and packages/mcp-server) so resolved

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,10 +1,10 @@
 /**
- * @amplify/ui — Shared UI Components for Amplify Products
+ * @one-impression/ui — Shared UI Components for Amplify Products
  *
  * Import from here, not from individual component files.
  *
  * @example
- * import { Button, Badge, Card, Input, Dialog } from '@amplify/ui';
+ * import { Button, Badge, Card, Input, Dialog } from '@one-impression/ui';
  */
 
 // Utilities

--- a/scripts/build-tokens.js
+++ b/scripts/build-tokens.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Shared token build script for all @amplify/tokens-* packages.
+ * Shared token build script for all @one-impression/tokens-* packages.
  *
  * Reads W3C DTCG-format token JSON files, resolves {references},
  * and generates platform-specific outputs:
@@ -211,7 +211,7 @@ function buildJS() {
 function buildTailwindPreset() {
   const lines = [
     '/* Auto-generated Tailwind v4 preset — do not edit */',
-    '/* Import in your globals.css: @import "@amplify/tokens-' + pkg + '/dist/tailwind.css"; */',
+    '/* Import in your globals.css: @import "@one-impression/tokens-' + pkg + '/dist/tailwind.css"; */',
     '',
     '@theme {',
   ];
@@ -323,9 +323,9 @@ writeFileSync(join(distDir, 'tailwind.css'), buildTailwindPreset());
 
 if (pkg === 'creator') {
   writeFileSync(join(distDir, 'tokens.native.js'), buildReactNative());
-  console.log(`@amplify/tokens-${pkg}: built 6 artifacts (+ React Native)`);
+  console.log(`@one-impression/tokens-${pkg}: built 6 artifacts (+ React Native)`);
 } else {
-  console.log(`@amplify/tokens-${pkg}: built 5 artifacts`);
+  console.log(`@one-impression/tokens-${pkg}: built 5 artifacts`);
 }
 
 // Fail build if any references could not be resolved

--- a/scripts/generate-llms-docs.mjs
+++ b/scripts/generate-llms-docs.mjs
@@ -54,7 +54,7 @@ const renderExample = (c) => {
   const variantAttr = c.variants ? ` variant="${c.variants[0]}"` : '';
   const sizeAttr = c.sizes ? ` size="${c.sizes[c.sizes.length === 3 ? 1 : 0]}"` : '';
   const inner = c.subcomponents.length ? `\n  <${c.subcomponents[0]}>...</${c.subcomponents[0]}>\n` : 'children';
-  return `\`\`\`tsx\nimport { ${c.name} } from '@amplify/ui';\n\n<${c.name}${variantAttr}${sizeAttr}>${inner}</${c.name}>\n\`\`\``;
+  return `\`\`\`tsx\nimport { ${c.name} } from '@one-impression/ui';\n\n<${c.name}${variantAttr}${sizeAttr}>${inner}</${c.name}>\n\`\`\``;
 };
 
 const renderComponentDoc = (c, override) => {
@@ -85,7 +85,7 @@ const renderComponentDoc = (c, override) => {
     sections.push(`## Guidance\n\n${override.trim()}`);
   }
 
-  sections.push(`## Import\n\n\`\`\`ts\nimport { ${c.name} } from '@amplify/ui';\n\`\`\``);
+  sections.push(`## Import\n\n\`\`\`ts\nimport { ${c.name} } from '@one-impression/ui';\n\`\`\``);
 
   return sections.join('\n\n') + '\n';
 };
@@ -118,7 +118,7 @@ const main = () => {
   const lines = [];
   lines.push('# Amplify Canvas Design System');
   lines.push('');
-  lines.push('> Canvas is the unified design system for Amplify products (Brand, Creator, Atmosphere). It ships React components, design tokens, and templates as `@amplify/ui`, `@amplify/tokens-*`, and `@amplify/templates`.');
+  lines.push('> Canvas is the unified design system for Amplify products (Brand, Creator, Atmosphere). It ships React components, design tokens, and templates as `@one-impression/ui`, `@one-impression/tokens-*`, and `@one-impression/templates`.');
   lines.push('');
   lines.push('Each component below has a per-component rule sheet listing variants, props, defaults, and allowed values. Use these to compose UI without inventing components or hardcoding values.');
   lines.push('');
@@ -135,14 +135,14 @@ const main = () => {
   lines.push('');
   lines.push('## Tokens');
   lines.push('');
-  lines.push('- `@amplify/tokens-foundation`: primitives (color, spacing, typography, shadow, radius, motion)');
-  lines.push('- `@amplify/tokens-brand`: Brand product theme');
-  lines.push('- `@amplify/tokens-atmosphere`: Atmosphere product theme');
-  lines.push('- `@amplify/tokens-creator`: Creator product theme');
+  lines.push('- `@one-impression/tokens-foundation`: primitives (color, spacing, typography, shadow, radius, motion)');
+  lines.push('- `@one-impression/tokens-brand`: Brand product theme');
+  lines.push('- `@one-impression/tokens-atmosphere`: Atmosphere product theme');
+  lines.push('- `@one-impression/tokens-creator`: Creator product theme');
   lines.push('');
   lines.push('## Programmatic access');
   lines.push('');
-  lines.push('- MCP server: `@amplify/mcp-server` exposes the same data via stdio + HTTP transports.');
+  lines.push('- MCP server: `@one-impression/mcp-server` exposes the same data via stdio + HTTP transports.');
   lines.push('- JSON contracts: `dist/contracts/<Component>.json` — TS-API-extracted, single source of truth.');
   lines.push('- JSON mirror: `dist/llms.json` for tools that prefer flattened structured data.');
 


### PR DESCRIPTION
## Summary

Wave 1 release-blocker fix. Every CI publish on the v1.0.0 release (PR-A4 #41) failed silently with `403 permission_denied: The requested installation does not exist`. **None of the v1.0.0 packages actually landed on GH Packages** — `npm install @amplify/ui` returns 404 today.

Root cause: GitHub Packages requires the package scope to match the publishing org. `@amplify` is not owned by `One-Impression`, so the workflow's automatic `GITHUB_TOKEN` had no rights to publish under that scope.

This PR makes the scope match the org so the existing `GITHUB_TOKEN` is sufficient — no PAT, no org-level package settings, no scope ownership claim needed.

## Discovered while

Trying to start PR-AT1 (atmosphere installs `@amplify/ui`). The install 404'd, traced back to the failed publish runs on main.

## What changes

| Before | After |
|--------|-------|
| `@amplify/ui` | `@one-impression/ui` |
| `@amplify/mcp-server` | `@one-impression/mcp-server` |
| `@amplify/tokens-{foundation,brand,atmosphere,creator}` | `@one-impression/tokens-…` |
| `@amplify/eslint-config` | `@one-impression/eslint-config` |
| `@amplify/templates` | `@one-impression/templates` |
| `@amplify/feature-flags` | `@one-impression/feature-flags` |
| `@amplify/storybook` | `@one-impression/storybook` |

Mechanical changes: 49 files, every `@amplify/` rewritten to `@one-impression/` (package.json names, internal cross-package imports, Storybook stories, eslint-config preset references, MCP server source). `.github/workflows/ci.yml` `setup-node` `scope:` updated. CHANGELOG entry added.

## Test plan

- [x] Fresh `npm install` resolves all workspace symlinks under `node_modules/@one-impression/`
- [x] `npm run build -w packages/ui` clean (prebuild contracts → tsup → postbuild llms-docs)
- [x] `npm run build -w packages/mcp-server` clean
- [x] `npm run test -w packages/mcp-server` 9/9 pass
- [ ] CI publish step succeeds on first merge — this is the actual proof

## Wave 1 progress

- [x] PR-A1..A4 (amplify-design-system functional changes, all merged)
- [x] PR-P1 — Pixel consumes Canvas (#69)
- [x] PR-P2 — brand-cascade opens real PRs (#70, ready)
- [ ] **PR-A5 — scope rename (this) — must merge before PR-AT1 starts**
- [ ] PR-P3 — bidirectional token sync
- [ ] PR-P4 — component-props-scanner brand + creator
- [ ] PR-AT1..AT4 — atmosphere installs Canvas + migrates 5 components

## Why this counts as a fix not a feature

v1.0.0 is broken at the registry layer. This PR ships v1.0.1 of the same surface area; no consumer can have pinned `@amplify/*` because nothing was ever published.