### PR TITLE
fix(ci): merge duplicate env keys in Publish step (unblock all PR CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,21 +74,16 @@ jobs:
         if: github.ref == 'refs/heads/main' && env.NPM_TOKEN_SET == 'true'
         env:
           NPM_TOKEN_SET: ${{ secrets.NPM_TOKEN != '' }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -e
           for pkg in tokens-foundation tokens-brand tokens-atmosphere tokens-creator ui mcp-server eslint-config; do
             echo "Publishing @amplify-ai/$pkg..."
             (
               cd packages/$pkg
-              # Public npm — access:public via publishConfig in package.json
               OUTPUT=$(npm publish 2>&1) && echo "$OUTPUT" || {
                 EXIT_CODE=$?
                 echo "$OUTPUT"
-                # Recognise every shape of "this version already exists" the
-                # registry might return. npm CLI emits EPUBLISHCONFLICT, public
-                # npm says "You cannot publish over the previously published
-                # versions" — silently skipping a no-op republish lets us
-                # iterate on docs/CI without bumping versions every time.
                 if echo "$OUTPUT" | grep -qE 'EPUBLISHCONFLICT|already been published|You cannot publish over the previously published versions|cannot publish over the previously published'; then
                   echo "Package already published at this version — skipping"
                 else
@@ -98,13 +93,6 @@ jobs:
               }
             )
           done
-        env:
-          # Public npm publishing requires NPM_TOKEN secret (org-level "amplify"
-          # publish access). Setup: create npm org "amplify" → generate
-          # automation token with "publish" scope → add as NPM_TOKEN secret on
-          # this repo. Until that's done, the step's `if:` skips publishing
-          # gracefully so CI stays green on builds + tests.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish skipped (NPM_TOKEN not set)
         if: github.ref == 'refs/heads/main' && env.NPM_TOKEN_SET != 'true'


### PR DESCRIPTION
## Summary
- The `Publish packages` step in `ci.yml` had two `env:` blocks (one before `run:`, one after). YAML duplicate mapping keys → GitHub Actions rejected the workflow at validation time → 0 jobs / 0s on every run since 2026-04-22.
- Merged into a single `env:` block holding `NPM_TOKEN_SET` + `NODE_AUTH_TOKEN`. Same behaviour, valid YAML.

## Impact
Unblocks PR #59 (Phase B Wave 1) plus the in-flight Phase A, Phase B Waves 2 + 3 PRs. Without this fix, every push fails CI for reasons unrelated to the actual code.

## Test plan
- [ ] CI run on this PR spawns real jobs (build, validate, secret-scan, sdui-sync-check)
- [ ] Build steps execute and report green/red on actual code, not "workflow file issue"

🤖 Generated with [Claude Code](https://claude.com/claude-code)