### PR TITLE
chore(storybook): rename brand → Amplify Canvas + redirect banner (Phase 1.3)

### DIFF
--- a/packages/storybook/.storybook/manager.ts
+++ b/packages/storybook/.storybook/manager.ts
@@ -3,8 +3,8 @@ import { create } from '@storybook/theming/create';
 
 const amplifyTheme = create({
   base: 'dark',
-  brandTitle: 'Amplify Design System',
-  brandUrl: 'https://github.com/One-Impression/amplify-design-system',
+  brandTitle: 'Amplify Canvas Design System',
+  brandUrl: 'https://canvas.amplify.club',
   colorPrimary: '#6531FF',
   colorSecondary: '#6531FF',
   appBg: '#0a0a0a',

--- a/packages/storybook/public/canvas-banner.html
+++ b/packages/storybook/public/canvas-banner.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html><head>
+<meta http-equiv="refresh" content="6;url=https://canvas.amplify.club/components">
+<title>Canvas Storybook moved</title>
+<style>
+body{font:14px/1.6 system-ui,sans-serif;background:#0a0a0a;color:#fff;margin:0;padding:60px 20px;text-align:center}
+.box{max-width:560px;margin:0 auto;background:#111;border:1px solid #222;border-radius:12px;padding:40px}
+h1{color:#6531FF;margin:0 0 12px;font-size:24px}
+p{color:#999;margin:8px 0}
+a{color:#6531FF;text-decoration:none;font-weight:500}
+a:hover{text-decoration:underline}
+</style>
+</head><body>
+<div class="box">
+<h1>Canvas Storybook has moved</h1>
+<p>The Amplify Canvas component library is now at <a href="https://canvas.amplify.club/components">canvas.amplify.club/components</a>.</p>
+<p>You'll be redirected automatically in a few seconds.</p>
+<p style="margin-top:24px;font-size:12px;color:#666">This GH Pages mirror remains available for 90 days then sunsets on 2026-07-28.</p>
+</div>
+</body></html>


### PR DESCRIPTION
## Summary — Phase 1.3 of the Canvas world-class plan

Updates Storybook branding to "Amplify Canvas Design System" and points the brand mark at `canvas.amplify.club`. Adds a `canvas-banner.html` static page for any deep links during the 90-day GH Pages sunset.

### Changes

| File | What |
|---|---|
| `.storybook/manager.ts` | brandTitle + brandUrl now reference Canvas + canvas.amplify.club |
| `packages/storybook/public/canvas-banner.html` (new) | meta-refresh redirect to canvas.amplify.club/components |

### Sunset plan

| Date | Action |
|---|---|
| 2026-04-28 | `canvas.amplify.club` live (Phase 1.1 deployed) |
| 2026-04-28 → 2026-07-27 | GH Pages Storybook stays live; brand mark points to canvas |
| **2026-07-28** | Disable Storybook GH Pages workflow, redirect domain |

### Out of scope (separate PRs)
- Embedding Storybook into `canvas.amplify.club/components` (Phase 1.2 v2)
- GH-Pages-level 301 redirect (requires custom domain DNS config)
- Per-component deep-link redirects

Pairs with: pixel-agent#78 (canvas public site rename)