### PR TITLE
docs(zenith): update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,12 @@ packages/
   tokens-atmosphere/  — Atmosphere tokens (gold accent, dark-first themes)
   tokens-creator/     — Creator App tokens (SDUI mappings, mobile-optimized)
   ui/                 — Shared React components (Button, Badge, Card, EmptyState, Skeleton)
+                        Current: v1.1.0
+                        Button sizes: xs (24px) | sm | md | lg
+                        IconButton sizes: xs (24×24) | sm | md | lg
+                        `xs` is a density-mode precursor — intended for data-dense dashboards/tables.
+                        Wave 2 Tier 2 will introduce a compact×cozy orthogonal axis; at that point
+                        `xs` becomes "compact sm" automatically.
   storybook/          — Component documentation and visual testing
   eslint-config/      — Design system lint rules (no-hardcoded-colors, no-raw-spacing, prefer-token-import)
   feature-flags/      — Feature flag utilities


### PR DESCRIPTION
## Summary
- **Trigger:** commit `d40f414`
- **File updated:** `CLAUDE.md`
- **Confidence:** 🟡 0.70
- **Reason:** A new `xs` size variant has been added to Button and IconButton components in @one-impression/ui v1.1.0, which engineers using this design system need to know about when building data-dense UIs or migrating Atmosphere components.

This is an automated documentation update by Zenith. Needs human review.

---
Generated by [Zenith AI CTO](https://github.com/one-impression/zenith-coding-agent)