### PR TITLE
fix(ci): recognise GH Packages 409 Conflict as non-fatal republish (PR-A7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,16 @@ jobs:
               OUTPUT=$(npm publish --access restricted 2>&1) && echo "$OUTPUT" || {
                 EXIT_CODE=$?
                 echo "$OUTPUT"
-                if echo "$OUTPUT" | grep -q 'EPUBLISHCONFLICT\|already been published\|You cannot publish over the previously published versions'; then
+                # Recognise every shape of "this version already exists" the
+                # registry might return. npm CLI emits EPUBLISHCONFLICT, the
+                # legacy npmjs registry says "already been published" /
+                # "You cannot publish over the previously published versions",
+                # and GitHub Packages says "Cannot publish over existing version"
+                # with HTTP 409. Missing any of these silently fails the loop
+                # on a no-op republish and blocks every subsequent package
+                # (PR-A6 incident — Button xs never reached the registry
+                # because tokens-foundation@1.0.0 tripped the 409 first).
+                if echo "$OUTPUT" | grep -qE 'EPUBLISHCONFLICT|already been published|You cannot publish over the previously published versions|Cannot publish over existing version|409 Conflict'; then
                   echo "Package already published at this version — skipping"
                 else
                   echo "::error::Publish failed for $pkg"


### PR DESCRIPTION
## Summary

Real bug found while preparing PR-AT2's lockfile install: **`@one-impression/ui@1.1.0` was never actually published**, because PR-A6's main CI publish loop bailed on the first package due to a regex that doesn't match GH Packages' phrasing of \"already published\".

## What broke

Run `25014457102` (PR-A6 main CI) failed with:
```
npm error 409 Conflict - Cannot publish over existing version
##[error]Publish failed for tokens-foundation
##[error]Process completed with exit code 1.
```

The publish loop attempts every package every time. When it hits a no-op republish (tokens-foundation@1.0.0, unchanged in PR-A6), it should detect the conflict + skip + continue. Instead the regex missed GH Packages' phrasing:

- ✅ Caught: `EPUBLISHCONFLICT` (npm CLI), `already been published` (npmjs.com), `You cannot publish over the previously published versions` (npmjs.com)
- ❌ Missed: `Cannot publish over existing version` (GH Packages), `409 Conflict` (HTTP)

So the loop exited 1 on what should have been a clean skip. Every subsequent package (including the version PR-A6 was specifically about) never got published.

## What this PR does

Extends the regex (switched to `-E` so alternations work without escapes) to also recognise the GH Packages phrasings. Tested locally against the actual error string from run 25014457102 — both new patterns match.

## After this merges

1. Main CI runs and reaches the publish step
2. Already-at-1.0.0 packages skip cleanly via the extended regex
3. `@one-impression/ui@1.1.0` finally lands on the registry (the version PR-A6 introduced)
4. PR-AT2 (#99 in atmosphere) — currently DRAFT awaiting lockfile — unblocks immediately and flips to ready-for-review

## Test plan

- [x] Regex tested locally against the literal error string from the failed run
- [ ] Reviewer to verify on merge: the next main CI run reports \"Package already published — skipping\" for tokens-foundation/brand/atmosphere/creator + eslint-config + mcp-server, then publishes ui@1.1.0
- [ ] After publish, `npm view @one-impression/ui versions` shows `["1.0.0", "1.1.0"]`

## Wave 1 status

15 PRs total in motion. This is the small fix that re-opens the cascade.