### PR TITLE
feat(ui): page affordances — Banner, Kbd, Notification, Tour

### DIFF
--- a/packages/ui/component-status.json
+++ b/packages/ui/component-status.json
@@ -88,6 +88,10 @@
     "MarkdownEditor": { "status": "alpha", "since": "2.4.0" },
     "BentoGrid": { "status": "alpha", "since": "2.4.0" },
     "MasonryGrid": { "status": "alpha", "since": "2.4.0" },
-    "SplitPane": { "status": "alpha", "since": "2.4.0" }
+    "SplitPane": { "status": "alpha", "since": "2.4.0" },
+    "Banner": { "status": "beta", "since": "2.6.0" },
+    "Kbd": { "status": "beta", "since": "2.6.0" },
+    "Notification": { "status": "beta", "since": "2.6.0" },
+    "Tour": { "status": "beta", "since": "2.6.0" }
   }
 }

--- a/packages/ui/src/components/Banner/Banner.stories.tsx
+++ b/packages/ui/src/components/Banner/Banner.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Banner } from './Banner';
+
+const meta = {
+  title: 'Components/Banner',
+  component: Banner,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['info', 'warning', 'error', 'success'] },
+    dismissible: { control: 'boolean' },
+  },
+} satisfies Meta<typeof Banner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Info: Story = {
+  args: {
+    variant: 'info',
+    title: 'Scheduled maintenance',
+    message: 'Atmosphere will be briefly unavailable Friday at 02:00 UTC.',
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    variant: 'warning',
+    title: 'Action required',
+    message: 'Verify your billing address before your next invoice.',
+    dismissible: true,
+  },
+};
+
+export const Error: Story = {
+  args: {
+    variant: 'error',
+    title: 'Payment failed',
+    message: 'We could not process your last payment. Update your card to avoid service interruption.',
+  },
+};
+
+export const SuccessWithActions: Story = {
+  args: {
+    variant: 'success',
+    message: 'Your campaign is live and visible to creators.',
+    actions: (
+      <button
+        type="button"
+        className="text-[13px] font-medium underline text-[var(--amp-semantic-text-primary)]"
+      >
+        View campaign
+      </button>
+    ),
+    dismissible: true,
+  },
+};

--- a/packages/ui/src/components/Banner/Banner.test.tsx
+++ b/packages/ui/src/components/Banner/Banner.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Banner } from './Banner';
+
+describe('Banner', () => {
+  it('renders message and title', () => {
+    render(<Banner variant="info" title="Heads up" message="Hello world" />);
+    expect(screen.getByText('Heads up')).toBeDefined();
+    expect(screen.getByText('Hello world')).toBeDefined();
+  });
+
+  it('uses role="alert" for warning + error variants', () => {
+    const { rerender } = render(<Banner variant="warning" message="warn" />);
+    expect(screen.getByRole('alert')).toBeDefined();
+    rerender(<Banner variant="error" message="err" />);
+    expect(screen.getByRole('alert')).toBeDefined();
+  });
+
+  it('uses role="status" for info + success', () => {
+    const { rerender } = render(<Banner variant="info" message="info" />);
+    expect(screen.getByRole('status')).toBeDefined();
+    rerender(<Banner variant="success" message="ok" />);
+    expect(screen.getByRole('status')).toBeDefined();
+  });
+
+  it('fires onDismiss when dismiss button clicked', () => {
+    const onDismiss = vi.fn();
+    render(
+      <Banner variant="info" message="msg" dismissible onDismiss={onDismiss} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders action slot', () => {
+    render(
+      <Banner
+        variant="info"
+        message="msg"
+        actions={<button data-testid="cta">Go</button>}
+      />
+    );
+    expect(screen.getByTestId('cta')).toBeDefined();
+  });
+});

--- a/packages/ui/src/components/Banner/Banner.tsx
+++ b/packages/ui/src/components/Banner/Banner.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export type BannerVariant = 'info' | 'warning' | 'error' | 'success';
+
+export interface BannerProps {
+  /** Visual + semantic tone. `warning` and `error` set role="alert" for assertive a11y. */
+  variant?: BannerVariant;
+  /** Short headline. */
+  title?: string;
+  /** Body copy — supports rich content. */
+  message: React.ReactNode;
+  /** Show a dismiss (×) affordance. */
+  dismissible?: boolean;
+  /** Fired when the user dismisses the banner. */
+  onDismiss?: () => void;
+  /** Right-aligned action slot — typically Buttons or links. */
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+const variantStyles: Record<
+  BannerVariant,
+  { container: string; iconColor: string; icon: React.ReactNode }
+> = {
+  info: {
+    container:
+      'bg-[var(--amp-semantic-bg-info-subtle,var(--amp-semantic-bg-raised))] border-[var(--amp-semantic-border-info,var(--amp-semantic-status-info))]',
+    iconColor: 'text-[var(--amp-semantic-status-info)]',
+    icon: (
+      <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    ),
+  },
+  warning: {
+    container:
+      'bg-[var(--amp-semantic-bg-warning-subtle,var(--amp-semantic-bg-raised))] border-[var(--amp-semantic-border-warning,var(--amp-semantic-status-warning))]',
+    iconColor: 'text-[var(--amp-semantic-status-warning)]',
+    icon: (
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+    ),
+  },
+  error: {
+    container:
+      'bg-[var(--amp-semantic-bg-error-subtle,var(--amp-semantic-bg-raised))] border-[var(--amp-semantic-border-error,var(--amp-semantic-status-error))]',
+    iconColor: 'text-[var(--amp-semantic-status-error)]',
+    icon: (
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4a2 2 0 00-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z" />
+    ),
+  },
+  success: {
+    container:
+      'bg-[var(--amp-semantic-bg-success-subtle,var(--amp-semantic-bg-raised))] border-[var(--amp-semantic-border-success,var(--amp-semantic-status-success))]',
+    iconColor: 'text-[var(--amp-semantic-status-success)]',
+    icon: (
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+    ),
+  },
+};
+
+/**
+ * Sticky page-level banner. Renders inline at the top of a page or section
+ * and persists until dismissed. Use for deploy notices, system status, or
+ * "action required" messages.
+ *
+ * Distinct from:
+ * - `Toast`: transient, floating, auto-dismiss.
+ * - `AnnouncementBar`: top-of-app marketing/announcement strip.
+ */
+export const Banner: React.FC<BannerProps> = ({
+  variant = 'info',
+  title,
+  message,
+  dismissible = false,
+  onDismiss,
+  actions,
+  className,
+}) => {
+  const v = variantStyles[variant];
+  const isAssertive = variant === 'warning' || variant === 'error';
+
+  return (
+    <div
+      role={isAssertive ? 'alert' : 'status'}
+      aria-live={isAssertive ? 'assertive' : 'polite'}
+      className={cn(
+        'w-full flex items-start gap-3 px-4 py-3 rounded-[12px] border',
+        v.container,
+        className
+      )}
+    >
+      <svg
+        className={cn('w-5 h-5 mt-0.5 shrink-0', v.iconColor)}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        aria-hidden="true"
+      >
+        {v.icon}
+      </svg>
+      <div className="flex-1 min-w-0">
+        {title && (
+          <p className="text-[14px] font-semibold text-[var(--amp-semantic-text-primary)] mb-0.5">
+            {title}
+          </p>
+        )}
+        <div className="text-[14px] text-[var(--amp-semantic-text-secondary)] leading-snug">
+          {message}
+        </div>
+      </div>
+      {actions && (
+        <div className="flex items-center gap-2 shrink-0 ml-2">{actions}</div>
+      )}
+      {dismissible && (
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss"
+          className={cn(
+            'shrink-0 inline-flex items-center justify-center w-7 h-7 rounded-md',
+            'text-[var(--amp-semantic-text-muted)] hover:text-[var(--amp-semantic-text-primary)]',
+            'hover:bg-[var(--amp-semantic-bg-surface)] transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--amp-semantic-border-focus)]'
+          )}
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            className="w-4 h-4"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+};

--- a/packages/ui/src/components/Banner/index.ts
+++ b/packages/ui/src/components/Banner/index.ts
@@ -1,0 +1,2 @@
+export { Banner } from './Banner';
+export type { BannerProps, BannerVariant } from './Banner';

--- a/packages/ui/src/components/Kbd/Kbd.stories.tsx
+++ b/packages/ui/src/components/Kbd/Kbd.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Kbd } from './Kbd';
+
+const meta = {
+  title: 'Components/Kbd',
+  component: Kbd,
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md'] },
+    isMac: { control: 'boolean' },
+  },
+} satisfies Meta<typeof Kbd>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SingleKey: Story = {
+  args: { children: 'K' },
+};
+
+export const ShortcutMac: Story = {
+  args: { keys: ['mod', 'K'], isMac: true },
+};
+
+export const ShortcutWindows: Story = {
+  args: { keys: ['mod', 'K'], isMac: false },
+};
+
+export const InContext: Story = {
+  render: () => (
+    <p className="text-[14px] text-[var(--amp-semantic-text-primary)]">
+      Press <Kbd keys={['mod', 'K']} isMac /> to open the command palette, then{' '}
+      <Kbd>↵</Kbd> to confirm.
+    </p>
+  ),
+};

--- a/packages/ui/src/components/Kbd/Kbd.test.tsx
+++ b/packages/ui/src/components/Kbd/Kbd.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Kbd } from './Kbd';
+
+describe('Kbd', () => {
+  it('renders a static key with role="img"', () => {
+    render(<Kbd>K</Kbd>);
+    const el = screen.getByRole('img');
+    expect(el.textContent).toBe('K');
+    expect(el.getAttribute('aria-label')).toBe('K');
+  });
+
+  it('renders Mac substitutions for keys=["mod","K"]', () => {
+    render(<Kbd keys={['mod', 'K']} isMac />);
+    const wrapper = screen.getByRole('img');
+    expect(wrapper.textContent).toContain('⌘');
+    expect(wrapper.textContent).toContain('K');
+    expect(wrapper.getAttribute('aria-label')).toBe('⌘ K');
+  });
+
+  it('renders Ctrl on non-Mac for keys=["mod","K"]', () => {
+    render(<Kbd keys={['mod', 'K']} isMac={false} />);
+    const wrapper = screen.getByRole('img');
+    expect(wrapper.textContent).toContain('Ctrl');
+    expect(wrapper.getAttribute('aria-label')).toBe('Ctrl K');
+  });
+
+  it('respects aria-label override', () => {
+    render(<Kbd keys={['mod', 'K']} isMac aria-label="Open palette" />);
+    expect(screen.getByLabelText('Open palette')).toBeDefined();
+  });
+});

--- a/packages/ui/src/components/Kbd/Kbd.tsx
+++ b/packages/ui/src/components/Kbd/Kbd.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export type KbdSize = 'sm' | 'md';
+
+/**
+ * Special tokens that get platform-aware substitution when passed via `keys`.
+ * - `mod` → ⌘ on Mac, Ctrl elsewhere
+ * - `alt` → ⌥ on Mac, Alt elsewhere
+ * - `shift` → ⇧ on Mac, Shift elsewhere
+ * - `enter` → ⏎
+ * - `esc` → Esc
+ */
+export type KbdKey =
+  | 'mod'
+  | 'alt'
+  | 'shift'
+  | 'enter'
+  | 'esc'
+  | 'tab'
+  | 'space'
+  | 'up'
+  | 'down'
+  | 'left'
+  | 'right'
+  | (string & {});
+
+export interface KbdProps {
+  /** Static label — used when `keys` is not provided. Pass a single key like "K". */
+  children?: React.ReactNode;
+  /**
+   * Optional list of keys. When provided, the component renders one
+   * `<kbd>` element per key with platform-aware substitution.
+   */
+  keys?: KbdKey[];
+  /** Visual size. */
+  size?: KbdSize;
+  /** Override platform detection — useful for tests + cross-platform docs. */
+  isMac?: boolean;
+  /** Accessibility label override. Defaults to the rendered key sequence. */
+  'aria-label'?: string;
+  className?: string;
+}
+
+const sizeClasses: Record<KbdSize, string> = {
+  sm: 'min-w-[18px] h-[18px] px-1 text-[10px]',
+  md: 'min-w-[22px] h-[22px] px-1.5 text-[11px]',
+};
+
+function detectIsMac(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  // navigator.platform is deprecated but still the most reliable signal in jsdom + browsers.
+  return /mac|iphone|ipad|ipod/i.test(navigator.platform || navigator.userAgent || '');
+}
+
+const macMap: Record<string, string> = {
+  mod: '⌘',
+  alt: '⌥',
+  shift: '⇧',
+  enter: '⏎',
+  esc: 'Esc',
+  tab: '⇥',
+  space: 'Space',
+  up: '↑',
+  down: '↓',
+  left: '←',
+  right: '→',
+};
+
+const winMap: Record<string, string> = {
+  mod: 'Ctrl',
+  alt: 'Alt',
+  shift: 'Shift',
+  enter: 'Enter',
+  esc: 'Esc',
+  tab: 'Tab',
+  space: 'Space',
+  up: '↑',
+  down: '↓',
+  left: '←',
+  right: '→',
+};
+
+function resolveKey(key: KbdKey, isMac: boolean): string {
+  const map = isMac ? macMap : winMap;
+  const lower = key.toLowerCase();
+  return map[lower] ?? key.toString();
+}
+
+const baseClasses = cn(
+  'inline-flex items-center justify-center',
+  'font-mono font-medium leading-none',
+  'rounded-[4px] border',
+  'bg-[var(--amp-semantic-bg-raised)] text-[var(--amp-semantic-text-secondary)]',
+  'border-[var(--amp-semantic-border-default)]',
+  'shadow-[inset_0_-1px_0_var(--amp-semantic-border-default)]'
+);
+
+/**
+ * Inline keyboard-shortcut hint.
+ *
+ * Two modes:
+ * 1. Static — pass children: `<Kbd>K</Kbd>`
+ * 2. Platform-aware sequence — pass keys: `<Kbd keys={["mod","K"]} />` renders
+ *    `⌘ K` on Mac and `Ctrl K` on Windows/Linux.
+ */
+export const Kbd: React.FC<KbdProps> = ({
+  children,
+  keys,
+  size = 'md',
+  isMac,
+  className,
+  'aria-label': ariaLabel,
+}) => {
+  if (keys && keys.length > 0) {
+    const mac = isMac ?? detectIsMac();
+    const resolved = keys.map((k) => resolveKey(k, mac));
+    const label = ariaLabel ?? resolved.join(' ');
+    return (
+      <span
+        role="img"
+        aria-label={label}
+        className={cn('inline-flex items-center gap-1', className)}
+      >
+        {resolved.map((key, i) => (
+          <kbd key={i} className={cn(baseClasses, sizeClasses[size])} aria-hidden="true">
+            {key}
+          </kbd>
+        ))}
+      </span>
+    );
+  }
+
+  const label =
+    ariaLabel ?? (typeof children === 'string' ? children : undefined);
+  return (
+    <kbd
+      role="img"
+      aria-label={label}
+      className={cn(baseClasses, sizeClasses[size], className)}
+    >
+      {children}
+    </kbd>
+  );
+};

--- a/packages/ui/src/components/Kbd/index.ts
+++ b/packages/ui/src/components/Kbd/index.ts
@@ -1,0 +1,2 @@
+export { Kbd } from './Kbd';
+export type { KbdProps, KbdKey, KbdSize } from './Kbd';

--- a/packages/ui/src/components/Notification/Notification.stories.tsx
+++ b/packages/ui/src/components/Notification/Notification.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Notification, NotificationList } from './Notification';
+
+const meta = {
+  title: 'Components/Notification',
+  component: Notification,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Notification>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const BellIcon = (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+    <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+  </svg>
+);
+
+export const Unread: Story = {
+  args: {
+    title: 'New campaign assigned',
+    body: 'Glow Cosmetics — Q4 launch needs your review.',
+    icon: BellIcon,
+    timestamp: '2m ago',
+    read: false,
+  },
+};
+
+export const Read: Story = {
+  args: {
+    title: 'Payout completed',
+    body: '₹45,000 deposited to your linked account.',
+    icon: BellIcon,
+    timestamp: 'Yesterday',
+    read: true,
+  },
+};
+
+export const WithLink: Story = {
+  args: {
+    title: 'Creator accepted brief',
+    body: '@nikhil_p accepted Brand X campaign.',
+    icon: BellIcon,
+    timestamp: '1h ago',
+    href: '#',
+  },
+};
+
+export const ListExample: StoryObj = {
+  render: () => (
+    <div className="w-[420px]">
+      <NotificationList label="Notifications">
+        <Notification
+          title="New brief from Glow Cosmetics"
+          body="Q4 launch — 8 deliverables, ₹2L total"
+          icon={BellIcon}
+          timestamp="2m ago"
+        />
+        <Notification
+          title="Payout completed"
+          body="₹45,000 deposited"
+          icon={BellIcon}
+          timestamp="Yesterday"
+          read
+        />
+        <Notification
+          title="Campaign approved"
+          body="Atmosphere Beauty — ready to publish"
+          icon={BellIcon}
+          timestamp="3d ago"
+          read
+        />
+      </NotificationList>
+    </div>
+  ),
+};

--- a/packages/ui/src/components/Notification/Notification.test.tsx
+++ b/packages/ui/src/components/Notification/Notification.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Notification, NotificationList } from './Notification';
+
+describe('Notification', () => {
+  it('renders title, body, and timestamp', () => {
+    render(
+      <Notification title="Hello" body="World" timestamp="now" />
+    );
+    expect(screen.getByText('Hello')).toBeDefined();
+    expect(screen.getByText('World')).toBeDefined();
+    expect(screen.getByText('now')).toBeDefined();
+  });
+
+  it('shows unread indicator when read=false', () => {
+    render(<Notification title="t" />);
+    expect(screen.getByLabelText('Unread')).toBeDefined();
+  });
+
+  it('does not show unread indicator when read=true', () => {
+    render(<Notification title="t" read />);
+    expect(screen.queryByLabelText('Unread')).toBeNull();
+  });
+
+  it('fires onMarkRead on click for unread items', () => {
+    const onMarkRead = vi.fn();
+    render(
+      <Notification id="abc" title="t" onMarkRead={onMarkRead} />
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onMarkRead).toHaveBeenCalledWith('abc');
+  });
+
+  it('does not fire onMarkRead for already-read items', () => {
+    const onMarkRead = vi.fn();
+    render(
+      <Notification id="abc" title="t" read onMarkRead={onMarkRead} />
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onMarkRead).not.toHaveBeenCalled();
+  });
+
+  it('renders as link when href provided', () => {
+    render(<Notification title="t" href="/somewhere" />);
+    const link = screen.getByRole('link');
+    expect(link.getAttribute('href')).toBe('/somewhere');
+  });
+});
+
+describe('NotificationList', () => {
+  it('renders list with role="list"', () => {
+    render(
+      <NotificationList>
+        <Notification title="a" />
+        <Notification title="b" />
+      </NotificationList>
+    );
+    expect(screen.getByRole('list')).toBeDefined();
+    expect(screen.getAllByRole('listitem').length).toBe(2);
+  });
+
+  it('renders empty slot when no children', () => {
+    render(<NotificationList empty={<p>No notifications</p>}>{[]}</NotificationList>);
+    expect(screen.getByText('No notifications')).toBeDefined();
+  });
+});

--- a/packages/ui/src/components/Notification/Notification.tsx
+++ b/packages/ui/src/components/Notification/Notification.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+export interface NotificationProps {
+  /** Stable id — used for marking read in lists. */
+  id?: string;
+  /** Whether this notification has been read. Unread shows an indicator dot. */
+  read?: boolean;
+  /** Optional avatar slot (typically `<Avatar>`). Mutually compatible with `icon`. */
+  avatar?: React.ReactNode;
+  /** Optional icon slot — small visual prefix. */
+  icon?: React.ReactNode;
+  /** Bold title/headline. */
+  title: React.ReactNode;
+  /** Body copy. */
+  body?: React.ReactNode;
+  /** Display timestamp — typically a pre-formatted relative string like "2h ago". */
+  timestamp?: string;
+  /** If set, the row becomes a link to this URL. */
+  href?: string;
+  /** Called when row is clicked / activated — fires before navigation. */
+  onMarkRead?: (id?: string) => void;
+  /** Optional click handler — fires alongside onMarkRead. */
+  onClick?: () => void;
+  className?: string;
+}
+
+/**
+ * Persistent in-app notification row.
+ *
+ * Distinct from `Toast` (transient, floating). Designed to live inside a
+ * notification panel/list. Unread notifications render an indicator dot;
+ * clicking the row fires `onMarkRead` then navigates if `href` is set.
+ */
+export const Notification: React.FC<NotificationProps> = ({
+  id,
+  read = false,
+  avatar,
+  icon,
+  title,
+  body,
+  timestamp,
+  href,
+  onMarkRead,
+  onClick,
+  className,
+}) => {
+  const handleActivate = (e: React.MouseEvent | React.KeyboardEvent) => {
+    if (!read) onMarkRead?.(id);
+    onClick?.();
+    // If no href, prevent default link traversal.
+    if (!href && 'preventDefault' in e) e.preventDefault();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleActivate(e);
+      // For non-link case, simulate click navigation.
+      if (href) {
+        window.location.href = href;
+      }
+    }
+  };
+
+  const content = (
+    <>
+      {!read && (
+        <span
+          aria-label="Unread"
+          className="absolute left-2 top-1/2 -translate-y-1/2 w-2 h-2 rounded-full bg-[var(--amp-semantic-status-info)]"
+        />
+      )}
+      {(avatar || icon) && (
+        <div className="shrink-0 mt-0.5">
+          {avatar ?? (
+            <div className="w-8 h-8 rounded-full bg-[var(--amp-semantic-bg-raised)] text-[var(--amp-semantic-text-muted)] flex items-center justify-center">
+              {icon}
+            </div>
+          )}
+        </div>
+      )}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline justify-between gap-2">
+          <p
+            className={cn(
+              'text-[14px] truncate',
+              read
+                ? 'font-medium text-[var(--amp-semantic-text-secondary)]'
+                : 'font-semibold text-[var(--amp-semantic-text-primary)]'
+            )}
+          >
+            {title}
+          </p>
+          {timestamp && (
+            <span className="shrink-0 text-[12px] text-[var(--amp-semantic-text-muted)]">
+              {timestamp}
+            </span>
+          )}
+        </div>
+        {body && (
+          <p className="text-[13px] text-[var(--amp-semantic-text-secondary)] leading-snug mt-0.5">
+            {body}
+          </p>
+        )}
+      </div>
+    </>
+  );
+
+  const sharedClasses = cn(
+    'relative flex items-start gap-3 pl-7 pr-3 py-3 rounded-[10px]',
+    'transition-colors cursor-pointer',
+    'hover:bg-[var(--amp-semantic-bg-raised)]',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--amp-semantic-border-focus)]',
+    !read && 'bg-[var(--amp-semantic-bg-info-subtle,var(--amp-semantic-bg-raised))]',
+    className
+  );
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        onClick={handleActivate}
+        aria-label={typeof title === 'string' ? title : undefined}
+        className={cn(sharedClasses, 'block no-underline text-inherit')}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={typeof title === 'string' ? title : undefined}
+      onClick={handleActivate}
+      onKeyDown={handleKeyDown}
+      className={sharedClasses}
+    >
+      {content}
+    </div>
+  );
+};
+
+export interface NotificationListProps {
+  children: React.ReactNode;
+  /** Optional accessible label for the list region. */
+  label?: string;
+  className?: string;
+  /** Empty state slot — shown when children is empty. */
+  empty?: React.ReactNode;
+}
+
+/**
+ * Thin composition: renders a vertical stack of `<Notification>`s with a list role
+ * for screen readers.
+ */
+export const NotificationList: React.FC<NotificationListProps> = ({
+  children,
+  label = 'Notifications',
+  className,
+  empty,
+}) => {
+  const childArray = React.Children.toArray(children);
+  if (childArray.length === 0 && empty) {
+    return <div className={className}>{empty}</div>;
+  }
+  return (
+    <div
+      role="list"
+      aria-label={label}
+      className={cn('flex flex-col gap-1', className)}
+    >
+      {childArray.map((child, i) => (
+        <div role="listitem" key={i}>
+          {child}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/packages/ui/src/components/Notification/index.ts
+++ b/packages/ui/src/components/Notification/index.ts
@@ -1,0 +1,2 @@
+export { Notification, NotificationList } from './Notification';
+export type { NotificationProps, NotificationListProps } from './Notification';

--- a/packages/ui/src/components/Tour/Tour.stories.tsx
+++ b/packages/ui/src/components/Tour/Tour.stories.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Tour, type TourStep } from './Tour';
+
+const meta = {
+  title: 'Components/Tour',
+  component: Tour,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Tour>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const demoSteps: TourStep[] = [
+  {
+    target: '#tour-demo-search',
+    title: 'Find anything fast',
+    body: 'Use search to jump between campaigns, creators, and reports.',
+    placement: 'bottom',
+  },
+  {
+    target: '#tour-demo-create',
+    title: 'Launch a new campaign',
+    body: 'Click here to brief Atmosphere on your next launch.',
+    placement: 'bottom',
+  },
+  {
+    title: 'You are all set',
+    body: 'Atmosphere will guide you through the rest in-context.',
+    placement: 'center',
+  },
+];
+
+const TourPlayground: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="p-8 min-h-[400px] flex flex-col gap-6 bg-[var(--amp-semantic-bg-canvas,#0b0b0c)]">
+      <div className="flex items-center gap-3">
+        <input
+          id="tour-demo-search"
+          placeholder="Search campaigns, creators…"
+          className="px-3 py-2 rounded-md border border-[var(--amp-semantic-border-default)] bg-[var(--amp-semantic-bg-surface)] text-[var(--amp-semantic-text-primary)] w-[280px]"
+        />
+        <button
+          id="tour-demo-create"
+          type="button"
+          className="px-3 py-2 rounded-md bg-[var(--amp-semantic-status-info)] text-white text-[14px] font-medium"
+        >
+          New campaign
+        </button>
+      </div>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="self-start px-3 py-1.5 rounded-md border border-[var(--amp-semantic-border-default)] text-[14px] text-[var(--amp-semantic-text-primary)]"
+      >
+        Start tour
+      </button>
+      <Tour
+        tourId="storybook-demo"
+        steps={demoSteps}
+        open={open}
+        onClose={() => setOpen(false)}
+        onComplete={() => setOpen(false)}
+        persist={false}
+      />
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: () => <TourPlayground />,
+};
+
+export const SingleCenteredStep: Story = {
+  render: () => {
+    const Inner: React.FC = () => {
+      const [open, setOpen] = useState(true);
+      return (
+        <div className="p-8 min-h-[300px]">
+          <Tour
+            tourId="centered-demo"
+            steps={[
+              {
+                title: 'Welcome to Atmosphere',
+                body: 'A unified workspace for marketing teams. Press Esc to close.',
+                placement: 'center',
+              },
+            ]}
+            open={open}
+            onClose={() => setOpen(false)}
+            onComplete={() => setOpen(false)}
+            persist={false}
+          />
+        </div>
+      );
+    };
+    return <Inner />;
+  },
+};

--- a/packages/ui/src/components/Tour/Tour.test.tsx
+++ b/packages/ui/src/components/Tour/Tour.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { Tour, type TourStep } from './Tour';
+
+const steps: TourStep[] = [
+  { title: 'Step 1', body: 'First', placement: 'center' },
+  { title: 'Step 2', body: 'Second', placement: 'center' },
+  { title: 'Step 3', body: 'Third', placement: 'center' },
+];
+
+describe('Tour', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders nothing when open=false', () => {
+    render(<Tour tourId="t1" steps={steps} open={false} persist={false} />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders first step + step counter when opened', () => {
+    render(<Tour tourId="t1" steps={steps} open persist={false} />);
+    expect(screen.getByText('Step 1')).toBeDefined();
+    expect(screen.getByText('1 of 3')).toBeDefined();
+  });
+
+  it('Enter key advances to next step', () => {
+    render(<Tour tourId="t1" steps={steps} open persist={false} />);
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Enter' });
+    });
+    expect(screen.getByText('Step 2')).toBeDefined();
+  });
+
+  it('Escape calls onClose', () => {
+    const onClose = vi.fn();
+    render(<Tour tourId="t1" steps={steps} open onClose={onClose} persist={false} />);
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('completing the last step calls onComplete', () => {
+    const onComplete = vi.fn();
+    render(
+      <Tour tourId="t1" steps={steps} open onComplete={onComplete} persist={false} startAt={2} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /done/i }));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists progress to localStorage', () => {
+    render(<Tour tourId="persist-test" steps={steps} open persist />);
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    expect(window.localStorage.getItem('amp:tour:persist-test')).toBe('1');
+  });
+
+  it('clears persisted progress on completion', () => {
+    window.localStorage.setItem('amp:tour:persist-test', '2');
+    const onComplete = vi.fn();
+    render(
+      <Tour
+        tourId="persist-test"
+        steps={steps}
+        open
+        onComplete={onComplete}
+        persist
+        startAt={2}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /done/i }));
+    expect(window.localStorage.getItem('amp:tour:persist-test')).toBeNull();
+  });
+
+  it('Back button returns to previous step', () => {
+    render(<Tour tourId="t1" steps={steps} open persist={false} startAt={1} />);
+    expect(screen.getByText('Step 2')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+    expect(screen.getByText('Step 1')).toBeDefined();
+  });
+});

--- a/packages/ui/src/components/Tour/Tour.tsx
+++ b/packages/ui/src/components/Tour/Tour.tsx
@@ -1,0 +1,366 @@
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { cn } from '../../lib/cn';
+
+export type TourStepPlacement = 'top' | 'bottom' | 'left' | 'right' | 'center';
+
+export interface TourStep {
+  /** CSS selector for the anchor element. Omit for unanchored (centered) steps. */
+  target?: string;
+  /** Step headline. */
+  title: string;
+  /** Body copy. */
+  body: React.ReactNode;
+  /** Where the card sits relative to the target. Defaults to `bottom` (or `center` if no target). */
+  placement?: TourStepPlacement;
+}
+
+export interface TourProps {
+  /** Stable identifier — used as the localStorage key for progress. */
+  tourId: string;
+  /** Ordered list of steps. */
+  steps: TourStep[];
+  /** Whether the tour is mounted/visible. */
+  open: boolean;
+  /** Called when the user finishes or skips the tour. */
+  onComplete?: () => void;
+  /** Called when the user dismisses (Esc / close / skip). */
+  onClose?: () => void;
+  /** Optional starting step — overrides any persisted progress. */
+  startAt?: number;
+  /** Disable localStorage persistence. */
+  persist?: boolean;
+  className?: string;
+}
+
+interface TargetRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+function readProgress(tourId: string, persist: boolean): number {
+  if (!persist || typeof window === 'undefined') return 0;
+  try {
+    const raw = window.localStorage.getItem(`amp:tour:${tourId}`);
+    if (!raw) return 0;
+    const parsed = parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function writeProgress(tourId: string, step: number, persist: boolean): void {
+  if (!persist || typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(`amp:tour:${tourId}`, String(step));
+  } catch {
+    /* ignore — quota / disabled storage */
+  }
+}
+
+function clearProgress(tourId: string, persist: boolean): void {
+  if (!persist || typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(`amp:tour:${tourId}`);
+  } catch {
+    /* ignore */
+  }
+}
+
+function measureTarget(selector: string | undefined): TargetRect | null {
+  if (!selector || typeof document === 'undefined') return null;
+  const el = document.querySelector<HTMLElement>(selector);
+  if (!el) return null;
+  const rect = el.getBoundingClientRect();
+  return {
+    top: rect.top,
+    left: rect.left,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+/**
+ * Multi-step product tour overlay.
+ *
+ * - Renders a dimmed backdrop in a top-level portal so it covers everything.
+ * - Each step anchors to a CSS selector (or floats centered if `target` is omitted).
+ * - Keyboard: Esc closes, Enter / → advances, ← goes back.
+ * - Persists current step index to `localStorage[amp:tour:{tourId}]` unless `persist=false`.
+ * - On the final step, "Done" calls `onComplete` and clears persisted progress.
+ */
+export const Tour: React.FC<TourProps> = ({
+  tourId,
+  steps,
+  open,
+  onComplete,
+  onClose,
+  startAt,
+  persist = true,
+  className,
+}) => {
+  const titleId = useId();
+  const descId = useId();
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [stepIndex, setStepIndex] = useState<number>(() =>
+    startAt ?? readProgress(tourId, persist)
+  );
+  const [targetRect, setTargetRect] = useState<TargetRect | null>(null);
+
+  // Clamp step index to bounds.
+  const clampedIndex = Math.min(Math.max(stepIndex, 0), Math.max(steps.length - 1, 0));
+  const step = steps[clampedIndex];
+  const placement: TourStepPlacement =
+    step?.placement ?? (step?.target ? 'bottom' : 'center');
+
+  const goNext = useCallback(() => {
+    setStepIndex((i) => {
+      const next = i + 1;
+      if (next >= steps.length) {
+        clearProgress(tourId, persist);
+        onComplete?.();
+        return i;
+      }
+      writeProgress(tourId, next, persist);
+      return next;
+    });
+  }, [steps.length, tourId, persist, onComplete]);
+
+  const goPrev = useCallback(() => {
+    setStepIndex((i) => {
+      const prev = Math.max(0, i - 1);
+      writeProgress(tourId, prev, persist);
+      return prev;
+    });
+  }, [tourId, persist]);
+
+  const handleClose = useCallback(() => {
+    onClose?.();
+  }, [onClose]);
+
+  // Keyboard handling
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleClose();
+      } else if (e.key === 'Enter' || e.key === 'ArrowRight') {
+        e.preventDefault();
+        goNext();
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        goPrev();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, goNext, goPrev, handleClose]);
+
+  // Focus the card when step changes
+  useEffect(() => {
+    if (open && cardRef.current) {
+      cardRef.current.focus();
+    }
+  }, [open, clampedIndex]);
+
+  // Measure target on step change + on resize/scroll
+  useEffect(() => {
+    if (!open || !step) return;
+    const update = () => setTargetRect(measureTarget(step.target));
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
+    return () => {
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update, true);
+    };
+  }, [open, step]);
+
+  if (!open || !step) return null;
+  if (typeof document === 'undefined') return null;
+
+  const isFirst = clampedIndex === 0;
+  const isLast = clampedIndex === steps.length - 1;
+
+  const cardPosition = computeCardPosition(targetRect, placement);
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[100]"
+      aria-hidden={false}
+    >
+      {/* Backdrop with optional spotlight cutout */}
+      <Backdrop targetRect={targetRect} onClick={handleClose} />
+
+      {/* Card */}
+      <div
+        ref={cardRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descId}
+        tabIndex={-1}
+        style={cardPosition.style}
+        className={cn(
+          'absolute z-[101] w-[320px] max-w-[90vw] rounded-[12px] p-4',
+          'bg-[var(--amp-semantic-bg-surface)] border border-[var(--amp-semantic-border-default)]',
+          'shadow-xl focus:outline-none',
+          className
+        )}
+      >
+        <div className="flex items-start justify-between gap-2 mb-2">
+          <h3
+            id={titleId}
+            className="text-[15px] font-semibold text-[var(--amp-semantic-text-primary)]"
+          >
+            {step.title}
+          </h3>
+          <button
+            type="button"
+            onClick={handleClose}
+            aria-label="Close tour"
+            className="shrink-0 -mt-1 -mr-1 inline-flex items-center justify-center w-7 h-7 rounded-md text-[var(--amp-semantic-text-muted)] hover:text-[var(--amp-semantic-text-primary)] hover:bg-[var(--amp-semantic-bg-raised)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--amp-semantic-border-focus)]"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="w-4 h-4" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div
+          id={descId}
+          className="text-[13px] text-[var(--amp-semantic-text-secondary)] leading-snug mb-4"
+        >
+          {step.body}
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-[12px] text-[var(--amp-semantic-text-muted)]">
+            {clampedIndex + 1} of {steps.length}
+          </span>
+          <div className="flex items-center gap-2">
+            {!isFirst && (
+              <button
+                type="button"
+                onClick={goPrev}
+                className="text-[13px] px-2.5 py-1.5 rounded-md text-[var(--amp-semantic-text-secondary)] hover:bg-[var(--amp-semantic-bg-raised)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--amp-semantic-border-focus)]"
+              >
+                Back
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={goNext}
+              className="text-[13px] font-medium px-3 py-1.5 rounded-md bg-[var(--amp-semantic-bg-accent,var(--amp-semantic-status-info))] text-[var(--amp-semantic-text-on-accent,white)] hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--amp-semantic-border-focus)]"
+            >
+              {isLast ? 'Done' : 'Next'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+interface BackdropProps {
+  targetRect: TargetRect | null;
+  onClick: () => void;
+}
+
+const Backdrop: React.FC<BackdropProps> = ({ targetRect, onClick }) => {
+  // When a target is present, render four panels around it to create a spotlight.
+  if (targetRect && targetRect.width > 0 && targetRect.height > 0) {
+    const padding = 6;
+    const t = targetRect.top - padding;
+    const l = targetRect.left - padding;
+    const w = targetRect.width + padding * 2;
+    const h = targetRect.height + padding * 2;
+    const panel = 'fixed bg-black/55 backdrop-blur-[1px]';
+    return (
+      <>
+        <div className={panel} style={{ top: 0, left: 0, right: 0, height: t }} onClick={onClick} aria-hidden="true" />
+        <div className={panel} style={{ top: t, left: 0, width: l, height: h }} onClick={onClick} aria-hidden="true" />
+        <div className={panel} style={{ top: t, left: l + w, right: 0, height: h }} onClick={onClick} aria-hidden="true" />
+        <div className={panel} style={{ top: t + h, left: 0, right: 0, bottom: 0 }} onClick={onClick} aria-hidden="true" />
+        {/* Spotlight ring */}
+        <div
+          aria-hidden="true"
+          className="fixed pointer-events-none rounded-[8px] ring-2 ring-[var(--amp-semantic-status-info,#60a5fa)]"
+          style={{ top: t, left: l, width: w, height: h }}
+        />
+      </>
+    );
+  }
+  return (
+    <div
+      className="fixed inset-0 bg-black/55 backdrop-blur-[1px]"
+      onClick={onClick}
+      aria-hidden="true"
+    />
+  );
+};
+
+interface CardPosition {
+  style: React.CSSProperties;
+}
+
+const CARD_GAP = 12;
+const CARD_WIDTH = 320;
+const CARD_EST_HEIGHT = 180;
+
+function computeCardPosition(
+  rect: TargetRect | null,
+  placement: TourStepPlacement
+): CardPosition {
+  if (!rect || placement === 'center') {
+    return {
+      style: {
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+      },
+    };
+  }
+
+  const viewportW = typeof window !== 'undefined' ? window.innerWidth : 1280;
+  const viewportH = typeof window !== 'undefined' ? window.innerHeight : 800;
+
+  let top = 0;
+  let left = 0;
+
+  switch (placement) {
+    case 'top':
+      top = rect.top - CARD_EST_HEIGHT - CARD_GAP;
+      left = rect.left + rect.width / 2 - CARD_WIDTH / 2;
+      break;
+    case 'bottom':
+      top = rect.top + rect.height + CARD_GAP;
+      left = rect.left + rect.width / 2 - CARD_WIDTH / 2;
+      break;
+    case 'left':
+      top = rect.top + rect.height / 2 - CARD_EST_HEIGHT / 2;
+      left = rect.left - CARD_WIDTH - CARD_GAP;
+      break;
+    case 'right':
+      top = rect.top + rect.height / 2 - CARD_EST_HEIGHT / 2;
+      left = rect.left + rect.width + CARD_GAP;
+      break;
+  }
+
+  // Clamp within viewport with 8px margin.
+  const margin = 8;
+  left = Math.max(margin, Math.min(left, viewportW - CARD_WIDTH - margin));
+  top = Math.max(margin, Math.min(top, viewportH - CARD_EST_HEIGHT - margin));
+
+  return { style: { top, left } };
+}
+
+/**
+ * Documentation alias — the canonical step shape is the `TourStep` type
+ * (re-exported from `index.ts`). This component is a no-op render slot
+ * provided for symmetry; consumers should pass `steps={...}` to `<Tour>`.
+ */
+export const TourStepMarker: React.FC<TourStep> = () => null;

--- a/packages/ui/src/components/Tour/index.ts
+++ b/packages/ui/src/components/Tour/index.ts
@@ -1,0 +1,2 @@
+export { Tour, TourStepMarker } from './Tour';
+export type { TourProps, TourStep, TourStepPlacement } from './Tour';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -431,3 +431,21 @@ export type {
 // SplitPane
 export { SplitPane } from './components/SplitPane';
 export type { SplitPaneProps, SplitPaneOrientation } from './components/SplitPane';
+
+// ─── Phase B Wave 5 — Page-level affordances ─────────────────────────────
+
+// Banner
+export { Banner } from './components/Banner';
+export type { BannerProps, BannerVariant } from './components/Banner';
+
+// Kbd
+export { Kbd } from './components/Kbd';
+export type { KbdProps, KbdKey, KbdSize } from './components/Kbd';
+
+// Notification
+export { Notification, NotificationList } from './components/Notification';
+export type { NotificationProps, NotificationListProps } from './components/Notification';
+
+// Tour
+export { Tour, TourStepMarker } from './components/Tour';
+export type { TourProps, TourStep, TourStepPlacement } from './components/Tour';


### PR DESCRIPTION
## Summary

Adds 4 page-level affordance components flagged in the Canvas audit. All four ship as `beta` (since `2.6.0`) per the project's component-status convention.

### `<Banner>`
Sticky inline page banner. Distinct from `<Toast>` (transient) and `<AnnouncementBar>` (top-of-app marketing strip). Use for deploy notices, system status, action-required messages.
- Variants: `info | warning | error | success`
- `dismissible` + `onDismiss`
- Right-aligned `actions` slot for inline CTAs
- a11y: `role="alert"` + `aria-live="assertive"` for warning/error, `role="status"` + `aria-live="polite"` otherwise

### `<Kbd>`
Inline keyboard-shortcut hint. Pure visual primitive.
- Static mode: `<Kbd>K</Kbd>`
- Platform-aware mode: `<Kbd keys={["mod","K"]} />` → renders ⌘ K on Mac, Ctrl K on Windows/Linux
- Optional `isMac` prop overrides detection (handy for cross-platform docs + tests)
- a11y: `role="img"` with `aria-label` derived from the rendered sequence

### `<Notification>` + `<NotificationList>`
Persistent in-app notification row (distinct from `<Toast>`).
- Unread state with indicator dot, marked-read on click
- Optional `avatar` (or `icon` fallback), `title`, `body`, `timestamp`
- Renders as `<a href>` when `href` is set; otherwise as `role="button"` with keyboard activation (Enter/Space)
- `<NotificationList>` is a thin composition with `role="list"` + accessible label + empty slot

### `<Tour>` + `<TourStepMarker>`
Multi-step product tour overlay.
- Portal-rendered to `document.body` so the backdrop covers the entire viewport
- Spotlight backdrop with cutout + ring around the anchored target (4-panel technique, no clip-path needed)
- Anchored placement (`top | bottom | left | right`) with viewport clamping; `center` fallback for unanchored steps
- Auto re-measures target on `resize` + capture-phase `scroll` so the card follows during in-page navigation
- Keyboard: `Esc` closes, `Enter` / `→` advances, `←` goes back
- Persists step index to `localStorage[amp:tour:{tourId}]` (opt-out via `persist={false}`); clears on completion

## Implementation notes

- Followed existing patterns from `Toast.tsx`, `Tooltip.tsx`, `Dialog.tsx`, `EmptyState.tsx`, `AnnouncementBar.tsx`
- TypeScript strict — no `any`
- Canvas semantic tokens only (with sensible fallbacks for tokens that may not exist yet, e.g. `--amp-semantic-bg-warning-subtle` falls back to `--amp-semantic-bg-raised`)
- No new external dependencies
- 91 components in the contracts manifest after this change (was 87)

## Test plan

- [x] `npm run test` — 25 new tests across 4 files all passing (45/45 total)
- [x] `npm run build` — full repo build green; tsup ESM + dts emit clean; contracts + llms-docs regenerated for 91 components
- [x] `npm run validate` — token reference integrity intact
- [ ] Storybook visual review — `npm run storybook`, check Banner/Kbd/Notification/Tour stories
- [ ] Chromatic visual regression on this PR

## Audit reference

Flagged in the Canvas audit as missing page-level affordance components — Banner (page-level message distinct from Toast/AnnouncementBar), Kbd (keyboard shortcut hint), Notification (persistent in-app notification distinct from Toast), Tour (product onboarding overlay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)