### PR TITLE
ci: skip publish step gracefully when NPM_TOKEN not set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,9 @@ jobs:
         run: npm run build -w packages/storybook
 
       - name: Publish packages
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && env.NPM_TOKEN_SET == 'true'
+        env:
+          NPM_TOKEN_SET: ${{ secrets.NPM_TOKEN != '' }}
         run: |
           set -e
           for pkg in tokens-foundation tokens-brand tokens-atmosphere tokens-creator ui mcp-server eslint-config; do
@@ -100,8 +102,16 @@ jobs:
           # Public npm publishing requires NPM_TOKEN secret (org-level "amplify"
           # publish access). Setup: create npm org "amplify" → generate
           # automation token with "publish" scope → add as NPM_TOKEN secret on
-          # this repo.
+          # this repo. Until that's done, the step's `if:` skips publishing
+          # gracefully so CI stays green on builds + tests.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish skipped (NPM_TOKEN not set)
+        if: github.ref == 'refs/heads/main' && env.NPM_TOKEN_SET != 'true'
+        env:
+          NPM_TOKEN_SET: ${{ secrets.NPM_TOKEN != '' }}
+        run: |
+          echo "::notice title=Publish skipped::NPM_TOKEN secret is not set on this repo. Build + tests passed but @amplify/* was NOT published. To enable publishing: (1) create npm org 'amplify' at npmjs.com/org/create, (2) generate an automation token with publish scope, (3) gh secret set NPM_TOKEN -R One-Impression/amplify-design-system. Then re-run this workflow."
 
   secret-scan:
     name: Secret Scan


### PR DESCRIPTION
## Summary

Without this guard, every push to main fails CI because the publish step runs `npm publish` against an empty `NODE_AUTH_TOKEN` and exits 1 with ENEEDAUTH. That's avoidable noise — builds and tests pass cleanly, only publishing is gated on a secret that's intentionally not set yet (we're awaiting npm org creation).

### After this PR

- Builds + tests + secret scan run on every push (unchanged)
- Publish step runs **only when `secrets.NPM_TOKEN` is set**
- When `NPM_TOKEN` is missing, a GitHub Actions notice surfaces the exact setup steps to enable publishing

### Setup steps (also embedded in the workflow notice)

1. Create org `amplify` at https://www.npmjs.com/org/create (free, public packages)
2. Generate automation token with publish scope
3. `gh secret set NPM_TOKEN -R One-Impression/amplify-design-system`
4. Push any commit to main (or manually re-run "Design System CI") → publish runs

### Why this matters

Currently main shows red on every commit. After merging this, main goes green for everything except publishing — clearer signal of actual code health vs. infra-secret state.

No code changes — workflow only.