### PR TITLE
chore(gitignore): exclude .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist/
 .DS_Store
 .env
 .env.local
+
+# Claude Code agent worktrees (created by Agent tool with isolation: "worktree")
+.claude/worktrees/


### PR DESCRIPTION
Excludes `.claude/worktrees/` from git. Claude Code Agent tool isolation dirs land there.