### PR TITLE
feat(ui): Phase B Wave 3 — data viz primitives (charts, KPI, MetricCard variants, Timeline, ProgressRing)

### DIFF
--- a/packages/storybook/stories/BarChart.stories.tsx
+++ b/packages/storybook/stories/BarChart.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { BarChart } from '@amplify-ai/ui';
+
+const meta = {
+  title: 'Data Viz/BarChart',
+  component: BarChart,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof BarChart>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const VerticalCampaigns: Story = {
+  args: {
+    ariaLabel: 'Top 8 campaigns by GMV',
+    xAxis: ['Nykaa', 'Sugar', 'Mamaearth', 'Boat', 'Plum', 'Wow', 'Lakme', 'MyGlamm'],
+    series: [{ name: 'GMV (₹L)', values: [124, 98, 87, 76, 64, 51, 48, 42] }],
+  },
+};
+
+export const HorizontalCreators: Story = {
+  args: {
+    layout: 'horizontal',
+    ariaLabel: 'Top creators by deliveries this quarter',
+    xAxis: ['Nikhil', 'Priya', 'Aanchal', 'Rohan', 'Tara', 'Vikram'],
+    series: [{ name: 'Deliveries', values: [42, 38, 35, 28, 24, 21] }],
+  },
+};
+
+export const StackedRevenueMix: Story = {
+  args: {
+    layout: 'stacked',
+    ariaLabel: 'Quarterly revenue mix by content type',
+    xAxis: ['Q1', 'Q2', 'Q3', 'Q4'],
+    series: [
+      { name: 'Reels', values: [180, 220, 280, 340] },
+      { name: 'Stories', values: [80, 95, 110, 130] },
+      { name: 'Shorts', values: [45, 60, 75, 95] },
+      { name: 'Posts', values: [30, 35, 38, 42] },
+    ],
+  },
+};
+
+export const GroupedBudgetVsActual: Story = {
+  args: {
+    layout: 'grouped',
+    ariaLabel: 'Monthly budget vs actual spend',
+    xAxis: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+    series: [
+      { name: 'Budget', values: [50, 50, 60, 60, 75, 75] },
+      { name: 'Actual', values: [42, 48, 58, 67, 72, 81] },
+    ],
+  },
+};

--- a/packages/storybook/stories/Funnel.stories.tsx
+++ b/packages/storybook/stories/Funnel.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Funnel } from '@amplify-ai/ui';
+
+const meta = {
+  title: 'Data Viz/Funnel',
+  component: Funnel,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof Funnel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CampaignPipeline: Story = {
+  args: {
+    ariaLabel: 'Campaign pipeline conversion',
+    stages: [
+      { name: 'Brand sign-ups', value: 4800 },
+      { name: 'Briefs created', value: 2640 },
+      { name: 'Creators matched', value: 1820 },
+      { name: 'Drafts approved', value: 1240 },
+      { name: 'Live campaigns', value: 920 },
+      { name: 'Reorders', value: 380, description: 'Same-brand repeat' },
+    ],
+  },
+};
+
+export const CreatorOnboarding: Story = {
+  args: {
+    ariaLabel: 'Creator onboarding funnel',
+    stages: [
+      { name: 'Profile views', value: 12400 },
+      { name: 'Sign-ups', value: 4200 },
+      { name: 'KYC complete', value: 2180 },
+      { name: 'First brief shipped', value: 1340 },
+      { name: 'Reach 5+ deliveries', value: 720 },
+    ],
+    showConversion: true,
+  },
+};
+
+export const PaymentRecovery: Story = {
+  args: {
+    ariaLabel: 'Overdue payment recovery flow',
+    stages: [
+      { name: 'Invoices raised', value: 880 },
+      { name: 'Reminder sent', value: 420 },
+      { name: 'Acknowledged', value: 280 },
+      { name: 'Paid', value: 210 },
+    ],
+  },
+};

--- a/packages/storybook/stories/Heatmap.stories.tsx
+++ b/packages/storybook/stories/Heatmap.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Heatmap } from '@amplify-ai/ui';
+
+const meta = {
+  title: 'Data Viz/Heatmap',
+  component: Heatmap,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof Heatmap>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Generate calendar data — 90 days
+function generateCalendarData() {
+  const cells = [];
+  const today = new Date();
+  for (let i = 89; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(today.getDate() - i);
+    const iso = d.toISOString().slice(0, 10);
+    // Weekend lower; mid-week peak
+    const dayOfWeek = d.getDay();
+    const base = dayOfWeek === 0 || dayOfWeek === 6 ? 1 : 5;
+    cells.push({
+      id: iso,
+      value: Math.max(0, Math.floor(Math.random() * base * 4)),
+    });
+  }
+  return cells;
+}
+
+export const CalendarCreatorActivity: Story = {
+  args: {
+    variant: 'calendar',
+    ariaLabel: 'Creator deliveries — last 90 days',
+    data: generateCalendarData(),
+  },
+};
+
+export const MatrixCampaignPerformance: Story = {
+  args: {
+    variant: 'matrix',
+    ariaLabel: 'Engagement rate by content type and time of day',
+    rowLabels: ['Morning', 'Midday', 'Evening', 'Night'],
+    colLabels: ['Reels', 'Stories', 'Shorts', 'Posts'],
+    data: [
+      { id: 'm-r', value: 6.2, row: 0, col: 0 },
+      { id: 'm-s', value: 4.1, row: 0, col: 1 },
+      { id: 'm-sh', value: 5.8, row: 0, col: 2 },
+      { id: 'm-p', value: 2.3, row: 0, col: 3 },
+      { id: 'd-r', value: 8.4, row: 1, col: 0 },
+      { id: 'd-s', value: 5.6, row: 1, col: 1 },
+      { id: 'd-sh', value: 7.2, row: 1, col: 2 },
+      { id: 'd-p', value: 3.1, row: 1, col: 3 },
+      { id: 'e-r', value: 11.8, row: 2, col: 0 },
+      { id: 'e-s', value: 9.2, row: 2, col: 1 },
+      { id: 'e-sh', value: 10.4, row: 2, col: 2 },
+      { id: 'e-p', value: 4.8, row: 2, col: 3 },
+      { id: 'n-r', value: 7.6, row: 3, col: 0 },
+      { id: 'n-s', value: 6.8, row: 3, col: 1 },
+      { id: 'n-sh', value: 8.1, row: 3, col: 2 },
+      { id: 'n-p', value: 3.4, row: 3, col: 3 },
+    ],
+    cellSize: 28,
+    cellGap: 4,
+  },
+};

--- a/packages/storybook/stories/KPI.stories.tsx
+++ b/packages/storybook/stories/KPI.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { KPI } from '@amplify-ai/ui';
+
+const meta = {
+  title: 'Data Viz/KPI',
+  component: KPI,
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: 'select', options: ['md', 'lg', 'xl'] },
+    trend: { control: 'select', options: [undefined, 'up', 'down', 'neutral'] },
+  },
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof KPI>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const RevenueLarge: Story = {
+  args: {
+    label: 'Quarterly GMV',
+    value: '₹11.5 Cr',
+    delta: 18.4,
+    deltaLabel: 'vs Q3',
+    sparkline: [3.2, 4.1, 4.8, 5.6, 6.4, 7.2, 8.1, 9.4, 10.2, 11.5],
+    size: 'lg',
+  },
+};
+
+export const ActiveCampaignsXL: Story = {
+  args: {
+    label: 'Active Campaigns',
+    value: 142,
+    delta: 12.5,
+    deltaLabel: 'vs last week',
+    size: 'xl',
+    sparkline: [98, 105, 112, 118, 124, 131, 138, 142],
+  },
+};
+
+export const ChurnInverted: Story = {
+  args: {
+    label: 'Brand Churn Rate',
+    value: '2.4%',
+    delta: -0.8,
+    deltaLabel: 'vs last month',
+    higherIsBetter: false, // a *decrease* in churn is good → green
+    size: 'md',
+  },
+};
+
+export const NeutralKPI: Story = {
+  args: {
+    label: 'Total Creators',
+    value: '12,840',
+    subtitle: 'across India + SEA',
+    size: 'md',
+  },
+};
+
+export const InteractiveKPI: Story = {
+  args: {
+    label: 'Pending Approvals',
+    value: 7,
+    delta: 16.7,
+    deltaLabel: 'vs yesterday',
+    higherIsBetter: false,
+    size: 'lg',
+    onClick: () => alert('Navigate to approvals'),
+  },
+};
+
+export const KPIGrid: Story = {
+  render: () => (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      <KPI
+        label="GMV"
+        value="₹11.5 Cr"
+        delta={18.4}
+        deltaLabel="QoQ"
+        sparkline={[6, 7, 8, 9, 10, 11.5]}
+        size="md"
+      />
+      <KPI
+        label="Active Campaigns"
+        value={142}
+        delta={12.5}
+        deltaLabel="WoW"
+        sparkline={[110, 118, 124, 131, 138, 142]}
+        size="md"
+      />
+      <KPI
+        label="Avg Engagement"
+        value="6.4%"
+        delta={-0.3}
+        deltaLabel="WoW"
+        higherIsBetter={true}
+        size="md"
+      />
+      <KPI
+        label="Churn"
+        value="2.4%"
+        delta={-0.8}
+        deltaLabel="MoM"
+        higherIsBetter={false}
+        size="md"
+      />
+    </div>
+  ),
+};

--- a/packages/storybook/stories/LineChart.stories.tsx
+++ b/packages/storybook/stories/LineChart.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LineChart } from '@amplify-ai/ui';
+
+const meta = {
+  title: 'Data Viz/LineChart',
+  component: LineChart,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Hand-rolled SVG line chart for single or multi-series time-series data. Responsive (100% width), tooltip slot, SR-only data table fallback.',
+      },
+    },
+  },
+} satisfies Meta<typeof LineChart>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+export const SingleSeriesRevenue: Story = {
+  args: {
+    ariaLabel: 'Monthly GMV in 2026',
+    xAxis: months,
+    series: [
+      {
+        name: 'GMV (₹ Cr)',
+        values: [3.2, 3.8, 4.1, 4.6, 5.4, 6.2, 6.8, 7.4, 8.1, 8.9, 9.7, 11.5],
+      },
+    ],
+  },
+};
+
+export const MultiSeriesCampaignPerf: Story = {
+  args: {
+    ariaLabel: 'Campaign performance — impressions vs engagement vs conversions',
+    xAxis: ['Wk 1', 'Wk 2', 'Wk 3', 'Wk 4', 'Wk 5', 'Wk 6', 'Wk 7', 'Wk 8'],
+    series: [
+      { name: 'Impressions (K)', values: [120, 180, 240, 310, 380, 420, 510, 580] },
+      { name: 'Engagements (K)', values: [12, 22, 28, 41, 49, 58, 71, 84] },
+      { name: 'Conversions', values: [340, 580, 720, 980, 1240, 1410, 1820, 2150] },
+    ],
+  },
+};
+
+export const CreatorEngagement: Story = {
+  args: {
+    ariaLabel: 'Creator engagement rate over 30 days',
+    xAxis: Array.from({ length: 30 }, (_, i) => `D${i + 1}`),
+    series: [
+      {
+        name: 'Engagement %',
+        values: [
+          4.2, 4.5, 4.1, 4.8, 5.2, 5.6, 5.9, 6.1, 5.8, 6.3, 6.7, 7.1, 6.9, 7.4, 7.8, 8.1, 7.6, 8.2,
+          8.6, 8.9, 9.1, 8.7, 9.3, 9.6, 9.9, 9.5, 10.1, 10.4, 10.7, 11.0,
+        ],
+      },
+    ],
+  },
+};
+
+export const BudgetVsActual: Story = {
+  args: {
+    ariaLabel: 'Brand budget vs actual spend',
+    xAxis: months.slice(0, 6),
+    series: [
+      { name: 'Budget', values: [50, 50, 60, 60, 75, 75], strokeDasharray: '6 4' },
+      { name: 'Actual', values: [42, 48, 58, 67, 72, 81] },
+    ],
+    tooltip: (idx, label, series) => (
+      <div className="rounded border border-[var(--amp-semantic-border-default)] bg-[var(--amp-semantic-bg-surface)] p-2 inline-block shadow-sm">
+        <p className="font-medium">{label}</p>
+        {series.map(s => (
+          <p key={s.name}>
+            {s.name}: ₹{s.values[idx]}L
+          </p>
+        ))}
+      </div>
+    ),
+  },
+};

--- a/packages/storybook/stories/PieChart.stories.tsx
+++ b/packages/storybook/stories/PieChart.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { PieChart } from '@amplify-ai/ui';
+
+const meta = {
+  title: 'Data Viz/PieChart',
+  component: PieChart,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof PieChart>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DonutContentMix: Story = {
+  args: {
+    variant: 'donut',
+    ariaLabel: 'Content type mix this quarter',
+    data: [
+      { name: 'Reels', value: 1240 },
+      { name: 'Stories', value: 680 },
+      { name: 'Shorts', value: 420 },
+      { name: 'Static Posts', value: 220 },
+      { name: 'Long-form', value: 80 },
+    ],
+    centerSlot: (
+      <div>
+        <p className="text-[10px] uppercase tracking-wide text-[var(--amp-semantic-text-muted)]">
+          Total
+        </p>
+        <p className="text-[20px] font-bold">2,640</p>
+      </div>
+    ),
+  },
+};
+
+export const PieRevenueShare: Story = {
+  args: {
+    variant: 'pie',
+    ariaLabel: 'Revenue share by category',
+    size: 220,
+    data: [
+      { name: 'Beauty', value: 4.2 },
+      { name: 'Fashion', value: 2.8 },
+      { name: 'F&B', value: 1.6 },
+      { name: 'Tech', value: 1.1 },
+      { name: 'Other', value: 0.7 },
+    ],
+  },
+};
+
+export const DonutCreatorStatus: Story = {
+  args: {
+    variant: 'donut',
+    ariaLabel: 'Creator pipeline status',
+    size: 180,
+    data: [
+      { name: 'Active', value: 142 },
+      { name: 'Paused', value: 38 },
+      { name: 'Onboarding', value: 22 },
+      { name: 'Churned', value: 14 },
+    ],
+  },
+};

--- a/packages/storybook/stories/ProgressRing.stories.tsx
+++ b/packages/storybook/stories/ProgressRing.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ProgressRing } from '@amplify-ai/ui';
+
+const meta = {
+  title: 'Data Viz/ProgressRing',
+  component: ProgressRing,
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg', 'xl'] },
+    variant: { control: 'select', options: ['default', 'accent', 'success', 'warning', 'error'] },
+    value: { control: { type: 'range', min: 0, max: 100, step: 1 } },
+  },
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof ProgressRing>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { value: 68, size: 'lg', variant: 'accent' },
+};
+
+export const SizeScale: Story = {
+  render: () => (
+    <div className="flex items-end gap-6">
+      <ProgressRing value={42} size="sm" />
+      <ProgressRing value={68} size="md" />
+      <ProgressRing value={84} size="lg" />
+      <ProgressRing value={92} size="xl" />
+    </div>
+  ),
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div className="flex items-end gap-6">
+      <ProgressRing value={75} size="lg" variant="default" />
+      <ProgressRing value={75} size="lg" variant="accent" />
+      <ProgressRing value={75} size="lg" variant="success" />
+      <ProgressRing value={75} size="lg" variant="warning" />
+      <ProgressRing value={75} size="lg" variant="error" />
+    </div>
+  ),
+};
+
+export const CustomCenterSlot: Story = {
+  args: {
+    value: 78,
+    size: 'xl',
+    variant: 'success',
+    children: (
+      <div>
+        <p className="text-[10px] uppercase tracking-wide text-[var(--amp-semantic-text-muted)]">
+          Brief health
+        </p>
+        <p className="text-[28px] font-bold leading-none">A−</p>
+        <p className="text-[10px] text-[var(--amp-semantic-text-muted)]">78/100</p>
+      </div>
+    ),
+  },
+};
+
+export const CampaignCompletion: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <ProgressRing value={64} size="lg" variant="accent" />
+      <div>
+        <p className="text-[14px] font-semibold">Q4 Campaign Goal</p>
+        <p className="text-[12px] text-[var(--amp-semantic-text-muted)]">
+          ₹7.4 Cr of ₹11.5 Cr delivered • 64% complete
+        </p>
+      </div>
+    </div>
+  ),
+};

--- a/packages/storybook/stories/Sparkline.stories.tsx
+++ b/packages/storybook/stories/Sparkline.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Sparkline } from '@amplify-ai/ui';
+
+const meta = {
+  title: 'Data Viz/Sparkline',
+  component: Sparkline,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['line', 'bar', 'area'] },
+  },
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof Sparkline>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const trendData = [12, 18, 14, 22, 28, 25, 32, 38, 35, 42, 48, 56];
+
+export const LineDefault: Story = {
+  args: {
+    ariaLabel: 'Engagement trend last 12 weeks',
+    data: trendData,
+    variant: 'line',
+    color: '#7c3aed',
+  },
+};
+
+export const BarVariant: Story = {
+  args: {
+    ariaLabel: 'Daily deliveries last 12 days',
+    data: trendData,
+    variant: 'bar',
+    color: '#16a34a',
+    width: 100,
+    height: 32,
+  },
+};
+
+export const AreaVariant: Story = {
+  args: {
+    ariaLabel: 'Revenue trend',
+    data: trendData,
+    variant: 'area',
+    color: '#2563eb',
+    width: 120,
+    height: 36,
+  },
+};
+
+export const InlineWithMetric: Story = {
+  render: () => (
+    <div className="flex items-center gap-3 text-[14px]">
+      <span className="font-semibold tabular-nums">₹4.2 Cr</span>
+      <Sparkline
+        ariaLabel="Quarterly revenue trend"
+        data={[2.1, 2.4, 2.8, 3.1, 3.5, 3.7, 4.0, 4.2]}
+        variant="area"
+        color="#16a34a"
+      />
+      <span className="text-[var(--amp-semantic-status-success,#16a34a)] text-[12px]">+12.4%</span>
+    </div>
+  ),
+};

--- a/packages/ui/component-status.json
+++ b/packages/ui/component-status.json
@@ -47,6 +47,14 @@
     "Toast": { "status": "stable", "since": "1.0.0" },
     "Tooltip": { "status": "stable", "since": "1.0.0" },
     "TrustBar": { "status": "stable", "since": "1.0.0" },
-    "WalletCard": { "status": "stable", "since": "1.0.0" }
+    "WalletCard": { "status": "stable", "since": "1.0.0" },
+    "BarChart": { "status": "beta", "since": "2.3.0" },
+    "Funnel": { "status": "beta", "since": "2.3.0" },
+    "Heatmap": { "status": "beta", "since": "2.3.0" },
+    "KPI": { "status": "beta", "since": "2.3.0" },
+    "LineChart": { "status": "beta", "since": "2.3.0" },
+    "PieChart": { "status": "beta", "since": "2.3.0" },
+    "ProgressRing": { "status": "beta", "since": "2.3.0" },
+    "Sparkline": { "status": "beta", "since": "2.3.0" }
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplify-ai/ui",
-  "version": "2.0.2",
+  "version": "2.3.0",
   "description": "Shared UI components for Amplify products \u2014 Brand, Creator, and Atmosphere",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/ui/src/components/BarChart/BarChart.tsx
+++ b/packages/ui/src/components/BarChart/BarChart.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { cn } from '../../lib/cn';
+import {
+  formatCompact,
+  linearScale,
+  niceTicks,
+  pickColor,
+} from '../../lib/chart-utils';
+
+export type BarChartLayout = 'vertical' | 'horizontal' | 'stacked' | 'grouped';
+
+export interface BarChartSeries {
+  name: string;
+  values: number[];
+  color?: string;
+}
+
+export interface BarChartProps {
+  /** Category labels (one per group). */
+  xAxis: string[];
+  /** One or more series. */
+  series: BarChartSeries[];
+  /** Layout mode. Defaults to 'vertical' (single-series) or 'grouped' (multi-series). */
+  layout?: BarChartLayout;
+  height?: number;
+  showGrid?: boolean;
+  showLegend?: boolean;
+  yTickFormat?: (value: number) => string;
+  /** Aria-label for screen readers. */
+  ariaLabel: string;
+  className?: string;
+}
+
+const DEFAULT_HEIGHT = 240;
+const PADDING = { top: 16, right: 16, bottom: 28, left: 44 };
+
+export const BarChart: React.FC<BarChartProps> = ({
+  xAxis,
+  series,
+  layout,
+  height = DEFAULT_HEIGHT,
+  showGrid = true,
+  showLegend,
+  yTickFormat = formatCompact,
+  ariaLabel,
+  className,
+}) => {
+  const resolvedLayout: BarChartLayout = layout ?? (series.length > 1 ? 'grouped' : 'vertical');
+  const isHorizontal = resolvedLayout === 'horizontal';
+  const VB_WIDTH = 600;
+  const VB_HEIGHT = height;
+
+  const computed = useMemo(() => {
+    let maxVal = 0;
+    let minVal = 0;
+    if (resolvedLayout === 'stacked') {
+      for (let i = 0; i < xAxis.length; i++) {
+        let stacked = 0;
+        for (const s of series) stacked += Math.max(0, s.values[i] ?? 0);
+        if (stacked > maxVal) maxVal = stacked;
+      }
+    } else {
+      for (const s of series) {
+        for (const v of s.values) {
+          if (v > maxVal) maxVal = v;
+          if (v < minVal) minVal = v;
+        }
+      }
+    }
+    if (maxVal === 0 && minVal === 0) maxVal = 1;
+    const ticks = niceTicks(minVal, maxVal, 5);
+    const valMin = ticks[0];
+    const valMax = ticks[ticks.length - 1];
+
+    const innerW = VB_WIDTH - PADDING.left - PADDING.right;
+    const innerH = VB_HEIGHT - PADDING.top - PADDING.bottom;
+    return { ticks, valMin, valMax, innerW, innerH };
+  }, [series, xAxis, resolvedLayout, VB_HEIGHT]);
+
+  const showLegendResolved = showLegend ?? series.length > 1;
+
+  function renderVerticalOrGrouped() {
+    const { innerW, innerH, valMin, valMax } = computed;
+    const groupCount = xAxis.length;
+    const groupW = groupCount > 0 ? innerW / groupCount : innerW;
+    const groupPad = 0.2 * groupW;
+    const usable = groupW - groupPad;
+    const barCount = resolvedLayout === 'grouped' ? series.length : 1;
+    const barW = usable / barCount;
+
+    return xAxis.map((label, gi) => {
+      const groupX = PADDING.left + gi * groupW + groupPad / 2;
+      return (
+        <g key={`${label}-${gi}`}>
+          {(resolvedLayout === 'grouped' ? series : series.slice(0, 1)).map((s, si) => {
+            const v = s.values[gi] ?? 0;
+            const yTop = PADDING.top + linearScale(Math.max(v, 0), valMin, valMax, innerH, 0);
+            const yBase = PADDING.top + linearScale(0, valMin, valMax, innerH, 0);
+            const x = groupX + si * barW;
+            const h = Math.abs(yBase - yTop);
+            return (
+              <rect
+                key={s.name}
+                x={x + 1}
+                y={Math.min(yTop, yBase)}
+                width={Math.max(0, barW - 2)}
+                height={h}
+                rx={3}
+                fill={s.color ?? pickColor(si)}
+              />
+            );
+          })}
+        </g>
+      );
+    });
+  }
+
+  function renderStacked() {
+    const { innerW, innerH, valMin, valMax } = computed;
+    const groupCount = xAxis.length;
+    const groupW = groupCount > 0 ? innerW / groupCount : innerW;
+    const groupPad = 0.25 * groupW;
+    const barW = groupW - groupPad;
+
+    return xAxis.map((label, gi) => {
+      const x = PADDING.left + gi * groupW + groupPad / 2;
+      let cumulative = 0;
+      return (
+        <g key={`${label}-${gi}`}>
+          {series.map((s, si) => {
+            const v = Math.max(0, s.values[gi] ?? 0);
+            const yTop = PADDING.top + linearScale(cumulative + v, valMin, valMax, innerH, 0);
+            const yBottom = PADDING.top + linearScale(cumulative, valMin, valMax, innerH, 0);
+            cumulative += v;
+            return (
+              <rect
+                key={s.name}
+                x={x}
+                y={yTop}
+                width={barW}
+                height={Math.max(0, yBottom - yTop)}
+                fill={s.color ?? pickColor(si)}
+              />
+            );
+          })}
+        </g>
+      );
+    });
+  }
+
+  function renderHorizontal() {
+    const { innerW, innerH, valMin, valMax } = computed;
+    const groupCount = xAxis.length;
+    const rowH = groupCount > 0 ? innerH / groupCount : innerH;
+    const rowPad = 0.2 * rowH;
+    const usable = rowH - rowPad;
+    const barCount = series.length > 1 ? series.length : 1;
+    const barH = usable / barCount;
+
+    return xAxis.map((label, gi) => {
+      const rowY = PADDING.top + gi * rowH + rowPad / 2;
+      return (
+        <g key={`${label}-${gi}`}>
+          {series.map((s, si) => {
+            const v = s.values[gi] ?? 0;
+            const xLeft = PADDING.left + linearScale(0, valMin, valMax, 0, innerW);
+            const xRight = PADDING.left + linearScale(v, valMin, valMax, 0, innerW);
+            const y = rowY + si * barH;
+            return (
+              <rect
+                key={s.name}
+                x={Math.min(xLeft, xRight)}
+                y={y + 1}
+                width={Math.abs(xRight - xLeft)}
+                height={Math.max(0, barH - 2)}
+                rx={3}
+                fill={s.color ?? pickColor(si)}
+              />
+            );
+          })}
+        </g>
+      );
+    });
+  }
+
+  return (
+    <div className={cn('w-full', className)}>
+      <svg
+        role="img"
+        aria-label={ariaLabel}
+        viewBox={`0 0 ${VB_WIDTH} ${VB_HEIGHT}`}
+        preserveAspectRatio="none"
+        className="w-full"
+        style={{ height }}
+      >
+        {/* gridlines */}
+        {showGrid &&
+          computed.ticks.map(tick => {
+            if (isHorizontal) {
+              const x = PADDING.left + linearScale(tick, computed.valMin, computed.valMax, 0, computed.innerW);
+              return (
+                <g key={tick}>
+                  <line
+                    x1={x}
+                    x2={x}
+                    y1={PADDING.top}
+                    y2={PADDING.top + computed.innerH}
+                    stroke="var(--amp-semantic-border-default, #e5e7eb)"
+                    strokeWidth={1}
+                    strokeDasharray="2 4"
+                  />
+                  <text
+                    x={x}
+                    y={VB_HEIGHT - 8}
+                    fontSize={11}
+                    textAnchor="middle"
+                    fill="var(--amp-semantic-text-muted, #6b7280)"
+                  >
+                    {yTickFormat(tick)}
+                  </text>
+                </g>
+              );
+            }
+            const y = PADDING.top + linearScale(tick, computed.valMin, computed.valMax, computed.innerH, 0);
+            return (
+              <g key={tick}>
+                <line
+                  x1={PADDING.left}
+                  x2={VB_WIDTH - PADDING.right}
+                  y1={y}
+                  y2={y}
+                  stroke="var(--amp-semantic-border-default, #e5e7eb)"
+                  strokeWidth={1}
+                  strokeDasharray="2 4"
+                />
+                <text
+                  x={PADDING.left - 6}
+                  y={y + 4}
+                  fontSize={11}
+                  textAnchor="end"
+                  fill="var(--amp-semantic-text-muted, #6b7280)"
+                >
+                  {yTickFormat(tick)}
+                </text>
+              </g>
+            );
+          })}
+
+        {/* category labels */}
+        {!isHorizontal &&
+          xAxis.map((label, i) => {
+            const groupW = xAxis.length > 0 ? computed.innerW / xAxis.length : computed.innerW;
+            const x = PADDING.left + i * groupW + groupW / 2;
+            return (
+              <text
+                key={`${label}-${i}`}
+                x={x}
+                y={VB_HEIGHT - 8}
+                fontSize={11}
+                textAnchor="middle"
+                fill="var(--amp-semantic-text-muted, #6b7280)"
+              >
+                {label}
+              </text>
+            );
+          })}
+        {isHorizontal &&
+          xAxis.map((label, i) => {
+            const rowH = xAxis.length > 0 ? computed.innerH / xAxis.length : computed.innerH;
+            const y = PADDING.top + i * rowH + rowH / 2 + 4;
+            return (
+              <text
+                key={`${label}-${i}`}
+                x={PADDING.left - 6}
+                y={y}
+                fontSize={11}
+                textAnchor="end"
+                fill="var(--amp-semantic-text-muted, #6b7280)"
+              >
+                {label}
+              </text>
+            );
+          })}
+
+        {/* bars */}
+        {resolvedLayout === 'stacked' && renderStacked()}
+        {(resolvedLayout === 'vertical' || resolvedLayout === 'grouped') && renderVerticalOrGrouped()}
+        {resolvedLayout === 'horizontal' && renderHorizontal()}
+      </svg>
+
+      {showLegendResolved && (
+        <ul className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-[12px]">
+          {series.map((s, i) => (
+            <li key={s.name} className="flex items-center gap-1.5">
+              <span
+                className="inline-block w-3 h-3 rounded-sm"
+                style={{ backgroundColor: s.color ?? pickColor(i) }}
+              />
+              <span className="text-[var(--amp-semantic-text-secondary,#374151)]">{s.name}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <table className="sr-only">
+        <caption>{ariaLabel}</caption>
+        <thead>
+          <tr>
+            <th scope="col">Category</th>
+            {series.map(s => (
+              <th key={s.name} scope="col">
+                {s.name}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {xAxis.map((label, i) => (
+            <tr key={label}>
+              <th scope="row">{label}</th>
+              {series.map(s => (
+                <td key={s.name}>{s.values[i] ?? ''}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+BarChart.displayName = 'BarChart';

--- a/packages/ui/src/components/BarChart/index.ts
+++ b/packages/ui/src/components/BarChart/index.ts
@@ -1,0 +1,2 @@
+export { BarChart } from './BarChart';
+export type { BarChartProps, BarChartSeries, BarChartLayout } from './BarChart';

--- a/packages/ui/src/components/Funnel/Funnel.tsx
+++ b/packages/ui/src/components/Funnel/Funnel.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { cn } from '../../lib/cn';
+import { formatCompact, pickColor } from '../../lib/chart-utils';
+
+export interface FunnelStage {
+  name: string;
+  value: number;
+  color?: string;
+  /** Optional helper line shown under the stage name. */
+  description?: string;
+}
+
+export interface FunnelProps {
+  stages: FunnelStage[];
+  /** Show drop-off / conversion percentage between stages. */
+  showConversion?: boolean;
+  /** Show absolute value. */
+  showValue?: boolean;
+  height?: number;
+  /** Format value labels (defaults to compact: 1.2K). */
+  valueFormat?: (n: number) => string;
+  ariaLabel: string;
+  className?: string;
+}
+
+export const Funnel: React.FC<FunnelProps> = ({
+  stages,
+  showConversion = true,
+  showValue = true,
+  height = 280,
+  valueFormat = formatCompact,
+  ariaLabel,
+  className,
+}) => {
+  const computed = useMemo(() => {
+    const max = stages.reduce((m, s) => (s.value > m ? s.value : m), 0) || 1;
+    return stages.map((stage, i) => {
+      const widthPct = (stage.value / max) * 100;
+      const fromPrev =
+        i === 0
+          ? 100
+          : stages[i - 1].value === 0
+            ? 0
+            : (stage.value / stages[i - 1].value) * 100;
+      const fromTop = stages[0].value === 0 ? 0 : (stage.value / stages[0].value) * 100;
+      return {
+        ...stage,
+        widthPct,
+        fromPrev,
+        fromTop,
+        color: stage.color ?? pickColor(i),
+      };
+    });
+  }, [stages]);
+
+  const stageH = stages.length > 0 ? Math.max(28, Math.floor(height / stages.length) - 8) : 0;
+
+  return (
+    <div
+      role="img"
+      aria-label={ariaLabel}
+      className={cn('w-full', className)}
+    >
+      <ul className="flex flex-col gap-2" style={{ minHeight: height }}>
+        {computed.map((stage, i) => (
+          <li key={`${stage.name}-${i}`} className="relative">
+            <div className="flex items-center gap-3">
+              {/* trapezoid bar (centered) */}
+              <div className="flex-1 flex justify-center">
+                <div
+                  style={{
+                    width: `${stage.widthPct}%`,
+                    height: stageH,
+                    backgroundColor: stage.color,
+                    clipPath:
+                      i < stages.length - 1
+                        ? `polygon(0 0, 100% 0, 95% 100%, 5% 100%)`
+                        : 'none',
+                    minWidth: 60,
+                  }}
+                  className="flex items-center justify-center text-white text-[14px] font-semibold transition-all"
+                >
+                  {showValue && valueFormat(stage.value)}
+                </div>
+              </div>
+              {/* meta column on the right */}
+              <div className="w-32 shrink-0">
+                <p className="text-[13px] font-medium text-[var(--amp-semantic-text-primary,#111827)]">
+                  {stage.name}
+                </p>
+                {stage.description && (
+                  <p className="text-[11px] text-[var(--amp-semantic-text-muted,#6b7280)]">
+                    {stage.description}
+                  </p>
+                )}
+                {showConversion && i > 0 && (
+                  <p className="text-[11px] text-[var(--amp-semantic-text-secondary,#374151)] mt-0.5">
+                    <span className={stage.fromPrev >= 50 ? 'text-[var(--amp-semantic-status-success,#16a34a)]' : 'text-[var(--amp-semantic-status-warning,#d97706)]'}>
+                      {stage.fromPrev.toFixed(0)}%
+                    </span>{' '}
+                    from prev
+                  </p>
+                )}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <table className="sr-only">
+        <caption>{ariaLabel}</caption>
+        <thead>
+          <tr>
+            <th scope="col">Stage</th>
+            <th scope="col">Value</th>
+            <th scope="col">% of top</th>
+            <th scope="col">% of prev</th>
+          </tr>
+        </thead>
+        <tbody>
+          {computed.map(s => (
+            <tr key={s.name}>
+              <th scope="row">{s.name}</th>
+              <td>{s.value}</td>
+              <td>{s.fromTop.toFixed(1)}%</td>
+              <td>{s.fromPrev.toFixed(1)}%</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+Funnel.displayName = 'Funnel';

--- a/packages/ui/src/components/Funnel/index.ts
+++ b/packages/ui/src/components/Funnel/index.ts
@@ -1,0 +1,2 @@
+export { Funnel } from './Funnel';
+export type { FunnelProps, FunnelStage } from './Funnel';

--- a/packages/ui/src/components/Heatmap/Heatmap.tsx
+++ b/packages/ui/src/components/Heatmap/Heatmap.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { cn } from '../../lib/cn';
+
+export type HeatmapVariant = 'calendar' | 'matrix';
+
+export interface HeatmapCell {
+  /** ISO date (calendar) or any unique id (matrix). */
+  id: string;
+  /** Numeric intensity (used to choose colour bucket). */
+  value: number;
+  /** Optional explicit row/col index for matrix; ignored for calendar. */
+  row?: number;
+  col?: number;
+  /** Hover label; falls back to `${id}: ${value}`. */
+  label?: string;
+}
+
+export interface HeatmapProps {
+  variant?: HeatmapVariant;
+  data: HeatmapCell[];
+  /** For matrix variant: row labels in display order (top→bottom). */
+  rowLabels?: string[];
+  /** For matrix variant: column labels in display order (left→right). */
+  colLabels?: string[];
+  /** Number of intensity buckets (5 → quintiles like GitHub). */
+  buckets?: number;
+  /** Cell size in px. */
+  cellSize?: number;
+  cellGap?: number;
+  /** CSS color used at full intensity; lower buckets are alpha-mixed. */
+  color?: string;
+  ariaLabel: string;
+  className?: string;
+}
+
+export const Heatmap: React.FC<HeatmapProps> = ({
+  variant = 'matrix',
+  data,
+  rowLabels,
+  colLabels,
+  buckets = 5,
+  cellSize = 14,
+  cellGap = 3,
+  color = 'var(--amp-semantic-accent, #7c3aed)',
+  ariaLabel,
+  className,
+}) => {
+  const computed = useMemo(() => {
+    const max = data.reduce((m, c) => (c.value > m ? c.value : m), 0);
+    const min = data.reduce((m, c) => (c.value < m ? c.value : m), Infinity);
+    const safeMin = min === Infinity ? 0 : min;
+    return { max: max || 1, min: safeMin };
+  }, [data]);
+
+  function bucketFor(value: number): number {
+    if (value <= 0) return 0;
+    const t = (value - computed.min) / (computed.max - computed.min || 1);
+    return Math.min(buckets - 1, Math.max(0, Math.floor(t * buckets)));
+  }
+
+  function bucketColor(bucket: number): string {
+    if (bucket === 0) return 'var(--amp-semantic-bg-subtle, #f3f4f6)';
+    const alpha = 0.15 + (bucket / (buckets - 1)) * 0.85;
+    return `color-mix(in srgb, ${color} ${(alpha * 100).toFixed(0)}%, transparent)`;
+  }
+
+  if (variant === 'calendar') {
+    // Calendar heatmap: GitHub-style — 7 rows (Sun-Sat) × N weeks
+    const sorted = [...data].sort((a, b) => a.id.localeCompare(b.id));
+    const cells = sorted.map(c => {
+      const date = new Date(c.id);
+      return { ...c, date };
+    });
+    if (cells.length === 0) {
+      return <div className={cn('text-[12px] text-[var(--amp-semantic-text-muted)]', className)}>No data</div>;
+    }
+    const start = cells[0].date;
+    const startWeek = new Date(start);
+    startWeek.setDate(start.getDate() - start.getDay()); // align to Sunday
+    const cols: HeatmapCell[][] = [];
+    let currentWeek: HeatmapCell[] = new Array(7).fill(null);
+    let weekIdx = 0;
+    for (const cell of cells) {
+      const diffDays = Math.floor((cell.date.getTime() - startWeek.getTime()) / (1000 * 60 * 60 * 24));
+      const w = Math.floor(diffDays / 7);
+      const d = diffDays % 7;
+      while (cols.length <= w) {
+        cols.push(new Array(7).fill(null));
+      }
+      cols[w][d] = cell;
+      weekIdx = w;
+    }
+    void weekIdx;
+
+    const totalW = cols.length * (cellSize + cellGap);
+    const totalH = 7 * (cellSize + cellGap);
+
+    return (
+      <div className={cn('inline-block', className)}>
+        <svg
+          role="img"
+          aria-label={ariaLabel}
+          width={totalW}
+          height={totalH}
+          viewBox={`0 0 ${totalW} ${totalH}`}
+        >
+          {cols.map((week, wi) =>
+            week.map((cell, di) => {
+              const x = wi * (cellSize + cellGap);
+              const y = di * (cellSize + cellGap);
+              if (!cell) {
+                return (
+                  <rect
+                    key={`${wi}-${di}`}
+                    x={x}
+                    y={y}
+                    width={cellSize}
+                    height={cellSize}
+                    rx={2}
+                    fill="transparent"
+                  />
+                );
+              }
+              const b = bucketFor(cell.value);
+              return (
+                <rect
+                  key={cell.id}
+                  x={x}
+                  y={y}
+                  width={cellSize}
+                  height={cellSize}
+                  rx={2}
+                  fill={bucketColor(b)}
+                >
+                  <title>{cell.label ?? `${cell.id}: ${cell.value}`}</title>
+                </rect>
+              );
+            })
+          )}
+        </svg>
+        <table className="sr-only">
+          <caption>{ariaLabel}</caption>
+          <thead>
+            <tr>
+              <th scope="col">Date</th>
+              <th scope="col">Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map(c => (
+              <tr key={c.id}>
+                <th scope="row">{c.id}</th>
+                <td>{c.value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  // Matrix heatmap
+  const rows = rowLabels ?? Array.from(new Set(data.map(d => String(d.row ?? 0)))).sort();
+  const cols = colLabels ?? Array.from(new Set(data.map(d => String(d.col ?? 0)))).sort();
+  const cellMap = new Map<string, HeatmapCell>();
+  for (const d of data) {
+    const r = d.row ?? 0;
+    const c = d.col ?? 0;
+    cellMap.set(`${r}-${c}`, d);
+  }
+  const labelW = 80;
+  const labelH = 20;
+  const matrixW = labelW + cols.length * (cellSize + cellGap);
+  const matrixH = labelH + rows.length * (cellSize + cellGap);
+
+  return (
+    <div className={cn('inline-block', className)}>
+      <svg
+        role="img"
+        aria-label={ariaLabel}
+        width={matrixW}
+        height={matrixH}
+        viewBox={`0 0 ${matrixW} ${matrixH}`}
+      >
+        {/* col headers */}
+        {cols.map((label, ci) => (
+          <text
+            key={`col-${label}-${ci}`}
+            x={labelW + ci * (cellSize + cellGap) + cellSize / 2}
+            y={labelH - 4}
+            fontSize={10}
+            textAnchor="middle"
+            fill="var(--amp-semantic-text-muted, #6b7280)"
+          >
+            {label}
+          </text>
+        ))}
+        {/* row headers + cells */}
+        {rows.map((rowLabel, ri) => (
+          <g key={`row-${rowLabel}-${ri}`}>
+            <text
+              x={labelW - 6}
+              y={labelH + ri * (cellSize + cellGap) + cellSize / 2 + 3}
+              fontSize={10}
+              textAnchor="end"
+              fill="var(--amp-semantic-text-muted, #6b7280)"
+            >
+              {rowLabel}
+            </text>
+            {cols.map((_, ci) => {
+              const cell = cellMap.get(`${ri}-${ci}`);
+              const v = cell?.value ?? 0;
+              const b = bucketFor(v);
+              return (
+                <rect
+                  key={`cell-${ri}-${ci}`}
+                  x={labelW + ci * (cellSize + cellGap)}
+                  y={labelH + ri * (cellSize + cellGap)}
+                  width={cellSize}
+                  height={cellSize}
+                  rx={2}
+                  fill={bucketColor(b)}
+                >
+                  <title>{cell?.label ?? `${rowLabel} × ${cols[ci]}: ${v}`}</title>
+                </rect>
+              );
+            })}
+          </g>
+        ))}
+      </svg>
+      <table className="sr-only">
+        <caption>{ariaLabel}</caption>
+        <thead>
+          <tr>
+            <th scope="col"></th>
+            {cols.map(c => (
+              <th key={c} scope="col">
+                {c}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((rl, ri) => (
+            <tr key={rl}>
+              <th scope="row">{rl}</th>
+              {cols.map((_, ci) => (
+                <td key={`${ri}-${ci}`}>{cellMap.get(`${ri}-${ci}`)?.value ?? ''}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+Heatmap.displayName = 'Heatmap';

--- a/packages/ui/src/components/Heatmap/index.ts
+++ b/packages/ui/src/components/Heatmap/index.ts
@@ -1,0 +1,2 @@
+export { Heatmap } from './Heatmap';
+export type { HeatmapProps, HeatmapCell, HeatmapVariant } from './Heatmap';

--- a/packages/ui/src/components/KPI/KPI.tsx
+++ b/packages/ui/src/components/KPI/KPI.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+import { Sparkline } from '../Sparkline/Sparkline';
+
+export type KPISize = 'md' | 'lg' | 'xl';
+export type KPITrend = 'up' | 'down' | 'neutral';
+
+export interface KPIProps {
+  /** Short label, e.g. "Active Campaigns". */
+  label: string;
+  /** Hero value. Pre-formatted (₹1.2Cr / 12.4K / 87%). */
+  value: string | number;
+  /** Numeric trend percent. Sign determines direction unless `trend` is set. */
+  delta?: number;
+  /** Force trend direction even if delta is missing or zero. */
+  trend?: KPITrend;
+  /** Comparison label, e.g. "vs last week". */
+  deltaLabel?: string;
+  /** Optional secondary subtitle. */
+  subtitle?: string;
+  /** Optional sparkline data (numbers, ordered). */
+  sparkline?: number[];
+  /** Higher-is-better? Inverts colour for delta when false (e.g. churn rate). */
+  higherIsBetter?: boolean;
+  size?: KPISize;
+  /** Optional icon shown next to the label. */
+  icon?: React.ReactNode;
+  /** Click handler — when set, KPI renders as a clickable surface. */
+  onClick?: () => void;
+  className?: string;
+  /** Aria description for screen readers. */
+  'aria-label'?: string;
+}
+
+const sizeStyles: Record<KPISize, { value: string; label: string; padding: string; spark: number }> = {
+  md: { value: 'text-[28px]', label: 'text-[12px]', padding: 'p-5', spark: 24 },
+  lg: { value: 'text-[36px]', label: 'text-[13px]', padding: 'p-6', spark: 32 },
+  xl: { value: 'text-[48px]', label: 'text-[14px]', padding: 'p-7', spark: 40 },
+};
+
+function resolveTrend(delta: number | undefined, explicit: KPITrend | undefined): KPITrend {
+  if (explicit) return explicit;
+  if (delta === undefined || delta === null) return 'neutral';
+  if (delta > 0) return 'up';
+  if (delta < 0) return 'down';
+  return 'neutral';
+}
+
+export const KPI: React.FC<KPIProps> = ({
+  label,
+  value,
+  delta,
+  trend,
+  deltaLabel,
+  subtitle,
+  sparkline,
+  higherIsBetter = true,
+  size = 'lg',
+  icon,
+  onClick,
+  className,
+  'aria-label': ariaLabel,
+}) => {
+  const direction = resolveTrend(delta, trend);
+  // colour reflects "good vs bad" not just "up vs down"
+  const isGood =
+    direction === 'neutral'
+      ? null
+      : (direction === 'up' && higherIsBetter) || (direction === 'down' && !higherIsBetter);
+
+  const trendColor =
+    isGood === true
+      ? 'text-[var(--amp-semantic-status-success,#16a34a)]'
+      : isGood === false
+        ? 'text-[var(--amp-semantic-status-error,#dc2626)]'
+        : 'text-[var(--amp-semantic-text-muted,#6b7280)]';
+
+  const styles = sizeStyles[size];
+  const isInteractive = !!onClick;
+  const surfaceClass = cn(
+    'block w-full text-left rounded-[16px] border border-[var(--amp-semantic-border-default,#e5e7eb)] bg-[var(--amp-semantic-bg-surface,#ffffff)]',
+    styles.padding,
+    isInteractive &&
+      'cursor-pointer transition-colors hover:border-[var(--amp-semantic-accent,#7c3aed)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--amp-semantic-accent,#7c3aed)]',
+    className
+  );
+  const inner = (
+    <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5">
+            {icon && <span className="text-[var(--amp-semantic-text-muted,#6b7280)]">{icon}</span>}
+            <p
+              className={cn(
+                styles.label,
+                'font-medium uppercase tracking-wide text-[var(--amp-semantic-text-secondary,#374151)]'
+              )}
+            >
+              {label}
+            </p>
+          </div>
+          <p
+            className={cn(
+              styles.value,
+              'mt-1 font-bold leading-tight text-[var(--amp-semantic-text-primary,#111827)] tabular-nums'
+            )}
+          >
+            {value}
+          </p>
+          {(delta !== undefined || subtitle) && (
+            <div className="mt-2 flex items-center gap-2 flex-wrap">
+              {delta !== undefined && (
+                <span className={cn('inline-flex items-center gap-0.5 text-[13px] font-medium', trendColor)}>
+                  <TrendIcon direction={direction} />
+                  {delta > 0 && '+'}
+                  {delta.toFixed(Math.abs(delta) < 10 ? 1 : 0)}%
+                </span>
+              )}
+              {deltaLabel && (
+                <span className="text-[12px] text-[var(--amp-semantic-text-muted,#6b7280)]">
+                  {deltaLabel}
+                </span>
+              )}
+              {!deltaLabel && subtitle && (
+                <span className="text-[12px] text-[var(--amp-semantic-text-muted,#6b7280)]">
+                  {subtitle}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      {sparkline && sparkline.length > 0 && (
+        <div className="shrink-0 text-[var(--amp-semantic-accent,#7c3aed)]">
+          <Sparkline
+            data={sparkline}
+            variant="area"
+            width={80}
+            height={styles.spark}
+            ariaLabel={`${label} trend`}
+          />
+        </div>
+      )}
+    </div>
+  );
+
+  if (isInteractive) {
+    return (
+      <button type="button" onClick={onClick} aria-label={ariaLabel} className={surfaceClass}>
+        {inner}
+      </button>
+    );
+  }
+  return (
+    <div aria-label={ariaLabel} className={surfaceClass}>
+      {inner}
+    </div>
+  );
+};
+
+KPI.displayName = 'KPI';
+
+function TrendIcon({ direction }: { direction: KPITrend }) {
+  if (direction === 'neutral') {
+    return (
+      <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+        <path strokeLinecap="round" d="M5 12h14" />
+      </svg>
+    );
+  }
+  return (
+    <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d={direction === 'up' ? 'M5 15l7-7 7 7' : 'M19 9l-7 7-7-7'}
+      />
+    </svg>
+  );
+}

--- a/packages/ui/src/components/KPI/index.ts
+++ b/packages/ui/src/components/KPI/index.ts
@@ -1,0 +1,2 @@
+export { KPI } from './KPI';
+export type { KPIProps, KPISize, KPITrend } from './KPI';

--- a/packages/ui/src/components/LineChart/LineChart.tsx
+++ b/packages/ui/src/components/LineChart/LineChart.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { cn } from '../../lib/cn';
+import {
+  DEFAULT_CHART_COLORS,
+  buildLinePath,
+  extentMulti,
+  formatCompact,
+  linearScale,
+  niceTicks,
+  pickColor,
+} from '../../lib/chart-utils';
+
+export interface LineChartSeries {
+  name: string;
+  /** Per-x-axis-index numeric values. Length must equal `xAxis.length`. */
+  values: Array<number | null>;
+  color?: string;
+  strokeWidth?: number;
+  strokeDasharray?: string;
+}
+
+export interface LineChartProps {
+  /** X-axis category labels. */
+  xAxis: string[];
+  /** One or more data series. */
+  series: LineChartSeries[];
+  /** Chart height in px. Width is always responsive (100%). */
+  height?: number;
+  /** Optional explicit y-axis [min, max]. Defaults to data extent. */
+  yDomain?: [number, number];
+  /** Show legend below chart. Defaults true if >1 series. */
+  showLegend?: boolean;
+  /** Show grid lines. */
+  showGrid?: boolean;
+  /** Custom y-axis tick formatter. */
+  yTickFormat?: (value: number) => string;
+  /** Hover tooltip renderer. Receives the active x-axis index. */
+  tooltip?: (xIndex: number, xLabel: string, series: LineChartSeries[]) => React.ReactNode;
+  /** Accessible label for screen readers. */
+  ariaLabel: string;
+  className?: string;
+}
+
+const DEFAULT_HEIGHT = 240;
+const PADDING = { top: 16, right: 16, bottom: 28, left: 44 };
+
+export const LineChart: React.FC<LineChartProps> = ({
+  xAxis,
+  series,
+  height = DEFAULT_HEIGHT,
+  yDomain,
+  showLegend,
+  showGrid = true,
+  yTickFormat = formatCompact,
+  tooltip,
+  ariaLabel,
+  className,
+}) => {
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+  // Use a fixed viewBox; scale via SVG preserveAspectRatio for responsiveness.
+  const VB_WIDTH = 600;
+  const VB_HEIGHT = height;
+
+  const computed = useMemo(() => {
+    const allValues = series.map(s => s.values.filter((v): v is number => v != null));
+    const [dataMin, dataMax] = yDomain ?? extentMulti(allValues);
+    const yMin = Math.min(0, dataMin);
+    const yMax = dataMax === yMin ? yMin + 1 : dataMax;
+    const ticks = niceTicks(yMin, yMax, 5);
+    const yScaleMin = ticks[0];
+    const yScaleMax = ticks[ticks.length - 1];
+
+    const innerW = VB_WIDTH - PADDING.left - PADDING.right;
+    const innerH = VB_HEIGHT - PADDING.top - PADDING.bottom;
+    const stepX = xAxis.length > 1 ? innerW / (xAxis.length - 1) : innerW;
+
+    const seriesPaths = series.map((s, sIdx) => {
+      const points = s.values
+        .map((v, i) =>
+          v == null
+            ? null
+            : {
+                x: PADDING.left + i * stepX,
+                y: PADDING.top + linearScale(v, yScaleMin, yScaleMax, innerH, 0),
+              }
+        )
+        .filter((p): p is { x: number; y: number } => p !== null);
+      return {
+        path: buildLinePath(points),
+        color: s.color ?? pickColor(sIdx),
+        strokeWidth: s.strokeWidth ?? 2,
+        strokeDasharray: s.strokeDasharray,
+        points,
+      };
+    });
+
+    return { ticks, yScaleMin, yScaleMax, innerW, innerH, stepX, seriesPaths };
+  }, [series, xAxis, yDomain, VB_HEIGHT]);
+
+  const showLegendResolved = showLegend ?? series.length > 1;
+
+  function onMove(e: React.MouseEvent<SVGRectElement>) {
+    if (xAxis.length === 0) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const ratio = (e.clientX - rect.left) / rect.width;
+    const localX = ratio * VB_WIDTH - PADDING.left;
+    const idx = Math.max(0, Math.min(xAxis.length - 1, Math.round(localX / computed.stepX)));
+    setHoverIdx(idx);
+  }
+
+  return (
+    <div className={cn('w-full', className)}>
+      <svg
+        role="img"
+        aria-label={ariaLabel}
+        viewBox={`0 0 ${VB_WIDTH} ${VB_HEIGHT}`}
+        preserveAspectRatio="none"
+        className="w-full"
+        style={{ height }}
+      >
+        {/* gridlines + y-axis ticks */}
+        {computed.ticks.map(tick => {
+          const y = PADDING.top + linearScale(tick, computed.yScaleMin, computed.yScaleMax, computed.innerH, 0);
+          return (
+            <g key={tick}>
+              {showGrid && (
+                <line
+                  x1={PADDING.left}
+                  x2={VB_WIDTH - PADDING.right}
+                  y1={y}
+                  y2={y}
+                  stroke="var(--amp-semantic-border-default, #e5e7eb)"
+                  strokeWidth={1}
+                  strokeDasharray="2 4"
+                />
+              )}
+              <text
+                x={PADDING.left - 6}
+                y={y + 4}
+                fontSize={11}
+                textAnchor="end"
+                fill="var(--amp-semantic-text-muted, #6b7280)"
+              >
+                {yTickFormat(tick)}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* x-axis labels */}
+        {xAxis.map((label, i) => {
+          if (xAxis.length > 12 && i % Math.ceil(xAxis.length / 8) !== 0) return null;
+          const x = PADDING.left + i * computed.stepX;
+          return (
+            <text
+              key={`${label}-${i}`}
+              x={x}
+              y={VB_HEIGHT - 8}
+              fontSize={11}
+              textAnchor="middle"
+              fill="var(--amp-semantic-text-muted, #6b7280)"
+            >
+              {label}
+            </text>
+          );
+        })}
+
+        {/* series lines */}
+        {computed.seriesPaths.map((sp, i) => (
+          <path
+            key={i}
+            d={sp.path}
+            fill="none"
+            stroke={sp.color}
+            strokeWidth={sp.strokeWidth}
+            strokeDasharray={sp.strokeDasharray}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        ))}
+
+        {/* hover marker */}
+        {hoverIdx !== null && (
+          <line
+            x1={PADDING.left + hoverIdx * computed.stepX}
+            x2={PADDING.left + hoverIdx * computed.stepX}
+            y1={PADDING.top}
+            y2={PADDING.top + computed.innerH}
+            stroke="var(--amp-semantic-text-muted, #9ca3af)"
+            strokeWidth={1}
+            strokeDasharray="3 3"
+          />
+        )}
+        {hoverIdx !== null &&
+          computed.seriesPaths.map((sp, i) => {
+            const v = series[i].values[hoverIdx];
+            if (v == null) return null;
+            const cx = PADDING.left + hoverIdx * computed.stepX;
+            const cy = PADDING.top + linearScale(v, computed.yScaleMin, computed.yScaleMax, computed.innerH, 0);
+            return <circle key={i} cx={cx} cy={cy} r={4} fill={sp.color} stroke="white" strokeWidth={2} />;
+          })}
+
+        {/* invisible hover layer */}
+        <rect
+          x={PADDING.left}
+          y={PADDING.top}
+          width={computed.innerW}
+          height={computed.innerH}
+          fill="transparent"
+          onMouseMove={onMove}
+          onMouseLeave={() => setHoverIdx(null)}
+        />
+      </svg>
+
+      {/* tooltip */}
+      {hoverIdx !== null && tooltip && (
+        <div className="mt-2 text-[12px]">{tooltip(hoverIdx, xAxis[hoverIdx], series)}</div>
+      )}
+
+      {/* legend */}
+      {showLegendResolved && (
+        <ul className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-[12px]">
+          {series.map((s, i) => (
+            <li key={s.name} className="flex items-center gap-1.5">
+              <span
+                className="inline-block w-3 h-1 rounded"
+                style={{ backgroundColor: s.color ?? pickColor(i) }}
+              />
+              <span className="text-[var(--amp-semantic-text-secondary,#374151)]">{s.name}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* SR-only data table fallback */}
+      <table className="sr-only">
+        <caption>{ariaLabel}</caption>
+        <thead>
+          <tr>
+            <th scope="col">X</th>
+            {series.map(s => (
+              <th key={s.name} scope="col">
+                {s.name}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {xAxis.map((label, i) => (
+            <tr key={label}>
+              <th scope="row">{label}</th>
+              {series.map(s => (
+                <td key={s.name}>{s.values[i] ?? ''}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+LineChart.displayName = 'LineChart';

--- a/packages/ui/src/components/LineChart/index.ts
+++ b/packages/ui/src/components/LineChart/index.ts
@@ -1,0 +1,2 @@
+export { LineChart } from './LineChart';
+export type { LineChartProps, LineChartSeries } from './LineChart';

--- a/packages/ui/src/components/PieChart/PieChart.tsx
+++ b/packages/ui/src/components/PieChart/PieChart.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { cn } from '../../lib/cn';
+import { arcPath, pickColor, sum } from '../../lib/chart-utils';
+
+export type PieChartVariant = 'pie' | 'donut';
+
+export interface PieChartSlice {
+  name: string;
+  value: number;
+  color?: string;
+}
+
+export interface PieChartProps {
+  data: PieChartSlice[];
+  /** 'pie' (full slices) or 'donut' (with hole). Defaults to 'donut'. */
+  variant?: PieChartVariant;
+  /** Outer diameter in px. */
+  size?: number;
+  /** Donut hole ratio (0–1). Only applies when variant='donut'. Default 0.6. */
+  innerRadiusRatio?: number;
+  /** Slot rendered in the center (donut variant only). */
+  centerSlot?: React.ReactNode;
+  showLegend?: boolean;
+  ariaLabel: string;
+  className?: string;
+}
+
+export const PieChart: React.FC<PieChartProps> = ({
+  data,
+  variant = 'donut',
+  size = 200,
+  innerRadiusRatio = 0.6,
+  centerSlot,
+  showLegend = true,
+  ariaLabel,
+  className,
+}) => {
+  const total = sum(data.map(d => d.value));
+  const radius = size / 2;
+  const innerR = variant === 'donut' ? radius * innerRadiusRatio : 0;
+
+  const slices = useMemo(() => {
+    if (total <= 0) return [];
+    let angle = -Math.PI / 2; // start at 12 o'clock
+    return data.map((slice, i) => {
+      const portion = slice.value / total;
+      const startAngle = angle;
+      const endAngle = angle + portion * 2 * Math.PI;
+      angle = endAngle;
+      const path = arcPath(radius, radius, radius, innerR, startAngle, endAngle);
+      return {
+        ...slice,
+        color: slice.color ?? pickColor(i),
+        path,
+        portion,
+      };
+    });
+  }, [data, total, radius, innerR]);
+
+  return (
+    <div className={cn('inline-flex flex-col items-center', className)}>
+      <div className="relative" style={{ width: size, height: size }}>
+        <svg
+          role="img"
+          aria-label={ariaLabel}
+          viewBox={`0 0 ${size} ${size}`}
+          width={size}
+          height={size}
+        >
+          {slices.length === 0 ? (
+            <circle
+              cx={radius}
+              cy={radius}
+              r={radius - 1}
+              fill="none"
+              stroke="var(--amp-semantic-border-default, #e5e7eb)"
+              strokeWidth={2}
+            />
+          ) : (
+            slices.map(s => (
+              <path
+                key={s.name}
+                d={s.path}
+                fill={s.color}
+                stroke="var(--amp-semantic-bg-surface, #ffffff)"
+                strokeWidth={1}
+              />
+            ))
+          )}
+        </svg>
+        {variant === 'donut' && centerSlot && (
+          <div
+            className="absolute inset-0 flex items-center justify-center text-center pointer-events-none"
+            style={{ padding: innerR * 0.4 }}
+          >
+            {centerSlot}
+          </div>
+        )}
+      </div>
+
+      {showLegend && (
+        <ul className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1 text-[12px]">
+          {slices.map(s => (
+            <li key={s.name} className="flex items-center gap-1.5">
+              <span
+                className="inline-block w-3 h-3 rounded-sm shrink-0"
+                style={{ backgroundColor: s.color }}
+              />
+              <span className="text-[var(--amp-semantic-text-secondary,#374151)] truncate">
+                {s.name}
+              </span>
+              <span className="text-[var(--amp-semantic-text-muted,#6b7280)] ml-auto">
+                {(s.portion * 100).toFixed(0)}%
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <table className="sr-only">
+        <caption>{ariaLabel}</caption>
+        <thead>
+          <tr>
+            <th scope="col">Slice</th>
+            <th scope="col">Value</th>
+            <th scope="col">Share</th>
+          </tr>
+        </thead>
+        <tbody>
+          {slices.map(s => (
+            <tr key={s.name}>
+              <th scope="row">{s.name}</th>
+              <td>{s.value}</td>
+              <td>{(s.portion * 100).toFixed(1)}%</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+PieChart.displayName = 'PieChart';

--- a/packages/ui/src/components/PieChart/index.ts
+++ b/packages/ui/src/components/PieChart/index.ts
@@ -1,0 +1,2 @@
+export { PieChart } from './PieChart';
+export type { PieChartProps, PieChartSlice, PieChartVariant } from './PieChart';

--- a/packages/ui/src/components/ProgressRing/ProgressRing.tsx
+++ b/packages/ui/src/components/ProgressRing/ProgressRing.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export type ProgressRingSize = 'sm' | 'md' | 'lg' | 'xl';
+export type ProgressRingVariant = 'default' | 'success' | 'warning' | 'error' | 'accent';
+
+export interface ProgressRingProps {
+  /** Progress value, 0–100. Clamped. */
+  value: number;
+  size?: ProgressRingSize;
+  variant?: ProgressRingVariant;
+  /** Stroke width in px (overrides size default). */
+  strokeWidth?: number;
+  /** Slot rendered in the center (e.g. label, percentage, value). */
+  children?: React.ReactNode;
+  /** Hide the default centered percentage label (when no children). */
+  hideLabel?: boolean;
+  /** Aria-label. Defaults to "{value}% complete". */
+  ariaLabel?: string;
+  className?: string;
+}
+
+const sizePx: Record<ProgressRingSize, number> = {
+  sm: 40,
+  md: 64,
+  lg: 96,
+  xl: 144,
+};
+const sizeStrokeDefault: Record<ProgressRingSize, number> = {
+  sm: 4,
+  md: 6,
+  lg: 8,
+  xl: 12,
+};
+const variantColor: Record<ProgressRingVariant, string> = {
+  default: 'var(--amp-semantic-text-secondary, #374151)',
+  accent: 'var(--amp-semantic-accent, #7c3aed)',
+  success: 'var(--amp-semantic-status-success, #16a34a)',
+  warning: 'var(--amp-semantic-status-warning, #d97706)',
+  error: 'var(--amp-semantic-status-error, #dc2626)',
+};
+const labelTextSize: Record<ProgressRingSize, string> = {
+  sm: 'text-[10px]',
+  md: 'text-[12px]',
+  lg: 'text-[16px]',
+  xl: 'text-[22px]',
+};
+
+export const ProgressRing: React.FC<ProgressRingProps> = ({
+  value,
+  size = 'md',
+  variant = 'accent',
+  strokeWidth,
+  children,
+  hideLabel = false,
+  ariaLabel,
+  className,
+}) => {
+  const px = sizePx[size];
+  const sw = strokeWidth ?? sizeStrokeDefault[size];
+  const r = (px - sw) / 2;
+  const cx = px / 2;
+  const cy = px / 2;
+  const circumference = 2 * Math.PI * r;
+  const clamped = Math.max(0, Math.min(100, value));
+  const dashOffset = circumference * (1 - clamped / 100);
+
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={Math.round(clamped)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label={ariaLabel ?? `${Math.round(clamped)}% complete`}
+      className={cn('relative inline-flex items-center justify-center', className)}
+      style={{ width: px, height: px }}
+    >
+      <svg width={px} height={px} viewBox={`0 0 ${px} ${px}`} className="-rotate-90">
+        <circle
+          cx={cx}
+          cy={cy}
+          r={r}
+          fill="none"
+          stroke="var(--amp-semantic-bg-subtle, #f3f4f6)"
+          strokeWidth={sw}
+        />
+        <circle
+          cx={cx}
+          cy={cy}
+          r={r}
+          fill="none"
+          stroke={variantColor[variant]}
+          strokeWidth={sw}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+          style={{ transition: 'stroke-dashoffset 320ms ease' }}
+        />
+      </svg>
+      {children !== undefined ? (
+        <div className={cn('absolute inset-0 flex items-center justify-center text-center', labelTextSize[size])}>
+          {children}
+        </div>
+      ) : !hideLabel ? (
+        <div
+          className={cn(
+            'absolute inset-0 flex items-center justify-center font-semibold tabular-nums text-[var(--amp-semantic-text-primary,#111827)]',
+            labelTextSize[size]
+          )}
+        >
+          {Math.round(clamped)}%
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+ProgressRing.displayName = 'ProgressRing';

--- a/packages/ui/src/components/ProgressRing/index.ts
+++ b/packages/ui/src/components/ProgressRing/index.ts
@@ -1,0 +1,2 @@
+export { ProgressRing } from './ProgressRing';
+export type { ProgressRingProps, ProgressRingSize, ProgressRingVariant } from './ProgressRing';

--- a/packages/ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/ui/src/components/Sparkline/Sparkline.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { cn } from '../../lib/cn';
+import { buildAreaPath, buildLinePath, linearScale } from '../../lib/chart-utils';
+
+export type SparklineVariant = 'line' | 'bar' | 'area';
+
+export interface SparklineProps {
+  data: number[];
+  variant?: SparklineVariant;
+  width?: number;
+  height?: number;
+  /** Stroke / bar fill color. Defaults to currentColor. */
+  color?: string;
+  /** Highlight last data point with a dot (line/area variants). */
+  showLastPoint?: boolean;
+  ariaLabel: string;
+  className?: string;
+}
+
+export const Sparkline: React.FC<SparklineProps> = ({
+  data,
+  variant = 'line',
+  width = 80,
+  height = 24,
+  color = 'currentColor',
+  showLastPoint = true,
+  ariaLabel,
+  className,
+}) => {
+  const computed = useMemo(() => {
+    if (data.length === 0) return null;
+    const min = Math.min(...data);
+    const max = Math.max(...data);
+    const safeMin = min === max ? min - 1 : min;
+    const safeMax = min === max ? max + 1 : max;
+    const stepX = data.length > 1 ? (width - 2) / (data.length - 1) : 0;
+    const points = data.map((v, i) => ({
+      x: 1 + i * stepX,
+      y: 1 + linearScale(v, safeMin, safeMax, height - 2, 0),
+    }));
+    return { points, min: safeMin, max: safeMax, stepX };
+  }, [data, width, height]);
+
+  return (
+    <span
+      role="img"
+      aria-label={ariaLabel}
+      className={cn('inline-block align-middle', className)}
+      style={{ width, height, color }}
+    >
+      <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
+        {computed && variant === 'line' && (
+          <>
+            <path
+              d={buildLinePath(computed.points)}
+              fill="none"
+              stroke={color}
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            {showLastPoint && computed.points.length > 0 && (
+              <circle
+                cx={computed.points[computed.points.length - 1].x}
+                cy={computed.points[computed.points.length - 1].y}
+                r={2}
+                fill={color}
+              />
+            )}
+          </>
+        )}
+
+        {computed && variant === 'area' && (
+          <>
+            <path
+              d={buildAreaPath(computed.points, height - 1)}
+              fill={color}
+              fillOpacity={0.18}
+              stroke="none"
+            />
+            <path
+              d={buildLinePath(computed.points)}
+              fill="none"
+              stroke={color}
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            {showLastPoint && computed.points.length > 0 && (
+              <circle
+                cx={computed.points[computed.points.length - 1].x}
+                cy={computed.points[computed.points.length - 1].y}
+                r={2}
+                fill={color}
+              />
+            )}
+          </>
+        )}
+
+        {computed && variant === 'bar' && (
+          <g>
+            {(() => {
+              const barW = computed.stepX > 0 ? Math.max(1, computed.stepX - 1) : Math.max(1, width - 2);
+              return data.map((v, i) => {
+                const yTop = 1 + linearScale(v, computed.min, computed.max, height - 2, 0);
+                const yBase = height - 1;
+                const x = 1 + i * (computed.stepX || 0);
+                return (
+                  <rect
+                    key={i}
+                    x={x}
+                    y={yTop}
+                    width={barW}
+                    height={Math.max(1, yBase - yTop)}
+                    fill={color}
+                  />
+                );
+              });
+            })()}
+          </g>
+        )}
+      </svg>
+    </span>
+  );
+};
+
+Sparkline.displayName = 'Sparkline';

--- a/packages/ui/src/components/Sparkline/index.ts
+++ b/packages/ui/src/components/Sparkline/index.ts
@@ -1,0 +1,2 @@
+export { Sparkline } from './Sparkline';
+export type { SparklineProps, SparklineVariant } from './Sparkline';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -197,3 +197,37 @@ export type { ActionFooterProps } from './components/ActionFooter';
 // PricePill
 export { PricePill } from './components/PricePill';
 export type { PricePillProps } from './components/PricePill';
+
+// --- Phase B Wave 3 — Data viz primitives ---
+
+// LineChart
+export { LineChart } from './components/LineChart';
+export type { LineChartProps, LineChartSeries } from './components/LineChart';
+
+// BarChart
+export { BarChart } from './components/BarChart';
+export type { BarChartProps, BarChartSeries, BarChartLayout } from './components/BarChart';
+
+// PieChart
+export { PieChart } from './components/PieChart';
+export type { PieChartProps, PieChartSlice, PieChartVariant } from './components/PieChart';
+
+// Sparkline
+export { Sparkline } from './components/Sparkline';
+export type { SparklineProps, SparklineVariant } from './components/Sparkline';
+
+// Heatmap
+export { Heatmap } from './components/Heatmap';
+export type { HeatmapProps, HeatmapCell, HeatmapVariant } from './components/Heatmap';
+
+// Funnel
+export { Funnel } from './components/Funnel';
+export type { FunnelProps, FunnelStage } from './components/Funnel';
+
+// KPI
+export { KPI } from './components/KPI';
+export type { KPIProps, KPISize, KPITrend } from './components/KPI';
+
+// ProgressRing
+export { ProgressRing } from './components/ProgressRing';
+export type { ProgressRingProps, ProgressRingSize, ProgressRingVariant } from './components/ProgressRing';

--- a/packages/ui/src/lib/chart-utils.ts
+++ b/packages/ui/src/lib/chart-utils.ts
@@ -1,0 +1,150 @@
+/**
+ * Shared SVG/chart utility helpers used by data viz primitives.
+ * Hand-rolled (no chart lib dep) — keeps @amplify-ai/ui zero-runtime-dep aside from clsx.
+ */
+
+/** Default chart colour palette — references CSS vars defined in @amplify/tokens-* */
+// TODO(phase-a): swap to design-token CSS vars once tokens-foundation v2.x ships
+export const DEFAULT_CHART_COLORS = [
+  'var(--amp-semantic-accent, #7c3aed)',
+  'var(--amp-semantic-status-info, #2563eb)',
+  'var(--amp-semantic-status-success, #16a34a)',
+  'var(--amp-semantic-status-warning, #d97706)',
+  'var(--amp-semantic-status-error, #dc2626)',
+  'var(--amp-semantic-accent-2, #ec4899)',
+  'var(--amp-semantic-accent-3, #06b6d4)',
+  'var(--amp-semantic-accent-4, #84cc16)',
+];
+
+export function pickColor(index: number, colors: readonly string[] = DEFAULT_CHART_COLORS): string {
+  return colors[index % colors.length];
+}
+
+/** Linear scale: maps a value in [domainMin, domainMax] to [rangeMin, rangeMax]. */
+export function linearScale(
+  value: number,
+  domainMin: number,
+  domainMax: number,
+  rangeMin: number,
+  rangeMax: number
+): number {
+  if (domainMax === domainMin) return rangeMin;
+  const t = (value - domainMin) / (domainMax - domainMin);
+  return rangeMin + t * (rangeMax - rangeMin);
+}
+
+/** Compute "nice" tick values for a numeric axis. */
+export function niceTicks(min: number, max: number, count = 5): number[] {
+  if (min === max) return [min];
+  const range = niceNumber(max - min, false);
+  const step = niceNumber(range / (count - 1), true);
+  const niceMin = Math.floor(min / step) * step;
+  const niceMax = Math.ceil(max / step) * step;
+  const ticks: number[] = [];
+  for (let v = niceMin; v <= niceMax + 1e-9; v += step) {
+    ticks.push(parseFloat(v.toFixed(10)));
+  }
+  return ticks;
+}
+
+function niceNumber(range: number, round: boolean): number {
+  const exponent = Math.floor(Math.log10(range));
+  const fraction = range / Math.pow(10, exponent);
+  let niceFraction: number;
+  if (round) {
+    if (fraction < 1.5) niceFraction = 1;
+    else if (fraction < 3) niceFraction = 2;
+    else if (fraction < 7) niceFraction = 5;
+    else niceFraction = 10;
+  } else {
+    if (fraction <= 1) niceFraction = 1;
+    else if (fraction <= 2) niceFraction = 2;
+    else if (fraction <= 5) niceFraction = 5;
+    else niceFraction = 10;
+  }
+  return niceFraction * Math.pow(10, exponent);
+}
+
+/** Format number for axis labels (compact: 1.2K, 3.4M). */
+export function formatCompact(value: number): string {
+  const abs = Math.abs(value);
+  if (abs >= 1e9) return (value / 1e9).toFixed(abs >= 1e10 ? 0 : 1) + 'B';
+  if (abs >= 1e6) return (value / 1e6).toFixed(abs >= 1e7 ? 0 : 1) + 'M';
+  if (abs >= 1e3) return (value / 1e3).toFixed(abs >= 1e4 ? 0 : 1) + 'K';
+  if (Number.isInteger(value)) return String(value);
+  return value.toFixed(1);
+}
+
+/** Build a smooth-ish SVG path for a polyline (linear segments). */
+export function buildLinePath(points: Array<{ x: number; y: number }>): string {
+  if (points.length === 0) return '';
+  return points
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x.toFixed(2)},${p.y.toFixed(2)}`)
+    .join(' ');
+}
+
+/** Build a closed area path (line + bottom edge) for area charts / sparklines. */
+export function buildAreaPath(
+  points: Array<{ x: number; y: number }>,
+  baselineY: number
+): string {
+  if (points.length === 0) return '';
+  const line = buildLinePath(points);
+  const last = points[points.length - 1];
+  const first = points[0];
+  return `${line} L${last.x.toFixed(2)},${baselineY.toFixed(2)} L${first.x.toFixed(2)},${baselineY.toFixed(2)} Z`;
+}
+
+/** Compute SVG arc for pie/donut slices. cx,cy = center; r = radius. */
+export function arcPath(
+  cx: number,
+  cy: number,
+  rOuter: number,
+  rInner: number,
+  startAngle: number,
+  endAngle: number
+): string {
+  const largeArc = endAngle - startAngle > Math.PI ? 1 : 0;
+  const x0 = cx + rOuter * Math.cos(startAngle);
+  const y0 = cy + rOuter * Math.sin(startAngle);
+  const x1 = cx + rOuter * Math.cos(endAngle);
+  const y1 = cy + rOuter * Math.sin(endAngle);
+  if (rInner <= 0) {
+    return `M${cx},${cy} L${x0},${y0} A${rOuter},${rOuter} 0 ${largeArc} 1 ${x1},${y1} Z`;
+  }
+  const xi0 = cx + rInner * Math.cos(endAngle);
+  const yi0 = cy + rInner * Math.sin(endAngle);
+  const xi1 = cx + rInner * Math.cos(startAngle);
+  const yi1 = cy + rInner * Math.sin(startAngle);
+  return [
+    `M${x0},${y0}`,
+    `A${rOuter},${rOuter} 0 ${largeArc} 1 ${x1},${y1}`,
+    `L${xi0},${yi0}`,
+    `A${rInner},${rInner} 0 ${largeArc} 0 ${xi1},${yi1}`,
+    'Z',
+  ].join(' ');
+}
+
+/** Sum helper that ignores NaN/undefined. */
+export function sum(values: ReadonlyArray<number | null | undefined>): number {
+  let total = 0;
+  for (const v of values) {
+    if (typeof v === 'number' && Number.isFinite(v)) total += v;
+  }
+  return total;
+}
+
+/** Min/max across nested arrays of numbers (multi-series). */
+export function extentMulti(seriesValues: ReadonlyArray<ReadonlyArray<number>>): [number, number] {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const row of seriesValues) {
+    for (const v of row) {
+      if (!Number.isFinite(v)) continue;
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+  }
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return [0, 1];
+  return [min, max];
+}


### PR DESCRIPTION
## Summary

Adds 8 hand-rolled SVG data viz components to `@amplify-ai/ui` v2.3.0 — zero new deps, all rendered through a shared `lib/chart-utils.ts`.

**New (8):** `LineChart`, `BarChart` (vertical/horizontal/stacked/grouped), `PieChart` (donut+pie), `Sparkline` (line/bar/area), `Heatmap` (calendar+matrix), `Funnel`, `KPI` (sm/md/lg/xl + sparkline slot + `higherIsBetter` inversion), `ProgressRing` (4 sizes, 5 variants, center slot).

**Existing components left untouched** — `MetricCard`, `Timeline`, `ProgressBar` are extension points; not rebuilt per the brief.

## Approach

- **No new chart library.** Hand-rolled SVG via shared utilities (`linearScale`, `niceTicks`, `arcPath`, `buildLinePath`, `buildAreaPath`, `formatCompact`).
- **Responsive.** Charts use `viewBox` + `width=100%`; consumers pass `height`.
- **A11y.** Every chart has `role="img"` + descriptive `aria-label` + SR-only `<table>` fallback with the same data.
- **Tokens.** Color via existing CSS vars with hex fallbacks (`var(--amp-semantic-accent, #7c3aed)`); shadows TBD once Phase A tokens v2.x lands (`// TODO(phase-a)` markers).
- **Realistic stories** — campaigns / GMV in ₹Cr / creator pipelines / brand churn / payment recovery.
- `'use client'` on all chart components (hover state / measurements).

## Verification

- [x] `tsc --noEmit` clean (only pre-existing Button.test.tsx error)
- [x] `npm run build` → 150KB ESM bundle, contracts + llms docs generated for 54 components
- [x] `storybook build` → all 8 new story files bundled
- [x] `vitest run` → 20/20 tests pass
- [x] Bumps `packages/ui` to **2.3.0**

## Test plan

- [ ] Visual review in Storybook (`npm run storybook`) — Data Viz section
- [ ] Spot-check responsive reflow at narrow widths
- [ ] axe a11y check on each story (addon-a11y already wired)
- [ ] Confirm no regression in sibling Wave 1 / Wave 2 / Phase A branches after merge

## Constraints met

- All visual primitives in `@amplify/ui` (no product-level UI)
- No new dependency packages
- Does not publish to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)