### PR TITLE
fix(npmrc): point @amplify scope at public npm (was still pointing at GH Packages)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-@amplify:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+@amplify:registry=https://registry.npmjs.org
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}


### PR DESCRIPTION
## Summary — follow-up to PR #51

PR #51 bulk-renamed `@one-impression` → `@amplify` across the repo. The sweep covered .npmrc's scope name but left the registry URL pointing at GH Packages:

```
# .npmrc on main right now (broken)
@amplify:registry=https://npm.pkg.github.com         ← wrong
//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}  ← wrong
```

Result: post-merge CI failed with `ENEEDAUTH need auth — requires you to be logged in to https://npm.pkg.github.com` because the project .npmrc was telling npm to publish there instead of public npm.

This PR fixes:

```
# .npmrc after this PR
@amplify:registry=https://registry.npmjs.org
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
```

Together with the `publishConfig.registry` on every `package.json` (already set in PR #51), `npm publish` now routes to public npm correctly.

## Still required from you

- Create npm org `amplify` at npmjs.com/org/create
- Generate org-level automation token with publish scope
- Add as repo secret: `gh secret set NPM_TOKEN -R One-Impression/amplify-design-system`

Once those are done, the next CI run on main publishes all 9 `@amplify/*` packages to public npm.