### PR TITLE
chore(release): @amplify-ai/* v2.0.1 published to public npm (follow-up to #51)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: 20
           cache: npm
           registry-url: https://registry.npmjs.org
-          scope: '@amplify'
+          scope: '@amplify-ai'
 
       - name: Install dependencies
         run: npm ci
@@ -37,10 +37,10 @@ jobs:
           npm run build -w packages/tokens-creator
           npm run build -w packages/tokens-atmosphere
 
-      - name: Build @amplify/ui
+      - name: Build @amplify-ai/ui
         run: npm run build -w packages/ui
 
-      - name: Build @amplify/mcp-server
+      - name: Build @amplify-ai/mcp-server
         run: npm run build -w packages/mcp-server
 
       - name: Validate cross-package consistency
@@ -77,7 +77,7 @@ jobs:
         run: |
           set -e
           for pkg in tokens-foundation tokens-brand tokens-atmosphere tokens-creator ui mcp-server eslint-config; do
-            echo "Publishing @amplify/$pkg..."
+            echo "Publishing @amplify-ai/$pkg..."
             (
               cd packages/$pkg
               # Public npm — access:public via publishConfig in package.json
@@ -111,7 +111,7 @@ jobs:
         env:
           NPM_TOKEN_SET: ${{ secrets.NPM_TOKEN != '' }}
         run: |
-          echo "::notice title=Publish skipped::NPM_TOKEN secret is not set on this repo. Build + tests passed but @amplify/* was NOT published. To enable publishing: (1) create npm org 'amplify' at npmjs.com/org/create, (2) generate an automation token with publish scope, (3) gh secret set NPM_TOKEN -R One-Impression/amplify-design-system. Then re-run this workflow."
+          echo "::notice title=Publish skipped::NPM_TOKEN secret is not set on this repo. Build + tests passed but @amplify-ai/* was NOT published. To enable publishing: (1) create npm org 'amplify-ai' at npmjs.com/org/create, (2) generate an automation token with publish scope, (3) gh secret set NPM_TOKEN -R One-Impression/amplify-design-system. Then re-run this workflow."
 
   secret-scan:
     name: Secret Scan

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-@amplify:registry=https://registry.npmjs.org
-//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+@amplify-ai:registry=https://registry.npmjs.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the public packages of `amplify-design-system`.
 
 ## [1.1.0] — 2026-04-28
 
-### Added (additive — `@amplify/ui`)
+### Added (additive — `@amplify-ai/ui`)
 
 - **`xs` size variant** on `Button` and `IconButton`. Discovered while preparing the atmosphere migration: data-dense dashboards need a smaller-than-`sm` control (`h-6` = 24px) for tight rows. Without `xs` the alternative would have been forcing every consumer to either accept Canvas's coarser scale or to bypass Canvas with bespoke local primitives — neither acceptable.
 - This is a precursor to the proper density-mode work planned in Wave 2 Tier 2 (`compact` × `cozy` orthogonal axis). Once density lands, `xs` becomes "compact `sm`" automatically; this PR keeps the explicit `xs` opt-out for callsites that want the smaller footprint regardless of density.
@@ -20,36 +20,36 @@ Pure additive — no breaking change. Existing `sm/md/lg` callsites unchanged.
 
 ### Changed (BREAKING — pre-publish)
 
-- **Scope rename: `@amplify/*` → `@amplify/*`** for every published
+- **Scope rename: `@amplify-ai/*` → `@amplify-ai/*`** for every published
   package. The previous `@amplify` scope is not owned by the
   `One-Impression` org, which caused every GH Packages publish attempt
   on the v1.0.0 release to fail with `403 permission_denied`. Renaming
   to a scope that matches the org makes the workflow's automatic
   `GITHUB_TOKEN` sufficient to publish — no extra PAT or org-level
   package settings required.
-- Affected packages: `@amplify/ui`, `@amplify/mcp-server`,
-  `@amplify/tokens-{foundation,brand,atmosphere,creator}`,
-  `@amplify/eslint-config`, `@amplify/templates`,
-  `@amplify/feature-flags`, `@amplify/storybook`.
+- Affected packages: `@amplify-ai/ui`, `@amplify-ai/mcp-server`,
+  `@amplify-ai/tokens-{foundation,brand,atmosphere,creator}`,
+  `@amplify-ai/eslint-config`, `@amplify-ai/templates`,
+  `@amplify-ai/feature-flags`, `@amplify-ai/storybook`.
 - Internal cross-package imports rewired in the same commit so the
   monorepo workspaces still resolve.
 - CI `setup-node` `scope:` updated to match.
-- Consumer install command changes from `@amplify/*` → `@amplify/*`.
+- Consumer install command changes from `@amplify-ai/*` → `@amplify-ai/*`.
 
-This is BREAKING for any external consumer that pinned `@amplify/*` —
+This is BREAKING for any external consumer that pinned `@amplify-ai/*` —
 but since v1.0.0 never actually published to GH Packages, no real
 consumers exist yet. Future migrations will follow standard semver.
 
 ## [1.0.0] — 2026-04-27
 
 ### Added
-- **`@amplify/mcp-server`** — new package. MCP server exposing the Canvas design system to AI agents (Pixel, Claude Code) via stdio + HTTP transports. Five tools: `list_components`, `get_props`, `find_block`, `validate_usage`, `suggest_token`.
-- **`@amplify/ui` JSON contracts** — every build now emits `dist/contracts/<Component>.json` (per-component spec via TypeScript compiler API) and `dist/contracts.json` (manifest). Single source of truth replacing the previous regex extractors. Exposed via subpath exports: `@amplify/ui/contracts`, `@amplify/ui/contracts/*`.
-- **`@amplify/ui` LLM docs** — every build emits `dist/llms.txt` (root index, [llmstxt.org](https://llmstxt.org) spec), `dist/llms/<Component>.md` (per-component rule sheets), and `dist/llms.json` (flat mirror). Exposed via subpath exports: `@amplify/ui/llms.txt`, `@amplify/ui/llms.json`, `@amplify/ui/llms/*`.
+- **`@amplify-ai/mcp-server`** — new package. MCP server exposing the Canvas design system to AI agents (Pixel, Claude Code) via stdio + HTTP transports. Five tools: `list_components`, `get_props`, `find_block`, `validate_usage`, `suggest_token`.
+- **`@amplify-ai/ui` JSON contracts** — every build now emits `dist/contracts/<Component>.json` (per-component spec via TypeScript compiler API) and `dist/contracts.json` (manifest). Single source of truth replacing the previous regex extractors. Exposed via subpath exports: `@amplify-ai/ui/contracts`, `@amplify-ai/ui/contracts/*`.
+- **`@amplify-ai/ui` LLM docs** — every build emits `dist/llms.txt` (root index, [llmstxt.org](https://llmstxt.org) spec), `dist/llms/<Component>.md` (per-component rule sheets), and `dist/llms.json` (flat mirror). Exposed via subpath exports: `@amplify-ai/ui/llms.txt`, `@amplify-ai/ui/llms.json`, `@amplify-ai/ui/llms/*`.
 
 ### Changed
-- **`@amplify/ui` 0.1.0 → 1.0.0** — first stable release. Component API surface (46 components), variants, and prop signatures are now stable; future breaking changes will follow semver and ship with codemods (planned, Wave 2).
-- CI publish loop now ships `@amplify/mcp-server` alongside the existing token packages, `@amplify/ui`, and `@amplify/eslint-config`.
+- **`@amplify-ai/ui` 0.1.0 → 1.0.0** — first stable release. Component API surface (46 components), variants, and prop signatures are now stable; future breaking changes will follow semver and ship with codemods (planned, Wave 2).
+- CI publish loop now ships `@amplify-ai/mcp-server` alongside the existing token packages, `@amplify-ai/ui`, and `@amplify-ai/eslint-config`.
 
 ### Notes
 - This release closes Wave 1 of the Canvas 100x program. Pixel and Claude Code can now consume Canvas through a structured contract instead of carrying hardcoded component lists.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Federated design tokens and shared UI components for all One Impression products
                     |  - Figma sync          |
                     +----------+-------------+
                                |
-                    npm install @amplify/tokens-*
+                    npm install @amplify-ai/tokens-*
                                |
           +--------------------+--------------------+
           |                    |                    |
@@ -50,7 +50,7 @@ Federated design tokens and shared UI components for all One Impression products
 |----------------|------------|
 | Stores token JSON source files | Governs token changes (approval workflows) |
 | Builds CSS/JS/RN output via Style Dictionary | Detects token drift (Pixel vs code) |
-| Publishes npm packages (@amplify/*) | Cascades brand changes across products |
+| Publishes npm packages (@amplify-ai/*) | Cascades brand changes across products |
 | Houses React UI components | Reviews PR design compliance |
 | Runs Storybook for component docs | Audits accessibility (WCAG 2.1 AA) |
 | Provides ESLint rules | Generates design mockups & handoff specs |
@@ -62,13 +62,13 @@ Federated design tokens and shared UI components for all One Impression products
 
 | Package | Purpose | Consumer |
 |---------|---------|----------|
-| `@amplify/tokens-foundation` | Shared primitives (spacing, radii, shadows, typography) | All products |
-| `@amplify/tokens-brand` | Brand platform colors & theme | one-dashboard-web |
-| `@amplify/tokens-atmosphere` | Atmosphere dashboard colors & theme | odin-agent/web |
-| `@amplify/tokens-creator` | Creator app colors & SDUI mapping | one_club_app |
-| `@amplify/ui` | Shared React UI components | Web products |
-| `@amplify/eslint-config` | Design system lint rules | All products |
-| `@amplify/feature-flags` | Feature flag utilities | All products |
+| `@amplify-ai/tokens-foundation` | Shared primitives (spacing, radii, shadows, typography) | All products |
+| `@amplify-ai/tokens-brand` | Brand platform colors & theme | one-dashboard-web |
+| `@amplify-ai/tokens-atmosphere` | Atmosphere dashboard colors & theme | odin-agent/web |
+| `@amplify-ai/tokens-creator` | Creator app colors & SDUI mapping | one_club_app |
+| `@amplify-ai/ui` | Shared React UI components | Web products |
+| `@amplify-ai/eslint-config` | Design system lint rules | All products |
+| `@amplify-ai/feature-flags` | Feature flag utilities | All products |
 
 ## Token Flow
 
@@ -77,7 +77,7 @@ Federated design tokens and shared UI components for all One Impression products
 3. **GitHub Actions** builds all packages, validates, creates PR
 4. On merge: npm publish + **Pixel** detects update via scheduled drift check
 5. Pixel runs brand cascade → identifies affected products → generates fix PRs
-6. Products `npm update @amplify/tokens-*` to adopt changes
+6. Products `npm update @amplify-ai/tokens-*` to adopt changes
 
 ## Pixel Integration Points
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,43 +21,43 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@amplify/eslint-config": {
+    "node_modules/@amplify-ai/eslint-config": {
       "resolved": "packages/eslint-config",
       "link": true
     },
-    "node_modules/@amplify/feature-flags": {
+    "node_modules/@amplify-ai/feature-flags": {
       "resolved": "packages/feature-flags",
       "link": true
     },
-    "node_modules/@amplify/mcp-server": {
+    "node_modules/@amplify-ai/mcp-server": {
       "resolved": "packages/mcp-server",
       "link": true
     },
-    "node_modules/@amplify/storybook": {
+    "node_modules/@amplify-ai/storybook": {
       "resolved": "packages/storybook",
       "link": true
     },
-    "node_modules/@amplify/templates": {
+    "node_modules/@amplify-ai/templates": {
       "resolved": "packages/templates",
       "link": true
     },
-    "node_modules/@amplify/tokens-atmosphere": {
+    "node_modules/@amplify-ai/tokens-atmosphere": {
       "resolved": "packages/tokens-atmosphere",
       "link": true
     },
-    "node_modules/@amplify/tokens-brand": {
+    "node_modules/@amplify-ai/tokens-brand": {
       "resolved": "packages/tokens-brand",
       "link": true
     },
-    "node_modules/@amplify/tokens-creator": {
+    "node_modules/@amplify-ai/tokens-creator": {
       "resolved": "packages/tokens-creator",
       "link": true
     },
-    "node_modules/@amplify/tokens-foundation": {
+    "node_modules/@amplify-ai/tokens-foundation": {
       "resolved": "packages/tokens-foundation",
       "link": true
     },
-    "node_modules/@amplify/ui": {
+    "node_modules/@amplify-ai/ui": {
       "resolved": "packages/ui",
       "link": true
     },
@@ -10784,21 +10784,21 @@
       }
     },
     "packages/eslint-config": {
-      "name": "@amplify/eslint-config",
+      "name": "@amplify-ai/eslint-config",
       "version": "2.0.0",
       "peerDependencies": {
         "eslint": ">=8.0.0"
       }
     },
     "packages/feature-flags": {
-      "name": "@amplify/feature-flags",
+      "name": "@amplify-ai/feature-flags",
       "version": "2.0.0",
       "peerDependencies": {
         "react": ">=17.0.0"
       }
     },
     "packages/mcp-server": {
-      "name": "@amplify/mcp-server",
+      "name": "@amplify-ai/mcp-server",
       "version": "2.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
@@ -10816,10 +10816,10 @@
       }
     },
     "packages/storybook": {
-      "name": "@amplify/storybook",
+      "name": "@amplify-ai/storybook",
       "version": "0.1.0",
       "devDependencies": {
-        "@amplify/ui": "*",
+        "@amplify-ai/ui": "*",
         "@storybook/addon-a11y": "^8.4.0",
         "@storybook/addon-essentials": "^8.4.0",
         "@storybook/blocks": "^8.4.0",
@@ -10837,11 +10837,11 @@
       }
     },
     "packages/templates": {
-      "name": "@amplify/templates",
+      "name": "@amplify-ai/templates",
       "version": "2.0.0",
       "dependencies": {
-        "@amplify/tokens-brand": "^2.0.0",
-        "@amplify/ui": "^2.0.0"
+        "@amplify-ai/tokens-brand": "^2.0.0",
+        "@amplify-ai/ui": "^2.0.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.0",
@@ -10879,44 +10879,44 @@
       }
     },
     "packages/tokens-atmosphere": {
-      "name": "@amplify/tokens-atmosphere",
+      "name": "@amplify-ai/tokens-atmosphere",
       "version": "2.0.0",
       "dependencies": {
-        "@amplify/tokens-foundation": "^2.0.0"
+        "@amplify-ai/tokens-foundation": "^2.0.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
     },
     "packages/tokens-brand": {
-      "name": "@amplify/tokens-brand",
+      "name": "@amplify-ai/tokens-brand",
       "version": "2.0.0",
       "dependencies": {
-        "@amplify/tokens-foundation": "^2.0.0"
+        "@amplify-ai/tokens-foundation": "^2.0.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
     },
     "packages/tokens-creator": {
-      "name": "@amplify/tokens-creator",
+      "name": "@amplify-ai/tokens-creator",
       "version": "2.0.0",
       "dependencies": {
-        "@amplify/tokens-foundation": "^2.0.0"
+        "@amplify-ai/tokens-foundation": "^2.0.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
     },
     "packages/tokens-foundation": {
-      "name": "@amplify/tokens-foundation",
+      "name": "@amplify-ai/tokens-foundation",
       "version": "2.0.0",
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
     },
     "packages/ui": {
-      "name": "@amplify/ui",
+      "name": "@amplify-ai/ui",
       "version": "2.0.0",
       "dependencies": {
         "clsx": "^2.1.0",

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,14 +1,14 @@
 /**
- * @amplify/eslint-config — Shared ESLint flat config
+ * @amplify-ai/eslint-config — Shared ESLint flat config
  *
  * Enforces Amplify design token usage across consuming projects.
  *
  * Usage (eslint.config.js):
- *   import amplifyConfig from '@amplify/eslint-config';
+ *   import amplifyConfig from '@amplify-ai/eslint-config';
  *   export default [...amplifyConfig];
  *
  * Or CommonJS:
- *   const amplifyConfig = require('@amplify/eslint-config');
+ *   const amplifyConfig = require('@amplify-ai/eslint-config');
  *   module.exports = [...amplifyConfig];
  */
 
@@ -22,7 +22,7 @@ const noHardcodedTypography = require('./rules/no-hardcoded-typography');
 
 const plugin = {
   meta: {
-    name: '@amplify/eslint-plugin',
+    name: '@amplify-ai/eslint-plugin',
     version: '2.0.0',
   },
   rules: {
@@ -39,16 +39,16 @@ const plugin = {
 module.exports = [
   {
     plugins: {
-      '@amplify': plugin,
+      '@amplify-ai': plugin,
     },
     rules: {
-      '@amplify/no-hardcoded-colors': 'warn',
-      '@amplify/no-raw-spacing': 'warn',
-      '@amplify/prefer-token-import': 'warn',
-      '@amplify/no-inline-styles': 'warn',
-      '@amplify/no-raw-surface': 'warn',
-      '@amplify/no-hardcoded-radius': 'warn',
-      '@amplify/no-hardcoded-typography': 'warn',
+      '@amplify-ai/no-hardcoded-colors': 'warn',
+      '@amplify-ai/no-raw-spacing': 'warn',
+      '@amplify-ai/prefer-token-import': 'warn',
+      '@amplify-ai/no-inline-styles': 'warn',
+      '@amplify-ai/no-raw-surface': 'warn',
+      '@amplify-ai/no-hardcoded-radius': 'warn',
+      '@amplify-ai/no-hardcoded-typography': 'warn',
     },
   },
 ];

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@amplify/eslint-config",
-  "version": "2.0.0",
+  "name": "@amplify-ai/eslint-config",
+  "version": "2.0.1",
   "description": "Shared ESLint config enforcing Amplify design token usage",
   "main": "index.js",
   "scripts": {},
@@ -10,9 +10,5 @@
   "files": [
     "index.js",
     "rules/"
-  ],
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org",
-    "access": "public"
-  }
+  ]
 }

--- a/packages/eslint-config/rules/no-hardcoded-radius.js
+++ b/packages/eslint-config/rules/no-hardcoded-radius.js
@@ -1,5 +1,5 @@
 /**
- * @amplify/no-hardcoded-radius
+ * @amplify-ai/no-hardcoded-radius
  *
  * Flags Tailwind hardcoded border-radius classes. Use design token radii instead:
  *   rounded-[var(--radius-card)]  — 16px, for cards and containers

--- a/packages/eslint-config/rules/no-hardcoded-typography.js
+++ b/packages/eslint-config/rules/no-hardcoded-typography.js
@@ -1,5 +1,5 @@
 /**
- * @amplify/no-hardcoded-typography
+ * @amplify-ai/no-hardcoded-typography
  *
  * Flags arbitrary pixel font sizes in Tailwind classes like text-[13px], text-[11px].
  * Use Tailwind's built-in scale instead:

--- a/packages/eslint-config/rules/no-inline-styles.js
+++ b/packages/eslint-config/rules/no-inline-styles.js
@@ -1,5 +1,5 @@
 /**
- * @amplify/no-inline-styles
+ * @amplify-ai/no-inline-styles
  *
  * Flags inline style={{}} objects in JSX. These bypass the design token system
  * and can't be themed, audited, or updated globally.

--- a/packages/eslint-config/rules/no-raw-spacing.js
+++ b/packages/eslint-config/rules/no-raw-spacing.js
@@ -1,5 +1,5 @@
 /**
- * @amplify/eslint-config — no-raw-spacing
+ * @amplify-ai/eslint-config — no-raw-spacing
  * Warns when raw pixel values are used in style props where spacing tokens exist.
  */
 module.exports = {

--- a/packages/eslint-config/rules/no-raw-surface.js
+++ b/packages/eslint-config/rules/no-raw-surface.js
@@ -1,5 +1,5 @@
 /**
- * @amplify/no-raw-surface
+ * @amplify-ai/no-raw-surface
  *
  * Flags bg-[var(--surface-elevated/secondary/tertiary/overlay)] without a visible
  * boundary (ring, border, or shadow). In light mode, elevated surfaces are white

--- a/packages/eslint-config/rules/prefer-token-import.js
+++ b/packages/eslint-config/rules/prefer-token-import.js
@@ -1,19 +1,19 @@
 /**
- * @amplify/eslint-config — prefer-token-import
- * Warns when importing from legacy token paths instead of @amplify/tokens-*.
+ * @amplify-ai/eslint-config — prefer-token-import
+ * Warns when importing from legacy token paths instead of @amplify-ai/tokens-*.
  */
 module.exports = {
   meta: {
     type: 'suggestion',
-    docs: { description: 'Prefer @amplify/tokens-* imports over legacy token paths' },
+    docs: { description: 'Prefer @amplify-ai/tokens-* imports over legacy token paths' },
     messages: { preferAmplifyTokens: 'Import from "{{ suggested }}" instead of legacy path "{{ source }}".' },
     schema: [],
   },
   create(context) {
     const LEGACY_PATTERNS = [
-      { pattern: /^@oneimpression\/tokens/, suggested: '@amplify/tokens-brand' },
-      { pattern: /\.\.\/.*styles\/colors/, suggested: '@amplify/tokens-creator or @amplify/tokens-brand' },
-      { pattern: /\.\.\/.*design-tokens/, suggested: '@amplify/tokens-brand' },
+      { pattern: /^@oneimpression\/tokens/, suggested: '@amplify-ai/tokens-brand' },
+      { pattern: /\.\.\/.*styles\/colors/, suggested: '@amplify-ai/tokens-creator or @amplify-ai/tokens-brand' },
+      { pattern: /\.\.\/.*design-tokens/, suggested: '@amplify-ai/tokens-brand' },
     ];
     return {
       ImportDeclaration(node) {

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@amplify/feature-flags",
-  "version": "2.0.0",
+  "name": "@amplify-ai/feature-flags",
+  "version": "2.0.1",
   "description": "Feature flag client and React hooks for Amplify platform",
   "main": "src/index.ts",
   "exports": {
@@ -13,9 +13,5 @@
   },
   "files": [
     "src/"
-  ],
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org",
-    "access": "public"
-  }
+  ]
 }

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,4 +1,4 @@
-# @amplify/mcp-server
+# @amplify-ai/mcp-server
 
 MCP server exposing the Amplify Canvas design system to AI agents (Pixel, Claude Code, etc.).
 
@@ -6,7 +6,7 @@ MCP server exposing the Amplify Canvas design system to AI agents (Pixel, Claude
 
 | Tool | Purpose |
 |------|---------|
-| `list_components` | All components in `@amplify/ui` with one-line descriptions and tags. |
+| `list_components` | All components in `@amplify-ai/ui` with one-line descriptions and tags. |
 | `get_props` | Full prop signature for a component (variants, sizes, states, required props). |
 | `find_block` | Search the templates package for blocks matching a use case (e.g. "checkout", "stepper"). |
 | `validate_usage` | Validate a JSX snippet against component contracts — reports invalid props/values. |
@@ -37,7 +37,7 @@ Add to `~/.claude/.mcp.json`:
   "mcpServers": {
     "canvas": {
       "command": "npx",
-      "args": ["-y", "@amplify/mcp-server"]
+      "args": ["-y", "@amplify-ai/mcp-server"]
     }
   }
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@amplify/mcp-server",
-  "version": "2.0.0",
+  "name": "@amplify-ai/mcp-server",
+  "version": "2.0.1",
   "description": "MCP server exposing the Amplify Canvas design system to AI agents (Pixel, Claude Code).",
   "type": "module",
   "main": "dist/index.js",
@@ -42,9 +42,5 @@
     "tsup": "^8.0.0",
     "tsx": "^4.16.0",
     "typescript": "^5.4.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org",
-    "access": "public"
   }
 }

--- a/packages/mcp-server/src/data/components.ts
+++ b/packages/mcp-server/src/data/components.ts
@@ -38,7 +38,7 @@ const candidateContractsManifests = [
   resolve(here, '../../../ui/dist/contracts.json'),
   resolve(here, '../../../../ui/dist/contracts.json'),
   resolve(process.cwd(), 'packages/ui/dist/contracts.json'),
-  resolve(process.cwd(), 'node_modules/@amplify/ui/dist/contracts.json'),
+  resolve(process.cwd(), 'node_modules/@amplify-ai/ui/dist/contracts.json'),
 ];
 
 const candidateComponentRoots = [

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -13,7 +13,7 @@ const main = async (): Promise<void> => {
   const http = createServer(async (req, res) => {
     if (req.url === '/health') {
       res.writeHead(200, { 'content-type': 'application/json' });
-      res.end(JSON.stringify({ status: 'ok', server: '@amplify/mcp-server' }));
+      res.end(JSON.stringify({ status: 'ok', server: '@amplify-ai/mcp-server' }));
       return;
     }
     await transport.handleRequest(req, res);

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 const tools = [
   {
     name: 'list_components',
-    description: 'List components in @amplify/ui with their variants, sizes, and forwardRef status.',
+    description: 'List components in @amplify-ai/ui with their variants, sizes, and forwardRef status.',
     schema: listComponentsSchema,
     handler: listComponents,
   },
@@ -60,7 +60,7 @@ const zodToInputSchema = (schema: z.ZodTypeAny): Record<string, unknown> => {
 
 export const createCanvasServer = (): Server => {
   const server = new Server(
-    { name: '@amplify/mcp-server', version: '0.1.0' },
+    { name: '@amplify-ai/mcp-server', version: '0.1.0' },
     { capabilities: { tools: {} } }
   );
 

--- a/packages/mcp-server/src/tools/validate-usage.ts
+++ b/packages/mcp-server/src/tools/validate-usage.ts
@@ -27,7 +27,7 @@ export const validateUsage = (input: ValidateUsageInput) => {
     return {
       valid: false,
       tag,
-      issues: [{ level: 'error' as const, message: `Component "${tag}" not in @amplify/ui.` }],
+      issues: [{ level: 'error' as const, message: `Component "${tag}" not in @amplify-ai/ui.` }],
     };
   }
 

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify/storybook",
+  "name": "@amplify-ai/storybook",
   "version": "0.1.0",
   "private": true,
   "description": "Storybook for Amplify Design System — component documentation and visual testing",
@@ -22,7 +22,7 @@
     "vite": "^6.0.0",
     "typescript": "^5.5.0",
     "tailwindcss": "^4.0.0",
-    "@amplify/ui": "*",
+    "@amplify-ai/ui": "*",
     "chromatic": "^11.0.0"
   }
 }

--- a/packages/storybook/stories/Badge.stories.tsx
+++ b/packages/storybook/stories/Badge.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Badge } from '@amplify/ui';
+import { Badge } from '@amplify-ai/ui';
 
 const meta = {
   title: 'Components/Badge',

--- a/packages/storybook/stories/Button.stories.tsx
+++ b/packages/storybook/stories/Button.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Button } from '@amplify/ui';
+import { Button } from '@amplify-ai/ui';
 
 const meta = {
   title: 'Components/Button',

--- a/packages/storybook/stories/Card.stories.tsx
+++ b/packages/storybook/stories/Card.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Card } from '@amplify/ui';
+import { Card } from '@amplify-ai/ui';
 
 const meta = {
   title: 'Components/Card',

--- a/packages/storybook/stories/Density.stories.tsx
+++ b/packages/storybook/stories/Density.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Button, DensityProvider, type Density } from '@amplify/ui';
+import { Button, DensityProvider, type Density } from '@amplify-ai/ui';
 
 const meta = {
   title: 'Foundation/Density',
@@ -14,7 +14,7 @@ Select, Chip, etc. follow) read the ambient density via \`useDensity()\`
 and select the density-appropriate row from their size table.
 
 \`\`\`tsx
-import { DensityProvider, Button } from '@amplify/ui';
+import { DensityProvider, Button } from '@amplify-ai/ui';
 
 <DensityProvider density="compact">
   <Button size="sm">Save</Button>     {/* renders h-7 */}

--- a/packages/storybook/stories/EmptyState.stories.tsx
+++ b/packages/storybook/stories/EmptyState.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { EmptyState } from '@amplify/ui';
+import { EmptyState } from '@amplify-ai/ui';
 
 const meta = {
   title: 'Components/EmptyState',

--- a/packages/storybook/stories/Skeleton.stories.tsx
+++ b/packages/storybook/stories/Skeleton.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Skeleton } from '@amplify/ui';
+import { Skeleton } from '@amplify-ai/ui';
 
 const meta = {
   title: 'Components/Skeleton',

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@amplify/templates",
-  "version": "2.0.0",
+  "name": "@amplify-ai/templates",
+  "version": "2.0.1",
   "description": "React SSR template engine for instant interactive mockups \u2014 100% Canvas design system compliant",
   "type": "module",
   "main": "dist/index.js",
@@ -12,8 +12,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@amplify/ui": "^2.0.0",
-    "@amplify/tokens-brand": "^2.0.0"
+    "@amplify-ai/ui": "^2.0.1",
+    "@amplify-ai/tokens-brand": "^2.0.1"
   },
   "peerDependencies": {
     "react": ">=18.0.0",
@@ -27,9 +27,5 @@
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.5.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org",
-    "access": "public"
   }
 }

--- a/packages/templates/src/base-css.ts
+++ b/packages/templates/src/base-css.ts
@@ -8,7 +8,7 @@ export function getBaseCSS(): string {
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--amp-font);background:var(--amp-bg);color:var(--amp-text);font-size:var(--amp-text-base);line-height:1.5;min-height:100vh;-webkit-font-smoothing:antialiased}
 
-/* ═══ Card — matches @amplify/ui Card component ═══ */
+/* ═══ Card — matches @amplify-ai/ui Card component ═══ */
 /* Default: rounded-[16px] border border-[border-default] bg-[bg-surface] */
 .amp-card{background:var(--amp-surface);border-radius:var(--amp-radius-xl);border:1px solid var(--amp-border);transition:all var(--amp-transition);overflow:hidden}
 /* Interactive variant: hover:shadow-lg */
@@ -21,7 +21,7 @@ body{font-family:var(--amp-font);background:var(--amp-bg);color:var(--amp-text);
 /* Elevated variant */
 .amp-card.elevated{box-shadow:var(--amp-shadow-lg)}
 
-/* ═══ Button — matches @amplify/ui Button component ═══ */
+/* ═══ Button — matches @amplify-ai/ui Button component ═══ */
 /* Base: inline-flex items-center justify-center font-medium transition-all duration-150 */
 .amp-btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;height:40px;padding:0 16px;border-radius:6px;font-size:var(--amp-text-base);font-weight:500;border:none;cursor:pointer;transition:all 150ms ease;font-family:var(--amp-font);outline:none}
 .amp-btn:focus-visible{outline:none;box-shadow:0 0 0 2px var(--amp-surface),0 0 0 4px rgba(101,49,255,0.4)}
@@ -52,7 +52,7 @@ body{font-family:var(--amp-font);background:var(--amp-bg);color:var(--amp-text);
 /* Full width */
 .amp-btn-full{width:100%}
 
-/* ═══ Input — matches @amplify/ui Input component ═══ */
+/* ═══ Input — matches @amplify-ai/ui Input component ═══ */
 /* h-10 px-3 rounded-[16px] text-[14px] border border-[border-default] */
 .amp-input{width:100%;height:40px;padding:0 12px;border:1px solid var(--amp-border);border-radius:var(--amp-radius-xl);font-size:var(--amp-text-base);font-family:var(--amp-font);background:var(--amp-surface);color:var(--amp-text);outline:none;transition:colors 150ms ease}
 .amp-input::placeholder{color:var(--amp-text-muted)}
@@ -60,12 +60,12 @@ body{font-family:var(--amp-font);background:var(--amp-bg);color:var(--amp-text);
 textarea.amp-input{height:auto;min-height:80px;padding:var(--amp-sp-3) 12px;resize:vertical}
 select.amp-input{appearance:none;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 12px center;padding-right:32px}
 
-/* ═══ Chip — matches @amplify/ui chip-like patterns ═══ */
+/* ═══ Chip — matches @amplify-ai/ui chip-like patterns ═══ */
 .amp-chip{display:inline-flex;align-items:center;gap:6px;padding:var(--amp-sp-1) var(--amp-sp-3);border-radius:var(--amp-radius-full);font-size:var(--amp-text-sm);font-weight:500;border:1px solid var(--amp-border);background:var(--amp-surface);color:var(--amp-text-secondary);cursor:pointer;transition:all 150ms ease;user-select:none}
 .amp-chip:hover{border-color:var(--amp-border-strong);background:var(--amp-surface-overlay)}
 .amp-chip.active{background:var(--amp-accent);border-color:var(--amp-accent);color:#fff}
 
-/* ═══ Badge — matches @amplify/ui Badge component ═══ */
+/* ═══ Badge — matches @amplify-ai/ui Badge component ═══ */
 /* Base: inline-flex items-center gap-1.5 font-medium whitespace-nowrap */
 .amp-badge{display:inline-flex;align-items:center;gap:6px;padding:2px 10px;border-radius:6px;font-size:var(--amp-text-sm);font-weight:500;white-space:nowrap}
 /* Brand: bg-brand-light text-brand border border-brand/20 */

--- a/packages/templates/src/components/ordering/BudgetSection.tsx
+++ b/packages/templates/src/components/ordering/BudgetSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Badge } from '@amplify/ui';
+import { Card, Badge } from '@amplify-ai/ui';
 import type { ComponentRenderer } from '../../registry';
 
 interface PackageItem {

--- a/packages/templates/src/components/ordering/Checkout.tsx
+++ b/packages/templates/src/components/ordering/Checkout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Button } from '@amplify/ui';
+import { Card, Button } from '@amplify-ai/ui';
 import type { ComponentRenderer } from '../../registry';
 
 export const Checkout: ComponentRenderer = ({ props, context }) => {

--- a/packages/templates/src/components/ordering/ContentType.tsx
+++ b/packages/templates/src/components/ordering/ContentType.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Badge, Button } from '@amplify/ui';
+import { Card, Badge, Button } from '@amplify-ai/ui';
 import type { ComponentRenderer } from '../../registry';
 
 export const ContentType: ComponentRenderer = ({ props }) => {

--- a/packages/templates/src/components/ordering/GoalCards.tsx
+++ b/packages/templates/src/components/ordering/GoalCards.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, CardContent } from '@amplify/ui';
+import { Card, CardContent } from '@amplify-ai/ui';
 import type { ComponentRenderer } from '../../registry';
 
 const defaultGoals = [

--- a/packages/templates/src/components/ordering/Intelligence.tsx
+++ b/packages/templates/src/components/ordering/Intelligence.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Badge } from '@amplify/ui';
+import { Card, Badge } from '@amplify-ai/ui';
 import type { ComponentRenderer } from '../../registry';
 
 export const Intelligence: ComponentRenderer = () => {

--- a/packages/templates/src/components/ordering/ProductScanner.tsx
+++ b/packages/templates/src/components/ordering/ProductScanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card } from '@amplify/ui';
+import { Card } from '@amplify-ai/ui';
 import type { ComponentRenderer } from '../../registry';
 
 const defaultRecentProducts = [

--- a/packages/templates/src/components/ordering/RepeatBanner.tsx
+++ b/packages/templates/src/components/ordering/RepeatBanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@amplify/ui';
+import { Button } from '@amplify-ai/ui';
 import type { ComponentRenderer } from '../../registry';
 
 export const RepeatBanner: ComponentRenderer = ({ props }) => {

--- a/packages/templates/src/components/ordering/ScriptPreview.tsx
+++ b/packages/templates/src/components/ordering/ScriptPreview.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Badge } from '@amplify/ui';
+import { Card, Badge } from '@amplify-ai/ui';
 import type { ComponentRenderer } from '../../registry';
 
 interface Script {

--- a/packages/templates/src/components/ordering/SuccessModal.tsx
+++ b/packages/templates/src/components/ordering/SuccessModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@amplify/ui';
+import { Button } from '@amplify-ai/ui';
 import type { ComponentRenderer } from '../../registry';
 
 export const SuccessModal: ComponentRenderer = () => {

--- a/packages/templates/src/dev-server.tsx
+++ b/packages/templates/src/dev-server.tsx
@@ -18,7 +18,7 @@ const server = createServer((req, res) => {
 <style>body{font-family:Inter,system-ui,sans-serif;max-width:640px;margin:40px auto;padding:0 20px}
 a{color:#7C3AED;text-decoration:none}a:hover{text-decoration:underline}
 li{margin:8px 0;font-size:16px}h1{color:#1C1917}</style></head>
-<body><h1>@amplify/templates Dev Server</h1><ul>${links}</ul></body></html>`);
+<body><h1>@amplify-ai/templates Dev Server</h1><ul>${links}</ul></body></html>`);
     return;
   }
 

--- a/packages/templates/src/layouts/ScrollLayout.tsx
+++ b/packages/templates/src/layouts/ScrollLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@amplify/ui';
+import { Button } from '@amplify-ai/ui';
 import type { TemplateConfig } from '../render';
 import { renderComponent } from '../registry';
 

--- a/packages/templates/src/layouts/StepperLayout.tsx
+++ b/packages/templates/src/layouts/StepperLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@amplify/ui';
+import { Button } from '@amplify-ai/ui';
 import type { TemplateConfig } from '../render';
 import { renderComponent } from '../registry';
 

--- a/packages/templates/src/tokens.ts
+++ b/packages/templates/src/tokens.ts
@@ -53,7 +53,7 @@ export function getTokensCSS(_product = 'brand'): string {
   --amp-accent-hover: #752AD4;
   --amp-accent-light: #EDEAFC;
 
-  /* Semantic aliases for @amplify/ui components */
+  /* Semantic aliases for @amplify-ai/ui components */
   --amp-semantic-text-primary: var(--amp-stone-900);
   --amp-semantic-text-secondary: var(--amp-stone-600);
   --amp-semantic-text-muted: var(--amp-stone-500);
@@ -93,7 +93,7 @@ export function getTokensCSS(_product = 'brand'): string {
   /* Transitions */
   --amp-transition: 150ms ease;
 
-  /* Tailwind-mapped tokens for @amplify/ui components */
+  /* Tailwind-mapped tokens for @amplify-ai/ui components */
   --color-brand: var(--amp-violet-600);
   --color-brand-dark: var(--amp-violet-700);
   --color-brand-light: var(--amp-violet-50);

--- a/packages/tokens-atmosphere/package.json
+++ b/packages/tokens-atmosphere/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@amplify/tokens-atmosphere",
-  "version": "2.0.0",
+  "name": "@amplify-ai/tokens-atmosphere",
+  "version": "2.0.1",
   "description": "Amplify Atmosphere (internal tools) design tokens",
   "main": "dist/tokens.js",
   "exports": {
@@ -13,7 +13,7 @@
     "build": "node build.js"
   },
   "dependencies": {
-    "@amplify/tokens-foundation": "^2.0.0"
+    "@amplify-ai/tokens-foundation": "^2.0.1"
   },
   "devDependencies": {
     "style-dictionary": "^4.3.0"
@@ -21,9 +21,5 @@
   "files": [
     "dist/",
     "tokens/"
-  ],
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org",
-    "access": "public"
-  }
+  ]
 }

--- a/packages/tokens-brand/package.json
+++ b/packages/tokens-brand/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@amplify/tokens-brand",
-  "version": "2.0.0",
+  "name": "@amplify-ai/tokens-brand",
+  "version": "2.0.1",
   "description": "Amplify Brand Platform design tokens \u2014 colors, typography for brand dashboard",
   "main": "dist/tailwind-preset.js",
   "exports": {
@@ -15,7 +15,7 @@
     "build": "node build.js"
   },
   "dependencies": {
-    "@amplify/tokens-foundation": "^2.0.0"
+    "@amplify-ai/tokens-foundation": "^2.0.1"
   },
   "devDependencies": {
     "style-dictionary": "^4.3.0"
@@ -23,9 +23,5 @@
   "files": [
     "dist/",
     "tokens/"
-  ],
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org",
-    "access": "public"
-  }
+  ]
 }

--- a/packages/tokens-creator/package.json
+++ b/packages/tokens-creator/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@amplify/tokens-creator",
-  "version": "2.0.0",
+  "name": "@amplify-ai/tokens-creator",
+  "version": "2.0.1",
   "description": "Amplify Creator App design tokens \u2014 SDUI theme colors, typography, and component tokens",
   "main": "dist/tokens.js",
   "exports": {
@@ -15,7 +15,7 @@
     "sync-check": "node scripts/sync-check.js"
   },
   "dependencies": {
-    "@amplify/tokens-foundation": "^2.0.0"
+    "@amplify-ai/tokens-foundation": "^2.0.1"
   },
   "devDependencies": {
     "style-dictionary": "^4.3.0"
@@ -24,9 +24,5 @@
     "dist/",
     "tokens/",
     "scripts/"
-  ],
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org",
-    "access": "public"
-  }
+  ]
 }

--- a/packages/tokens-foundation/package.json
+++ b/packages/tokens-foundation/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@amplify/tokens-foundation",
-  "version": "2.0.0",
+  "name": "@amplify-ai/tokens-foundation",
+  "version": "2.0.1",
   "description": "Amplify Design System \u2014 shared foundation tokens (spacing, radii, shadows, breakpoints, z-index)",
   "main": "dist/tokens.js",
   "exports": {
@@ -19,9 +19,5 @@
   "files": [
     "dist/",
     "tokens/"
-  ],
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org",
-    "access": "public"
-  }
+  ]
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@amplify/ui",
-  "version": "2.0.0",
+  "name": "@amplify-ai/ui",
+  "version": "2.0.1",
   "description": "Shared UI components for Amplify products \u2014 Brand, Creator, and Atmosphere",
   "type": "module",
   "main": "dist/index.js",
@@ -57,9 +57,5 @@
   "dependencies": {
     "clsx": "^2.1.0",
     "tailwind-merge": "^2.3.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org",
-    "access": "public"
   }
 }

--- a/packages/ui/scripts/generate-contracts.mjs
+++ b/packages/ui/scripts/generate-contracts.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Generate JSON component contracts from @amplify/ui source.
+ * Generate JSON component contracts from @amplify-ai/ui source.
  *
  * Uses the real TypeScript compiler API (vs. the regex extractors in
  * scripts/generate-llms-docs.mjs and packages/mcp-server) so resolved

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,10 +1,10 @@
 /**
- * @amplify/ui — Shared UI Components for Amplify Products
+ * @amplify-ai/ui — Shared UI Components for Amplify Products
  *
  * Import from here, not from individual component files.
  *
  * @example
- * import { Button, Badge, Card, Input, Dialog } from '@amplify/ui';
+ * import { Button, Badge, Card, Input, Dialog } from '@amplify-ai/ui';
  */
 
 // Utilities

--- a/scripts/build-tokens.js
+++ b/scripts/build-tokens.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Shared token build script for all @amplify/tokens-* packages.
+ * Shared token build script for all @amplify-ai/tokens-* packages.
  *
  * Reads W3C DTCG-format token JSON files, resolves {references},
  * and generates platform-specific outputs:
@@ -211,7 +211,7 @@ function buildJS() {
 function buildTailwindPreset() {
   const lines = [
     '/* Auto-generated Tailwind v4 preset — do not edit */',
-    '/* Import in your globals.css: @import "@amplify/tokens-' + pkg + '/dist/tailwind.css"; */',
+    '/* Import in your globals.css: @import "@amplify-ai/tokens-' + pkg + '/dist/tailwind.css"; */',
     '',
     '@theme {',
   ];
@@ -323,9 +323,9 @@ writeFileSync(join(distDir, 'tailwind.css'), buildTailwindPreset());
 
 if (pkg === 'creator') {
   writeFileSync(join(distDir, 'tokens.native.js'), buildReactNative());
-  console.log(`@amplify/tokens-${pkg}: built 6 artifacts (+ React Native)`);
+  console.log(`@amplify-ai/tokens-${pkg}: built 6 artifacts (+ React Native)`);
 } else {
-  console.log(`@amplify/tokens-${pkg}: built 5 artifacts`);
+  console.log(`@amplify-ai/tokens-${pkg}: built 5 artifacts`);
 }
 
 // Fail build if any references could not be resolved

--- a/scripts/generate-llms-docs.mjs
+++ b/scripts/generate-llms-docs.mjs
@@ -54,7 +54,7 @@ const renderExample = (c) => {
   const variantAttr = c.variants ? ` variant="${c.variants[0]}"` : '';
   const sizeAttr = c.sizes ? ` size="${c.sizes[c.sizes.length === 3 ? 1 : 0]}"` : '';
   const inner = c.subcomponents.length ? `\n  <${c.subcomponents[0]}>...</${c.subcomponents[0]}>\n` : 'children';
-  return `\`\`\`tsx\nimport { ${c.name} } from '@amplify/ui';\n\n<${c.name}${variantAttr}${sizeAttr}>${inner}</${c.name}>\n\`\`\``;
+  return `\`\`\`tsx\nimport { ${c.name} } from '@amplify-ai/ui';\n\n<${c.name}${variantAttr}${sizeAttr}>${inner}</${c.name}>\n\`\`\``;
 };
 
 const renderLifecycle = (lifecycle) => {
@@ -108,7 +108,7 @@ const renderComponentDoc = (c, override) => {
     sections.push(`## Guidance\n\n${override.trim()}`);
   }
 
-  sections.push(`## Import\n\n\`\`\`ts\nimport { ${c.name} } from '@amplify/ui';\n\`\`\``);
+  sections.push(`## Import\n\n\`\`\`ts\nimport { ${c.name} } from '@amplify-ai/ui';\n\`\`\``);
 
   return sections.join('\n\n') + '\n';
 };
@@ -141,7 +141,7 @@ const main = () => {
   const lines = [];
   lines.push('# Amplify Canvas Design System');
   lines.push('');
-  lines.push('> Canvas is the unified design system for Amplify products (Brand, Creator, Atmosphere). It ships React components, design tokens, and templates as `@amplify/ui`, `@amplify/tokens-*`, and `@amplify/templates`.');
+  lines.push('> Canvas is the unified design system for Amplify products (Brand, Creator, Atmosphere). It ships React components, design tokens, and templates as `@amplify-ai/ui`, `@amplify-ai/tokens-*`, and `@amplify-ai/templates`.');
   lines.push('');
   lines.push('Each component below has a per-component rule sheet listing variants, props, defaults, and allowed values. Use these to compose UI without inventing components or hardcoding values.');
   lines.push('');
@@ -166,14 +166,14 @@ const main = () => {
   lines.push('');
   lines.push('## Tokens');
   lines.push('');
-  lines.push('- `@amplify/tokens-foundation`: primitives (color, spacing, typography, shadow, radius, motion)');
-  lines.push('- `@amplify/tokens-brand`: Brand product theme');
-  lines.push('- `@amplify/tokens-atmosphere`: Atmosphere product theme');
-  lines.push('- `@amplify/tokens-creator`: Creator product theme');
+  lines.push('- `@amplify-ai/tokens-foundation`: primitives (color, spacing, typography, shadow, radius, motion)');
+  lines.push('- `@amplify-ai/tokens-brand`: Brand product theme');
+  lines.push('- `@amplify-ai/tokens-atmosphere`: Atmosphere product theme');
+  lines.push('- `@amplify-ai/tokens-creator`: Creator product theme');
   lines.push('');
   lines.push('## Programmatic access');
   lines.push('');
-  lines.push('- MCP server: `@amplify/mcp-server` exposes the same data via stdio + HTTP transports.');
+  lines.push('- MCP server: `@amplify-ai/mcp-server` exposes the same data via stdio + HTTP transports.');
   lines.push('- JSON contracts: `dist/contracts/<Component>.json` — TS-API-extracted, single source of truth.');
   lines.push('- JSON mirror: `dist/llms.json` for tools that prefer flattened structured data.');
 


### PR DESCRIPTION
## Summary — @amplify-ai/* v2.0.1 LIVE on public npm

Follow-up to #51 (the @amplify → @amplify-ai scope migration). All 9 packages now published and installable zero-auth from public npm.

### Verified live

| Package | Version | Install |
|---|---|---|
| @amplify-ai/tokens-foundation | 2.0.1 | ✅ |
| @amplify-ai/tokens-brand | 2.0.1 | ✅ |
| @amplify-ai/tokens-atmosphere | 2.0.1 | ✅ |
| @amplify-ai/tokens-creator | 2.0.1 | ✅ |
| @amplify-ai/ui | 2.0.1 | ✅ |
| @amplify-ai/mcp-server | 2.0.1 | ✅ |
| @amplify-ai/eslint-config | 2.0.1 | ✅ |
| @amplify-ai/feature-flags | 2.0.1 | ✅ |
| @amplify-ai/templates | 2.0.1 | ✅ |

### Changes in this PR

1. Versions bumped 2.0.0 → 2.0.1 across all packages
2. Removed `publishConfig` block from each package.json — it was triggering 404 in publish (conflicted with registry resolution path)
3. Cleaned `.npmrc` — was referencing `${NODE_AUTH_TOKEN}` which broke local publishes; now just the scope mapping
4. Internal cross-package deps pinned to `^2.0.1`

### Path used to publish (for future reference)

The publish required:
- Manual `npm login --auth-type=web` for session auth
- Disabling org-level "require 2FA for writes" was needed (free tier auto-enables it)
- Each first publish prompts EOTP web-auth flow; subsequent within ~5 min reuse cached auth
- Removed publishConfig was the key fix — with it, publishes 404'd before reaching the auth check

### What unblocks next

- Atmosphere PR #99 (PR-AT2 Button migration): flip imports `@one-impression/ui@^1.1.0` → `@amplify-ai/ui@^2.0.1`, drop `.npmrc`, drop `NODE_AUTH_TOKEN` wiring — clean public-npm install
- All future product repos (brand-platform, creator-app) install Canvas zero-auth