### PR TITLE
feat(ui): add xs size to Button + IconButton — precursor for atmosphere migration (PR-A6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the public packages of `amplify-design-system`.
 
+## [1.1.0] — 2026-04-28
+
+### Added (additive — `@one-impression/ui`)
+
+- **`xs` size variant** on `Button` and `IconButton`. Discovered while preparing the atmosphere migration: data-dense dashboards need a smaller-than-`sm` control (`h-6` = 24px) for tight rows. Without `xs` the alternative would have been forcing every consumer to either accept Canvas's coarser scale or to bypass Canvas with bespoke local primitives — neither acceptable.
+- This is a precursor to the proper density-mode work planned in Wave 2 Tier 2 (`compact` × `cozy` orthogonal axis). Once density lands, `xs` becomes "compact `sm`" automatically; this PR keeps the explicit `xs` opt-out for callsites that want the smaller footprint regardless of density.
+
+| Component | Size | Width / Height | Padding | Use case |
+|-----------|------|----------------|---------|----------|
+| Button | `xs` | h-6 (24px) | px-2 | Inline tables, dashboards, dense forms |
+| IconButton | `xs` | 24×24 | — | Inline row actions in DataTable |
+
+Pure additive — no breaking change. Existing `sm/md/lg` callsites unchanged.
+
 ## [1.0.1] — 2026-04-27
 
 ### Changed (BREAKING — pre-publish)

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@one-impression/ui",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Shared UI components for Amplify products — Brand, Creator, and Atmosphere",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { cn } from '../../lib/cn';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'destructive' | 'outline';
-export type ButtonSize = 'sm' | 'md' | 'lg';
+export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
 
 export interface ButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'style'> {
   variant?: ButtonVariant;
@@ -23,6 +23,7 @@ const variantClasses: Record<ButtonVariant, string> = {
 };
 
 const sizeClasses: Record<ButtonSize, string> = {
+  xs: 'h-6 px-2 text-xs gap-1 rounded',
   sm: 'h-8 px-3 text-sm gap-1.5 rounded-md',
   md: 'h-10 px-4 text-base gap-2 rounded-md',
   lg: 'h-12 px-6 text-base gap-2 rounded-lg',

--- a/packages/ui/src/components/IconButton/IconButton.tsx
+++ b/packages/ui/src/components/IconButton/IconButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { cn } from '../../lib/cn';
 
 export type IconButtonVariant = 'default' | 'ghost' | 'outline';
-export type IconButtonSize = 'sm' | 'md' | 'lg';
+export type IconButtonSize = 'xs' | 'sm' | 'md' | 'lg';
 
 export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   icon: React.ReactNode;
@@ -21,6 +21,7 @@ const variantClasses: Record<IconButtonVariant, string> = {
 };
 
 const sizeClasses: Record<IconButtonSize, string> = {
+  xs: 'w-6 h-6',
   sm: 'w-8 h-8',
   md: 'w-10 h-10',
   lg: 'w-12 h-12',


### PR DESCRIPTION
## Summary

Discovered while preparing PR-AT2: atmosphere's data-dense dashboards need a smaller-than-`sm` Button (`h-6` = 24px) for tight rows. Canvas's `sm/md/lg` was right for marketing surfaces but too coarse for power-user UI.

This PR adds `xs` to both `Button` and `IconButton` as a focused, additive precursor to the proper density-mode work planned in Wave 2 Tier 2 (`compact × cozy` orthogonal axis). When density lands, `xs` becomes "compact `sm`" automatically; this PR keeps the explicit `xs` opt-out for callsites that want the smaller footprint regardless of density.

## Why this matters

Without `xs`, the atmosphere migration would have one of three options:
1. Accept Canvas's coarser scale → visible regression in dashboard tightness (real product value lost)
2. Bypass Canvas with bespoke local primitives → exactly the system-circumvention we're trying to eliminate
3. Push every consumer's bespoke needs into Canvas as variants → bloat, loss of opinion

`xs` is a meaningful primitive that belongs in any data-dense design system (Carbon, Spectrum, Polaris all have it). Adding it isn't variant bloat — it's filling a deliberate gap.

## What changes

| Component | Size | Width / Height | Padding | Use case |
|-----------|------|----------------|---------|----------|
| Button | `xs` | h-6 (24px) | px-2 | Inline tables, dashboards, dense forms |
| IconButton | `xs` | 24×24 | — | Inline row actions in DataTable |

- `@one-impression/ui` 1.0.0 → 1.1.0 (semver minor — purely additive).
- CHANGELOG entry documenting the precursor relationship to density.
- Auto-picked-up by JSON contracts (`Button.json` + `IconButton.json` now show `xs` in `sizes`) and llms-docs.

## Test plan

- [x] `npm run build -w packages/ui` clean — 46 contracts emitted, Button + IconButton both show `xs` in their sizes array
- [x] Pure additive — no existing `sm/md/lg` callsite affected
- [ ] Reviewer to verify CI publish step ships v1.1.0 to GH Packages on merge
- [ ] PR-AT2 (next, after this merges) consumes `Button size="xs"` for the atmosphere `xs` and `default` (`h-8 → sm`) callsites cleanly

## Wave 1 status (after this merges)

- 11 of 14 PRs merged
- PR-AT2 unblocked (still needs your `gh auth refresh -s read:packages,write:packages` for the install)