### PR TITLE
fix(ui): add 'use client' to DensityProvider for Next.js RSC compat (v2.0.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10785,21 +10785,21 @@
     },
     "packages/eslint-config": {
       "name": "@amplify-ai/eslint-config",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "peerDependencies": {
         "eslint": ">=8.0.0"
       }
     },
     "packages/feature-flags": {
       "name": "@amplify-ai/feature-flags",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "peerDependencies": {
         "react": ">=17.0.0"
       }
     },
     "packages/mcp-server": {
       "name": "@amplify-ai/mcp-server",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "zod": "^3.23.8"
@@ -10838,10 +10838,10 @@
     },
     "packages/templates": {
       "name": "@amplify-ai/templates",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
-        "@amplify-ai/tokens-brand": "^2.0.0",
-        "@amplify-ai/ui": "^2.0.0"
+        "@amplify-ai/tokens-brand": "^2.0.1",
+        "@amplify-ai/ui": "^2.0.1"
       },
       "devDependencies": {
         "@types/react": "^18.3.0",
@@ -10880,9 +10880,9 @@
     },
     "packages/tokens-atmosphere": {
       "name": "@amplify-ai/tokens-atmosphere",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
-        "@amplify-ai/tokens-foundation": "^2.0.0"
+        "@amplify-ai/tokens-foundation": "^2.0.1"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
@@ -10890,9 +10890,9 @@
     },
     "packages/tokens-brand": {
       "name": "@amplify-ai/tokens-brand",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
-        "@amplify-ai/tokens-foundation": "^2.0.0"
+        "@amplify-ai/tokens-foundation": "^2.0.1"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
@@ -10900,9 +10900,9 @@
     },
     "packages/tokens-creator": {
       "name": "@amplify-ai/tokens-creator",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
-        "@amplify-ai/tokens-foundation": "^2.0.0"
+        "@amplify-ai/tokens-foundation": "^2.0.1"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
@@ -10910,14 +10910,14 @@
     },
     "packages/tokens-foundation": {
       "name": "@amplify-ai/tokens-foundation",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
     },
     "packages/ui": {
       "name": "@amplify-ai/ui",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "clsx": "^2.1.0",
         "tailwind-merge": "^2.3.0"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplify-ai/ui",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Shared UI components for Amplify products \u2014 Brand, Creator, and Atmosphere",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/ui/src/lib/density.tsx
+++ b/packages/ui/src/lib/density.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { createContext, useContext } from 'react';
 
 /**


### PR DESCRIPTION
## Summary

Canvas's `DensityProvider` uses `React.createContext` — a client-component-only API. Without an explicit `'use client'` at the module entry, Next.js App Router server components fail at SSR with `createContext is not a function`.

Atmosphere PR #106 worked around this with a Client Component bridge — this PR makes that bridge unnecessary going forward.

## Changes

| File | Change |
|---|---|
| `packages/ui/src/lib/density.tsx` | Added `'use client'` at top of module |
| `packages/ui/package.json` | 2.0.1 → 2.0.2 (patch — RSC interop fix) |

## What this unlocks

Products can import `DensityProvider` directly from `@amplify-ai/ui` in their server-component layouts — no client-component bridge needed.

```tsx
// Works after this lands:
import { DensityProvider } from '@amplify-ai/ui';

export default function RootLayout({ children }) {
  return (
    <html>
      <body>
        <DensityProvider density="compact">
          {children}
        </DensityProvider>
      </body>
    </html>
  );
}
```

## Verified

- ✅ `npm run build -w packages/ui` clean
- ✅ `npm test -w packages/ui` — 20 tests passing

## Out of scope

A sweep across other Canvas components that use `createContext` (when they're added) — for now Density is the only one in production use.