### PR TITLE
feat(ui): Studio v2 primitives — BriefStrip, HistoryStrip, CouncilRail, VariantCard

### DIFF
--- a/packages/ui/component-status.json
+++ b/packages/ui/component-status.json
@@ -106,6 +106,10 @@
     "FieldError": { "status": "beta", "since": "2.7.0" },
     "FormSection": { "status": "beta", "since": "2.7.0" },
     "RadioGroup": { "status": "beta", "since": "2.6.0" },
-    "Combobox": { "status": "beta", "since": "2.6.0" }
+    "Combobox": { "status": "beta", "since": "2.6.0" },
+    "BriefStrip": { "status": "beta", "since": "2.8.0", "notes": "Studio v2 Wave 2 — chip strip primitive composing Chip; persistent brief header for Magic Studio v2." },
+    "HistoryStrip": { "status": "beta", "since": "2.8.0", "notes": "Studio v2 Wave 2 — horizontal generation timeline with mini-thumb status (ready/generating/error/locked/win)." },
+    "CouncilRail": { "status": "beta", "since": "2.8.0", "notes": "Studio v2 Wave 2 — right-rail per-agent verdicts; supports disagreementsOnly collapse + ask-the-council affordance." },
+    "VariantCard": { "status": "beta", "since": "2.8.0", "notes": "Studio v2 Wave 2 — canvas variant card with empty/generating/ready/error state machine; shimmer + retry built-in." }
   }
 }

--- a/packages/ui/src/components/BriefStrip/BriefStrip.stories.tsx
+++ b/packages/ui/src/components/BriefStrip/BriefStrip.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { BriefStrip, type BriefChipItem } from './BriefStrip';
+
+const meta = {
+  title: 'Studio v2/BriefStrip',
+  component: BriefStrip,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    status: { type: 'beta' },
+  },
+} satisfies Meta<typeof BriefStrip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sampleChips: BriefChipItem[] = [
+  { id: 'g', kind: 'goal', key: 'goal:', value: 'confident editorial' },
+  { id: 'a', kind: 'audience', key: 'for:', value: 'returning brands' },
+  { id: 'l', kind: 'lock', value: 'serif heading', locked: true },
+  { id: 'av', kind: 'avoid', key: 'avoid:', value: 'stock photography' },
+  { id: 'r', kind: 'ref', key: 'ref:', value: 'Issue 42' },
+  { id: 'd', kind: 'density', key: 'density:', value: 'spacious' },
+];
+
+export const Empty: Story = {
+  args: {
+    chips: [],
+  },
+};
+
+export const Populated: Story = {
+  args: {
+    chips: sampleChips,
+  },
+};
+
+export const WithLockedChips: Story = {
+  args: {
+    chips: [
+      { id: '1', kind: 'goal', key: 'goal:', value: 'launch announcement' },
+      { id: '2', kind: 'lock', value: 'brand purple', locked: true },
+      { id: '3', kind: 'lock', value: 'logo top-left', locked: true },
+    ],
+  },
+};
+
+export const Expandable: Story = {
+  args: {
+    chips: sampleChips,
+    expandable: true,
+  },
+};
+
+export const Interactive: Story = {
+  render: () => {
+    const [chips, setChips] = React.useState<BriefChipItem[]>([
+      { id: '1', kind: 'goal', key: 'goal:', value: 'editorial cover' },
+      { id: '2', kind: 'audience', key: 'for:', value: 'design leads' },
+    ]);
+    return (
+      <BriefStrip
+        chips={chips}
+        onChipRemove={(id) => setChips((c) => c.filter((x) => x.id !== id))}
+        onParseInput={(text) =>
+          setChips((c) => [
+            ...c,
+            { id: String(Date.now()), kind: 'custom', value: text },
+          ])
+        }
+        expandable
+        onExpand={() => undefined}
+      />
+    );
+  },
+  args: {
+    chips: [],
+  },
+};

--- a/packages/ui/src/components/BriefStrip/BriefStrip.test.tsx
+++ b/packages/ui/src/components/BriefStrip/BriefStrip.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { BriefStrip, type BriefChipItem } from './BriefStrip';
+
+afterEach(cleanup);
+
+const baseChips: BriefChipItem[] = [
+  { id: 'g', kind: 'goal', key: 'goal:', value: 'confident editorial' },
+  { id: 'a', kind: 'audience', key: 'for:', value: 'returning brands' },
+  { id: 'l', kind: 'lock', value: 'serif heading', locked: true },
+];
+
+describe('BriefStrip', () => {
+  it('renders a region with aria-label="Brief"', () => {
+    render(<BriefStrip chips={baseChips} />);
+    const region = screen.getByRole('region', { name: 'Brief' });
+    expect(region).toBeDefined();
+  });
+
+  it('renders one listitem per chip plus the add affordance', () => {
+    render(<BriefStrip chips={baseChips} />);
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(baseChips.length);
+  });
+
+  it('renders chip key prefix and value text', () => {
+    render(<BriefStrip chips={baseChips} />);
+    expect(screen.getByText('goal:')).toBeDefined();
+    expect(screen.getByText('confident editorial')).toBeDefined();
+    expect(screen.getByText('for:')).toBeDefined();
+    expect(screen.getByText('returning brands')).toBeDefined();
+  });
+
+  it('shows empty-state placeholder text when chips=[]', () => {
+    render(<BriefStrip chips={[]} />);
+    // The placeholder copy lives inside the "+ add" button.
+    expect(
+      screen.getByText('Type a goal, audience, or constraint…'),
+    ).toBeDefined();
+  });
+
+  it('fires onChipClick when a chip is clicked', () => {
+    const onChipClick = vi.fn();
+    render(<BriefStrip chips={baseChips} onChipClick={onChipClick} />);
+    fireEvent.click(screen.getByLabelText('Edit goal: confident editorial'));
+    expect(onChipClick).toHaveBeenCalledWith('g');
+  });
+
+  it('renders remove button only for non-locked chips when onChipRemove provided', () => {
+    const onChipRemove = vi.fn();
+    render(<BriefStrip chips={baseChips} onChipRemove={onChipRemove} />);
+    // Two non-locked chips (goal + audience) → two remove buttons.
+    const removeButtons = screen.getAllByRole('button', { name: /Remove / });
+    expect(removeButtons).toHaveLength(2);
+  });
+
+  it('does NOT render remove button for locked chips', () => {
+    const onChipRemove = vi.fn();
+    render(<BriefStrip chips={baseChips} onChipRemove={onChipRemove} />);
+    const lockedRemove = screen.queryByRole('button', {
+      name: 'Remove lock: serif heading',
+    });
+    expect(lockedRemove).toBeNull();
+  });
+
+  it('fires onChipRemove with the right id when remove button clicked', () => {
+    const onChipRemove = vi.fn();
+    render(<BriefStrip chips={baseChips} onChipRemove={onChipRemove} />);
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Remove goal: confident editorial' }),
+    );
+    expect(onChipRemove).toHaveBeenCalledWith('g');
+  });
+
+  it('clicking + add fires onAddRequest then opens an input', () => {
+    const onAddRequest = vi.fn();
+    render(<BriefStrip chips={baseChips} onAddRequest={onAddRequest} />);
+    fireEvent.click(screen.getByLabelText('Add to brief'));
+    expect(onAddRequest).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText('Add to brief')).toBeDefined();
+    // After click, the input is rendered (replaces the button).
+    expect(
+      (screen.getByLabelText('Add to brief') as HTMLInputElement).tagName,
+    ).toBe('INPUT');
+  });
+
+  it('Enter on input fires onParseInput with the raw text', () => {
+    const onParseInput = vi.fn();
+    render(<BriefStrip chips={[]} onParseInput={onParseInput} />);
+    fireEvent.click(screen.getByLabelText(/Add to brief/));
+    const input = screen.getByLabelText('Add to brief') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'for premium creators' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onParseInput).toHaveBeenCalledWith('for premium creators');
+  });
+
+  it('Escape on input cancels without firing onParseInput', () => {
+    const onParseInput = vi.fn();
+    render(<BriefStrip chips={[]} onParseInput={onParseInput} />);
+    fireEvent.click(screen.getByLabelText(/Add to brief/));
+    const input = screen.getByLabelText('Add to brief') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'should be cancelled' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onParseInput).not.toHaveBeenCalled();
+  });
+
+  it('renders Expand brief button only when expandable=true', () => {
+    const onExpand = vi.fn();
+    const { rerender } = render(<BriefStrip chips={baseChips} />);
+    expect(screen.queryByRole('button', { name: 'Expand brief' })).toBeNull();
+    rerender(<BriefStrip chips={baseChips} expandable onExpand={onExpand} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Expand brief' }));
+    expect(onExpand).toHaveBeenCalledTimes(1);
+  });
+
+  it('locked chip renders the lock glyph', () => {
+    render(<BriefStrip chips={baseChips} />);
+    const lockChip = screen.getByLabelText('Edit lock: serif heading');
+    // Lock glyph is rendered as a sibling span; check its presence in DOM.
+    expect(lockChip.textContent).toContain('serif heading');
+  });
+});

--- a/packages/ui/src/components/BriefStrip/BriefStrip.tsx
+++ b/packages/ui/src/components/BriefStrip/BriefStrip.tsx
@@ -1,0 +1,269 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+/**
+ * BriefStrip — horizontal chip strip representing the user's brief.
+ *
+ * Composes the existing <Chip> primitive — but uses a slimmer, brief-tuned
+ * visual treatment so the strip can sit above a dense canvas without competing
+ * with primary content. Each chip is a compact, editable token of the brief
+ * (goal, audience, lock, etc). Studio v2 uses this as the persistent header
+ * row driving variant generation.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type BriefChipKind =
+  | 'goal'
+  | 'audience'
+  | 'lock'
+  | 'avoid'
+  | 'ref'
+  | 'density'
+  | 'custom';
+
+export interface BriefChipItem {
+  id: string;
+  kind: BriefChipKind;
+  /** Optional faded prefix shown before the value, e.g. "goal:". */
+  key?: string;
+  /** Primary label text. */
+  value: string;
+  /** Locked chips render with the lock glyph and accent-soft background. */
+  locked?: boolean;
+}
+
+export interface BriefStripProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  chips: BriefChipItem[];
+  onChipClick?: (id: string) => void;
+  onChipRemove?: (id: string) => void;
+  /** Fired when the user clicks the "+ add" affordance. */
+  onAddRequest?: () => void;
+  /** Fired when the user types into the inline input and presses Enter. */
+  onParseInput?: (rawText: string) => void;
+  /** When true, shows an "Expand brief" affordance on the right. */
+  expandable?: boolean;
+  onExpand?: () => void;
+  className?: string;
+}
+
+// ─── Visual tokens ───────────────────────────────────────────────────────────
+
+const baseChipClasses = cn(
+  'inline-flex shrink-0 items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium',
+  'transition-colors duration-150',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1',
+  'focus-visible:ring-[var(--amp-semantic-border-focus)]'
+);
+
+const kindToneClasses: Record<BriefChipKind, string> = {
+  goal: 'bg-[var(--amp-semantic-bg-accent-subtle)] text-[var(--amp-semantic-text-accent)]',
+  audience: 'bg-[var(--amp-semantic-bg-info-subtle)] text-[var(--amp-semantic-status-info)]',
+  lock: 'bg-[var(--amp-semantic-bg-accent-subtle)] text-[var(--amp-semantic-text-accent)]',
+  avoid: 'bg-[var(--amp-semantic-bg-error-subtle)] text-[var(--amp-semantic-status-error)]',
+  ref: 'bg-[var(--amp-semantic-bg-subtle)] text-[var(--amp-semantic-text-secondary)]',
+  density: 'bg-[var(--amp-semantic-bg-subtle)] text-[var(--amp-semantic-text-secondary)]',
+  custom: 'bg-[var(--amp-semantic-bg-subtle)] text-[var(--amp-semantic-text-secondary)]',
+};
+
+const lockedToneOverride =
+  'bg-[var(--amp-semantic-bg-accent-subtle)] text-[var(--amp-semantic-text-accent)] ring-1 ring-inset ring-[var(--amp-semantic-border-accent)]';
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export const BriefStrip = React.forwardRef<HTMLDivElement, BriefStripProps>(
+  (
+    {
+      chips,
+      onChipClick,
+      onChipRemove,
+      onAddRequest,
+      onParseInput,
+      expandable = false,
+      onExpand,
+      className,
+      ...rest
+    },
+    ref,
+  ) => {
+    const [draft, setDraft] = React.useState('');
+    const [editing, setEditing] = React.useState(false);
+    const inputRef = React.useRef<HTMLInputElement>(null);
+
+    React.useEffect(() => {
+      if (editing) inputRef.current?.focus();
+    }, [editing]);
+
+    const handleAddClick = () => {
+      onAddRequest?.();
+      setEditing(true);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const value = draft.trim();
+        if (value) onParseInput?.(value);
+        setDraft('');
+        setEditing(false);
+      } else if (e.key === 'Escape') {
+        setDraft('');
+        setEditing(false);
+      }
+    };
+
+    const handleBlur = () => {
+      const value = draft.trim();
+      if (value) onParseInput?.(value);
+      setDraft('');
+      setEditing(false);
+    };
+
+    const isEmpty = chips.length === 0;
+
+    return (
+      <div
+        ref={ref}
+        role="region"
+        aria-label="Brief"
+        className={cn(
+          'flex w-full items-center gap-2 overflow-x-auto whitespace-nowrap',
+          'border-b border-[var(--amp-semantic-border-subtle)]',
+          'bg-[var(--amp-semantic-bg-surface)]',
+          'px-3 py-2',
+          'scrollbar-thin',
+          className,
+        )}
+        {...rest}
+      >
+        <div
+          className="flex min-w-0 flex-1 items-center gap-1.5"
+          data-testid="brief-strip-chips"
+          role="list"
+        >
+          {chips.map((chip) => {
+            const removable = !!onChipRemove && !chip.locked;
+            const tone = chip.locked ? lockedToneOverride : kindToneClasses[chip.kind];
+            return (
+              <span
+                key={chip.id}
+                role="listitem"
+                className="group/brief-chip relative inline-flex shrink-0 items-center"
+              >
+                <button
+                  type="button"
+                  className={cn(baseChipClasses, tone, 'pr-2')}
+                  onClick={() => onChipClick?.(chip.id)}
+                  aria-label={`Edit ${chip.kind}: ${chip.value}`}
+                  data-chip-kind={chip.kind}
+                  data-chip-id={chip.id}
+                >
+                  {chip.locked && (
+                    <span aria-hidden="true" className="text-[10px] leading-none">
+                      &#128274;
+                    </span>
+                  )}
+                  {chip.key && (
+                    <span className="text-[var(--amp-semantic-text-tertiary)]">{chip.key}</span>
+                  )}
+                  <span>{chip.value}</span>
+                </button>
+                {removable && (
+                  <button
+                    type="button"
+                    aria-label={`Remove ${chip.kind}: ${chip.value}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onChipRemove?.(chip.id);
+                    }}
+                    className={cn(
+                      'ml-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full',
+                      'text-[var(--amp-semantic-text-tertiary)] opacity-0 transition-opacity duration-150',
+                      'hover:bg-[var(--amp-semantic-bg-subtle)] hover:text-[var(--amp-semantic-text-default)]',
+                      'group-hover/brief-chip:opacity-100 focus-visible:opacity-100',
+                      'focus-visible:outline-none focus-visible:ring-2',
+                      'focus-visible:ring-[var(--amp-semantic-border-focus)]',
+                    )}
+                  >
+                    <svg
+                      className="h-2.5 w-2.5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2.5}
+                      aria-hidden="true"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                )}
+              </span>
+            );
+          })}
+
+          {editing ? (
+            <input
+              ref={inputRef}
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={handleKeyDown}
+              onBlur={handleBlur}
+              placeholder="Type a goal, audience, or constraint…"
+              aria-label="Add to brief"
+              className={cn(
+                'inline-flex min-w-[14rem] shrink-0 items-center rounded-full',
+                'border border-dashed border-[var(--amp-semantic-border-default)]',
+                'bg-transparent px-2.5 py-1 text-xs',
+                'text-[var(--amp-semantic-text-default)]',
+                'placeholder:text-[var(--amp-semantic-text-tertiary)]',
+                'focus-visible:outline-none focus-visible:ring-2',
+                'focus-visible:ring-[var(--amp-semantic-border-focus)]',
+              )}
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={handleAddClick}
+              className={cn(
+                baseChipClasses,
+                'border border-dashed border-[var(--amp-semantic-border-default)] bg-transparent',
+                'text-[var(--amp-semantic-text-tertiary)]',
+                'hover:bg-[var(--amp-semantic-bg-subtle)]',
+                'hover:text-[var(--amp-semantic-text-default)]',
+              )}
+              aria-label={
+                isEmpty
+                  ? 'Add to brief — type a goal, audience, or constraint'
+                  : 'Add to brief'
+              }
+            >
+              <span aria-hidden="true">+</span>
+              <span>{isEmpty ? 'Type a goal, audience, or constraint…' : 'add'}</span>
+            </button>
+          )}
+        </div>
+
+        {expandable && (
+          <button
+            type="button"
+            onClick={onExpand}
+            aria-label="Expand brief"
+            className={cn(
+              'inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-xs',
+              'text-[var(--amp-semantic-text-secondary)]',
+              'hover:bg-[var(--amp-semantic-bg-subtle)]',
+              'hover:text-[var(--amp-semantic-text-default)]',
+              'focus-visible:outline-none focus-visible:ring-2',
+              'focus-visible:ring-[var(--amp-semantic-border-focus)]',
+            )}
+          >
+            <span aria-hidden="true">&#10530;</span>
+            <span>Expand brief</span>
+          </button>
+        )}
+      </div>
+    );
+  },
+);
+
+BriefStrip.displayName = 'BriefStrip';

--- a/packages/ui/src/components/BriefStrip/index.ts
+++ b/packages/ui/src/components/BriefStrip/index.ts
@@ -1,0 +1,2 @@
+export { BriefStrip } from './BriefStrip';
+export type { BriefStripProps, BriefChipItem, BriefChipKind } from './BriefStrip';

--- a/packages/ui/src/components/CouncilRail/CouncilRail.stories.tsx
+++ b/packages/ui/src/components/CouncilRail/CouncilRail.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CouncilRail, type AgentVerdict } from './CouncilRail';
+
+const meta = {
+  title: 'Studio v2/CouncilRail',
+  component: CouncilRail,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    status: { type: 'beta' },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: 600, maxWidth: 360, display: 'flex' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CouncilRail>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const fullCouncil: AgentVerdict[] = [
+  {
+    agentId: 'pixel',
+    agentName: 'Pixel',
+    agentRole: 'Design Director',
+    agentColor: 'var(--amp-semantic-accent-primary, #6531FF)',
+    initial: 'P',
+    verdict: 'ok',
+    body: 'Hierarchy and rhythm are right; spacing tokens consistent.',
+  },
+  {
+    agentId: 'zenith',
+    agentName: 'Zenith',
+    agentRole: 'CTO',
+    agentColor: '#0EA5E9',
+    initial: 'Z',
+    verdict: 'warn',
+    body: 'Two unused props; keep the API tighter for the launch.',
+  },
+  {
+    agentId: 'penny',
+    agentName: 'Penny',
+    agentRole: 'CFO',
+    agentColor: '#F59E0B',
+    initial: 'N',
+    verdict: 'ok',
+    body: 'Within content budget; no LLM cost regressions.',
+  },
+  {
+    agentId: 'heimdall',
+    agentName: 'Heimdall',
+    agentRole: 'Chief Analyst',
+    agentColor: '#10B981',
+    initial: 'H',
+    verdict: 'flag',
+    body: 'Last 14 days of similar copy converted 22% lower than the V2 lens.',
+  },
+];
+
+export const FullCouncil: Story = {
+  args: {
+    forVariantLabel: 'V1',
+    verdicts: fullCouncil,
+    summaryHeadline: '3 of 4 agents agree V1',
+    summaryDetail: 'Heimdall flags conversion risk — review before lock.',
+  },
+};
+
+export const Unanimous: Story = {
+  args: {
+    forVariantLabel: 'V2',
+    verdicts: [
+      {
+        agentId: 'pixel',
+        agentName: 'Pixel',
+        agentRole: 'Design Director',
+        agentColor: 'var(--amp-semantic-accent-primary, #6531FF)',
+        initial: 'P',
+        verdict: 'ok',
+        body: 'Looks great.',
+      },
+      {
+        agentId: 'zenith',
+        agentName: 'Zenith',
+        agentRole: 'CTO',
+        agentColor: '#0EA5E9',
+        initial: 'Z',
+        verdict: 'ok',
+        body: 'Implementation clean.',
+      },
+      {
+        agentId: 'aria',
+        agentName: 'Aria',
+        agentRole: 'COO',
+        agentColor: '#EF4444',
+        initial: 'A',
+        verdict: 'ok',
+        body: 'Operationally sound.',
+      },
+    ],
+    summaryHeadline: 'Council unanimous on V2',
+  },
+};
+
+export const DisagreementsOnly: Story = {
+  args: {
+    forVariantLabel: 'V1',
+    verdicts: fullCouncil,
+    disagreementsOnly: true,
+    summaryHeadline: '3 of 4 agents agree V1',
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    verdicts: [],
+  },
+};
+
+export const WithAskQuestion: Story = {
+  args: {
+    forVariantLabel: 'V3',
+    verdicts: fullCouncil.slice(0, 2),
+    onAskQuestion: (text) => console.log('asked:', text),
+  },
+};

--- a/packages/ui/src/components/CouncilRail/CouncilRail.test.tsx
+++ b/packages/ui/src/components/CouncilRail/CouncilRail.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { CouncilRail, type AgentVerdict } from './CouncilRail';
+
+afterEach(cleanup);
+
+const verdicts: AgentVerdict[] = [
+  {
+    agentId: 'pixel',
+    agentName: 'Pixel',
+    agentRole: 'Design Director',
+    agentColor: '#6531FF',
+    initial: 'P',
+    verdict: 'ok',
+    body: 'Looks tight.',
+  },
+  {
+    agentId: 'zenith',
+    agentName: 'Zenith',
+    agentRole: 'CTO',
+    agentColor: '#0EA5E9',
+    initial: 'Z',
+    verdict: 'warn',
+    body: 'Two unused props.',
+  },
+  {
+    agentId: 'heimdall',
+    agentName: 'Heimdall',
+    agentRole: 'Chief Analyst',
+    agentColor: '#10B981',
+    initial: 'H',
+    verdict: 'flag',
+    body: 'Conversion risk vs last 14 days.',
+  },
+];
+
+const allOk: AgentVerdict[] = verdicts.map((v) => ({ ...v, verdict: 'ok' as const }));
+
+describe('CouncilRail', () => {
+  it('renders a region with aria-label="Council critiques"', () => {
+    render(<CouncilRail verdicts={verdicts} />);
+    expect(screen.getByRole('region', { name: 'Council critiques' })).toBeDefined();
+  });
+
+  it('renders the Council header', () => {
+    render(<CouncilRail verdicts={verdicts} />);
+    expect(screen.getByRole('heading', { name: 'Council', level: 3 })).toBeDefined();
+  });
+
+  it('renders the variant label tag when forVariantLabel provided', () => {
+    render(<CouncilRail forVariantLabel="V1" verdicts={verdicts} />);
+    expect(screen.getByTestId('council-rail-variant-label').textContent).toContain('V1');
+  });
+
+  it('renders one card per verdict by default', () => {
+    render(<CouncilRail verdicts={verdicts} />);
+    expect(screen.getByText('Pixel')).toBeDefined();
+    expect(screen.getByText('Zenith')).toBeDefined();
+    expect(screen.getByText('Heimdall')).toBeDefined();
+    // body text rendered.
+    expect(screen.getByText('Looks tight.')).toBeDefined();
+    expect(screen.getByText('Two unused props.')).toBeDefined();
+  });
+
+  it('uses verdict for each badge', () => {
+    const { container } = render(<CouncilRail verdicts={verdicts} />);
+    expect(container.querySelectorAll('[data-verdict="ok"]').length).toBe(1);
+    expect(container.querySelectorAll('[data-verdict="warn"]').length).toBe(1);
+    expect(container.querySelectorAll('[data-verdict="flag"]').length).toBe(1);
+  });
+
+  it('renders the summary card when summaryHeadline supplied', () => {
+    render(
+      <CouncilRail
+        verdicts={verdicts}
+        summaryHeadline="3 of 4 agents agree V1"
+        summaryDetail="Heimdall flags conversion risk."
+      />,
+    );
+    expect(screen.getByTestId('council-summary')).toBeDefined();
+    expect(screen.getByText('3 of 4 agents agree V1')).toBeDefined();
+    expect(screen.getByText('Heimdall flags conversion risk.')).toBeDefined();
+  });
+
+  it('does NOT render summary when neither headline nor detail supplied', () => {
+    render(<CouncilRail verdicts={verdicts} />);
+    expect(screen.queryByTestId('council-summary')).toBeNull();
+  });
+
+  it('disagreementsOnly collapses ok agents into a single line', () => {
+    render(
+      <CouncilRail forVariantLabel="V1" verdicts={verdicts} disagreementsOnly />,
+    );
+    expect(screen.getByTestId('council-rail-unanimous')).toBeDefined();
+    // Only warn + flag cards should remain.
+    expect(screen.queryByText('Looks tight.')).toBeNull();
+    expect(screen.getByText('Two unused props.')).toBeDefined();
+    expect(screen.getByText('Conversion risk vs last 14 days.')).toBeDefined();
+  });
+
+  it('disagreementsOnly with all ok shows just the unanimous line', () => {
+    render(<CouncilRail forVariantLabel="V2" verdicts={allOk} disagreementsOnly />);
+    expect(screen.getByTestId('council-rail-unanimous')).toBeDefined();
+    // No CouncilCard rendered.
+    expect(screen.queryByText('Pixel')).toBeNull();
+  });
+
+  it('shows empty placeholder when verdicts is empty', () => {
+    render(<CouncilRail verdicts={[]} />);
+    expect(screen.getByTestId('council-rail-empty')).toBeDefined();
+  });
+
+  it('fires onAskQuestion on Enter when input has text', () => {
+    const onAskQuestion = vi.fn();
+    render(<CouncilRail verdicts={verdicts} onAskQuestion={onAskQuestion} />);
+    const input = screen.getByLabelText('Ask the council a question');
+    fireEvent.change(input, { target: { value: 'how would Pixel score this?' } });
+    fireEvent.submit(input.closest('form')!);
+    expect(onAskQuestion).toHaveBeenCalledWith('how would Pixel score this?');
+  });
+
+  it('does NOT fire onAskQuestion when input is empty', () => {
+    const onAskQuestion = vi.fn();
+    render(<CouncilRail verdicts={verdicts} onAskQuestion={onAskQuestion} />);
+    const input = screen.getByLabelText('Ask the council a question');
+    fireEvent.submit(input.closest('form')!);
+    expect(onAskQuestion).not.toHaveBeenCalled();
+  });
+
+  it('a11y: each card has an aria-label that combines agent name + role + verdict', () => {
+    render(<CouncilRail verdicts={verdicts} />);
+    expect(
+      screen.getByLabelText('Pixel (Design Director) — ok'),
+    ).toBeDefined();
+    expect(
+      screen.getByLabelText('Heimdall (Chief Analyst) — flag'),
+    ).toBeDefined();
+  });
+});

--- a/packages/ui/src/components/CouncilRail/CouncilRail.tsx
+++ b/packages/ui/src/components/CouncilRail/CouncilRail.tsx
@@ -1,0 +1,286 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+/**
+ * CouncilRail — right-rail showing per-agent verdicts on a variant.
+ *
+ * The rail is the visible-thinking surface of Studio v2: each agent (Pixel,
+ * Zenith, etc) renders a card with their critique and a verdict (ok / warn /
+ * flag). A summary card at the top condenses the council's mood; the bottom
+ * exposes a slim affordance to ask the council a question.
+ *
+ * Layout is composed from three sub-pieces — `CouncilSummary`, `CouncilCard`,
+ * and the rail container — but the public API is the single `<CouncilRail>`
+ * component to keep call sites simple.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type CouncilVerdict = 'ok' | 'warn' | 'flag';
+
+export interface AgentVerdict {
+  agentId: string;
+  agentName: string;
+  agentRole: string;
+  /** CSS color value used for the avatar bg. Token preferred, hex tolerated. */
+  agentColor: string;
+  initial: string;
+  verdict: CouncilVerdict;
+  body: string;
+}
+
+export interface CouncilRailProps extends React.HTMLAttributes<HTMLElement> {
+  forVariantLabel?: string;
+  verdicts: AgentVerdict[];
+  summaryHeadline?: string;
+  summaryDetail?: string;
+  /** Collapse all-`ok` agents into a single line. */
+  disagreementsOnly?: boolean;
+  onAskQuestion?: (text: string) => void;
+  className?: string;
+}
+
+// ─── Verdict styling ─────────────────────────────────────────────────────────
+
+const verdictBadge: Record<CouncilVerdict, { label: string; className: string }> = {
+  ok: {
+    label: 'ok',
+    className:
+      'bg-[var(--amp-semantic-bg-success-subtle)] text-[var(--amp-semantic-status-success)]',
+  },
+  warn: {
+    label: 'warn',
+    className:
+      'bg-[var(--amp-semantic-bg-warning-subtle)] text-[var(--amp-semantic-status-warning)]',
+  },
+  flag: {
+    label: 'flag',
+    className:
+      'bg-[var(--amp-semantic-bg-error-subtle)] text-[var(--amp-semantic-status-error)]',
+  },
+};
+
+// ─── Council summary sub-component ───────────────────────────────────────────
+
+export interface CouncilSummaryProps {
+  headline?: string;
+  detail?: string;
+  forVariantLabel?: string;
+}
+
+export const CouncilSummary: React.FC<CouncilSummaryProps> = ({
+  headline,
+  detail,
+  forVariantLabel,
+}) => {
+  if (!headline && !detail) return null;
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        'rounded-lg border border-[var(--amp-semantic-border-accent)] p-3',
+        // Soft accent gradient — uses tokens only.
+        'bg-[linear-gradient(135deg,var(--amp-semantic-bg-accent-subtle),var(--amp-semantic-bg-surface))]',
+      )}
+      data-testid="council-summary"
+    >
+      {headline && (
+        <div className="text-sm font-semibold text-[var(--amp-semantic-text-default)]">
+          {headline}
+          {forVariantLabel && (
+            <span className="ml-1 font-normal text-[var(--amp-semantic-text-tertiary)]">
+              · {forVariantLabel}
+            </span>
+          )}
+        </div>
+      )}
+      {detail && (
+        <p className="mt-1 text-xs text-[var(--amp-semantic-text-secondary)]">{detail}</p>
+      )}
+    </div>
+  );
+};
+
+CouncilSummary.displayName = 'CouncilSummary';
+
+// ─── Council card sub-component ──────────────────────────────────────────────
+
+export interface CouncilCardProps {
+  verdict: AgentVerdict;
+}
+
+export const CouncilCard: React.FC<CouncilCardProps> = ({ verdict }) => {
+  const v = verdictBadge[verdict.verdict];
+  return (
+    <article
+      className={cn(
+        'rounded-lg border border-[var(--amp-semantic-border-default)] bg-[var(--amp-semantic-bg-surface)] p-3',
+      )}
+      aria-label={`${verdict.agentName} (${verdict.agentRole}) — ${v.label}`}
+      data-agent-id={verdict.agentId}
+      data-verdict={verdict.verdict}
+    >
+      <header className="flex items-center gap-2">
+        <span
+          aria-hidden="true"
+          className={cn(
+            'inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full',
+            'text-xs font-semibold text-[var(--amp-semantic-text-inverse)]',
+          )}
+          style={{ backgroundColor: verdict.agentColor }}
+        >
+          {verdict.initial}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-semibold text-[var(--amp-semantic-text-default)]">
+            {verdict.agentName}
+          </div>
+          <div className="truncate text-[11px] text-[var(--amp-semantic-text-tertiary)]">
+            {verdict.agentRole}
+          </div>
+        </div>
+        <span
+          className={cn(
+            'shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
+            v.className,
+          )}
+        >
+          {v.label}
+        </span>
+      </header>
+      <p className="mt-2 text-xs leading-relaxed text-[var(--amp-semantic-text-secondary)]">
+        {verdict.body}
+      </p>
+    </article>
+  );
+};
+
+CouncilCard.displayName = 'CouncilCard';
+
+// ─── Council rail ────────────────────────────────────────────────────────────
+
+export const CouncilRail = React.forwardRef<HTMLElement, CouncilRailProps>(
+  (
+    {
+      forVariantLabel,
+      verdicts,
+      summaryHeadline,
+      summaryDetail,
+      disagreementsOnly = false,
+      onAskQuestion,
+      className,
+      ...rest
+    },
+    ref,
+  ) => {
+    const [draft, setDraft] = React.useState('');
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      const value = draft.trim();
+      if (!value) return;
+      onAskQuestion?.(value);
+      setDraft('');
+    };
+
+    // Collapse all-ok set when disagreementsOnly=true.
+    const okVerdicts = verdicts.filter((v) => v.verdict === 'ok');
+    const nonOkVerdicts = verdicts.filter((v) => v.verdict !== 'ok');
+    const collapseOk = disagreementsOnly && okVerdicts.length > 0;
+
+    return (
+      <aside
+        ref={ref}
+        role="region"
+        aria-label="Council critiques"
+        className={cn(
+          'flex h-full w-full flex-col gap-3 overflow-y-auto p-3',
+          'bg-[var(--amp-semantic-bg-canvas,var(--amp-semantic-bg-base))]',
+          'border-l border-[var(--amp-semantic-border-subtle)]',
+          className,
+        )}
+        {...rest}
+      >
+        <header className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-[var(--amp-semantic-text-default)]">
+            Council
+          </h3>
+          {forVariantLabel && (
+            <span
+              className={cn(
+                'rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
+                'bg-[var(--amp-semantic-bg-accent-subtle)] text-[var(--amp-semantic-text-accent)]',
+              )}
+              data-testid="council-rail-variant-label"
+            >
+              on {forVariantLabel}
+            </span>
+          )}
+        </header>
+
+        <CouncilSummary
+          headline={summaryHeadline}
+          detail={summaryDetail}
+          forVariantLabel={forVariantLabel}
+        />
+
+        <div className="flex flex-col gap-2">
+          {collapseOk && (
+            <div
+              data-testid="council-rail-unanimous"
+              className={cn(
+                'rounded-lg border border-[var(--amp-semantic-border-success)] px-3 py-2',
+                'bg-[var(--amp-semantic-bg-success-subtle)]',
+              )}
+            >
+              <span className="text-xs font-medium text-[var(--amp-semantic-status-success)]">
+                Council unanimous{forVariantLabel ? ` on ${forVariantLabel}` : ''} —{' '}
+                {okVerdicts.length} agree
+              </span>
+            </div>
+          )}
+
+          {(collapseOk ? nonOkVerdicts : verdicts).map((v) => (
+            <CouncilCard key={v.agentId} verdict={v} />
+          ))}
+
+          {!collapseOk && verdicts.length === 0 && (
+            <div
+              data-testid="council-rail-empty"
+              className="rounded-lg border border-dashed border-[var(--amp-semantic-border-default)] p-3 text-xs text-[var(--amp-semantic-text-tertiary)]"
+            >
+              No verdicts yet. Generate a variant to see council reactions.
+            </div>
+          )}
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="mt-auto flex items-center gap-1.5 rounded-md border border-[var(--amp-semantic-border-default)] bg-[var(--amp-semantic-bg-surface)] px-2 py-1.5"
+        >
+          <span
+            aria-hidden="true"
+            className="text-[10px] font-semibold text-[var(--amp-semantic-text-tertiary)]"
+          >
+            &#8984;/
+          </span>
+          <input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="ask the council a question"
+            aria-label="Ask the council a question"
+            className={cn(
+              'flex-1 bg-transparent text-xs',
+              'text-[var(--amp-semantic-text-default)]',
+              'placeholder:text-[var(--amp-semantic-text-tertiary)]',
+              'focus-visible:outline-none',
+            )}
+          />
+        </form>
+      </aside>
+    );
+  },
+);
+
+CouncilRail.displayName = 'CouncilRail';

--- a/packages/ui/src/components/CouncilRail/index.ts
+++ b/packages/ui/src/components/CouncilRail/index.ts
@@ -1,0 +1,8 @@
+export { CouncilRail, CouncilCard, CouncilSummary } from './CouncilRail';
+export type {
+  CouncilRailProps,
+  CouncilCardProps,
+  CouncilSummaryProps,
+  AgentVerdict,
+  CouncilVerdict,
+} from './CouncilRail';

--- a/packages/ui/src/components/HistoryStrip/HistoryStrip.stories.tsx
+++ b/packages/ui/src/components/HistoryStrip/HistoryStrip.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { HistoryStrip, type GenerationItem } from './HistoryStrip';
+
+const meta = {
+  title: 'Studio v2/HistoryStrip',
+  component: HistoryStrip,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    status: { type: 'beta' },
+  },
+} satisfies Meta<typeof HistoryStrip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const gen1: GenerationItem = {
+  id: 'g1',
+  label: 'Gen 1',
+  thumbs: [
+    { id: 'v1', status: 'ready' },
+    { id: 'v2', status: 'ready' },
+    { id: 'v3', status: 'win' },
+    { id: 'v4', status: 'ready' },
+  ],
+  summary: '8.2s · V3 selected',
+};
+
+const gen2Current: GenerationItem = {
+  id: 'g2',
+  label: 'Gen 2 · now',
+  thumbs: [
+    { id: 'v1', status: 'locked' },
+    { id: 'v2', status: 'generating' },
+    { id: 'v3', status: 'generating' },
+  ],
+  summary: 'generating…',
+  current: true,
+};
+
+const gen3Errored: GenerationItem = {
+  id: 'g3',
+  label: 'Gen 3',
+  thumbs: [
+    { id: 'v1', status: 'ready' },
+    { id: 'v2', status: 'error' },
+  ],
+  summary: '12.4s · 1 failed',
+};
+
+export const Empty: Story = {
+  args: {
+    generations: [],
+  },
+};
+
+export const SingleGeneration: Story = {
+  args: {
+    generations: [{ ...gen1, current: true }],
+  },
+};
+
+export const FullTimeline: Story = {
+  args: {
+    generations: [gen1, gen2Current, gen3Errored],
+  },
+};
+
+export const MixedStates: Story = {
+  args: {
+    generations: [
+      {
+        id: 'gx',
+        label: 'Gen 1',
+        thumbs: [
+          { id: 'v1', status: 'ready' },
+          { id: 'v2', status: 'win' },
+          { id: 'v3', status: 'locked' },
+          { id: 'v4', status: 'error' },
+        ],
+        summary: 'all four states',
+        current: true,
+      },
+    ],
+  },
+};
+
+export const Interactive: Story = {
+  args: {
+    generations: [gen1, gen2Current, gen3Errored],
+    onSelect: (id) => console.log('select gen', id),
+    onThumbSelect: (gid, vid) => console.log('select variant', gid, vid),
+  },
+};

--- a/packages/ui/src/components/HistoryStrip/HistoryStrip.test.tsx
+++ b/packages/ui/src/components/HistoryStrip/HistoryStrip.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { HistoryStrip, type GenerationItem } from './HistoryStrip';
+
+afterEach(cleanup);
+
+const baseGenerations: GenerationItem[] = [
+  {
+    id: 'g1',
+    label: 'Gen 1',
+    thumbs: [
+      { id: 'v1', status: 'ready' },
+      { id: 'v2', status: 'win' },
+    ],
+    summary: '8.2s · V2 selected',
+  },
+  {
+    id: 'g2',
+    label: 'Gen 2 · now',
+    thumbs: [
+      { id: 'v1', status: 'generating' },
+      { id: 'v2', status: 'locked' },
+      { id: 'v3', status: 'error' },
+    ],
+    summary: 'generating',
+    current: true,
+  },
+];
+
+describe('HistoryStrip', () => {
+  it('renders a region with aria-label="Variant history"', () => {
+    render(<HistoryStrip generations={baseGenerations} />);
+    expect(screen.getByRole('region', { name: 'Variant history' })).toBeDefined();
+  });
+
+  it('renders one button per generation', () => {
+    render(<HistoryStrip generations={baseGenerations} />);
+    expect(screen.getByRole('button', { name: 'Select Gen 1' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Select Gen 2 · now' })).toBeDefined();
+  });
+
+  it('shows empty state when generations is []', () => {
+    render(<HistoryStrip generations={[]} />);
+    expect(screen.getByTestId('history-strip-empty')).toBeDefined();
+    expect(screen.getByText('No generations yet')).toBeDefined();
+  });
+
+  it('marks current generation with aria-current', () => {
+    render(<HistoryStrip generations={baseGenerations} />);
+    const current = screen.getByRole('button', { name: 'Select Gen 2 · now' });
+    expect(current.getAttribute('aria-current')).toBe('true');
+    const non = screen.getByRole('button', { name: 'Select Gen 1' });
+    expect(non.getAttribute('aria-current')).toBeNull();
+  });
+
+  it('fires onSelect with generation id', () => {
+    const onSelect = vi.fn();
+    render(<HistoryStrip generations={baseGenerations} onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Select Gen 1' }));
+    expect(onSelect).toHaveBeenCalledWith('g1');
+  });
+
+  it('renders summary text when supplied', () => {
+    render(<HistoryStrip generations={baseGenerations} />);
+    expect(screen.getByText('8.2s · V2 selected')).toBeDefined();
+    expect(screen.getByText('generating')).toBeDefined();
+  });
+
+  it('renders thumbs with data-status attribute reflecting status', () => {
+    const { container } = render(<HistoryStrip generations={baseGenerations} />);
+    const ready = container.querySelectorAll('[data-status="ready"]');
+    const win = container.querySelectorAll('[data-status="win"]');
+    const generating = container.querySelectorAll('[data-status="generating"]');
+    const locked = container.querySelectorAll('[data-status="locked"]');
+    const error = container.querySelectorAll('[data-status="error"]');
+    expect(ready.length).toBe(1);
+    expect(win.length).toBe(1);
+    expect(generating.length).toBe(1);
+    expect(locked.length).toBe(1);
+    expect(error.length).toBe(1);
+  });
+
+  it('thumbs are clickable when onThumbSelect provided', () => {
+    const onThumbSelect = vi.fn();
+    render(
+      <HistoryStrip generations={baseGenerations} onThumbSelect={onThumbSelect} />,
+    );
+    const variantButtons = screen.getAllByRole('button', { name: /^Variant / });
+    expect(variantButtons.length).toBe(5);
+    fireEvent.click(variantButtons[0]);
+    expect(onThumbSelect).toHaveBeenCalledTimes(1);
+    expect(onThumbSelect).toHaveBeenCalledWith('g1', 'v1');
+  });
+
+  it('thumbs are NOT focusable / clickable when onThumbSelect missing', () => {
+    render(<HistoryStrip generations={baseGenerations} />);
+    expect(screen.queryByRole('button', { name: /^Variant / })).toBeNull();
+  });
+
+  it('Enter on thumb triggers onThumbSelect', () => {
+    const onThumbSelect = vi.fn();
+    render(
+      <HistoryStrip generations={baseGenerations} onThumbSelect={onThumbSelect} />,
+    );
+    const variantButton = screen.getAllByRole('button', { name: /^Variant / })[1];
+    fireEvent.keyDown(variantButton, { key: 'Enter' });
+    expect(onThumbSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders branch arrow between consecutive generations', () => {
+    const { container } = render(<HistoryStrip generations={baseGenerations} />);
+    // Find arrow span — the only span containing the right-arrow glyph.
+    const arrows = Array.from(container.querySelectorAll('span')).filter((el) =>
+      el.textContent === '→',
+    );
+    expect(arrows.length).toBe(1);
+  });
+
+  it('truncates thumbs beyond 4 with overflow indicator', () => {
+    const many: GenerationItem[] = [
+      {
+        id: 'big',
+        label: 'Gen big',
+        thumbs: [
+          { id: '1', status: 'ready' },
+          { id: '2', status: 'ready' },
+          { id: '3', status: 'ready' },
+          { id: '4', status: 'ready' },
+          { id: '5', status: 'ready' },
+          { id: '6', status: 'ready' },
+        ],
+      },
+    ];
+    render(<HistoryStrip generations={many} />);
+    expect(screen.getByLabelText('2 more variants')).toBeDefined();
+  });
+});

--- a/packages/ui/src/components/HistoryStrip/HistoryStrip.tsx
+++ b/packages/ui/src/components/HistoryStrip/HistoryStrip.tsx
@@ -1,0 +1,250 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+/**
+ * HistoryStrip — horizontal timeline of generation cycles in Studio v2.
+ *
+ * Each generation chip shows up to four mini-thumbnails representing the
+ * variants produced in that cycle. The current generation is visually
+ * highlighted; consecutive generations are joined by a tiny branch arrow so
+ * the user can read the timeline left-to-right. The strip is purely
+ * presentational — selection state is owned by the parent.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type VariantThumbStatus = 'ready' | 'generating' | 'error' | 'locked' | 'win';
+
+export interface VariantThumb {
+  id: string;
+  status: VariantThumbStatus;
+}
+
+export interface GenerationItem {
+  id: string;
+  /** Human label, e.g. "Gen 1" or "Gen 2 · now". */
+  label: string;
+  /** Up to 4 thumbnails. Anything beyond is truncated visually. */
+  thumbs: VariantThumb[];
+  /** Optional summary line, e.g. "8.2s · V1 selected". */
+  summary?: string;
+  /** Marks this generation as the current selection. */
+  current?: boolean;
+}
+
+export interface HistoryStripProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
+  generations: GenerationItem[];
+  onSelect?: (genId: string) => void;
+  onThumbSelect?: (genId: string, variantId: string) => void;
+  className?: string;
+}
+
+// ─── Shimmer keyframes (id-guarded, injected once) ──────────────────────────
+
+const STYLE_ID = 'amp-history-strip-keyframes';
+const styleSheet = `
+@keyframes amp-history-shimmer {
+  0%   { background-position: -120% 0; }
+  100% { background-position: 220% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .amp-history-thumb--generating { animation: none !important; background: var(--amp-semantic-bg-subtle) !important; }
+}
+`;
+
+function useInjectedKeyframes() {
+  React.useEffect(() => {
+    if (typeof document === 'undefined') return;
+    if (document.getElementById(STYLE_ID)) return;
+    const el = document.createElement('style');
+    el.id = STYLE_ID;
+    el.textContent = styleSheet;
+    document.head.appendChild(el);
+  }, []);
+}
+
+// ─── Thumb sub-component ─────────────────────────────────────────────────────
+
+const baseThumb = cn(
+  'relative h-4 w-[22px] shrink-0 overflow-hidden rounded-[3px]',
+  'border border-[var(--amp-semantic-border-subtle)]',
+);
+
+const thumbStatusClasses: Record<VariantThumbStatus, string> = {
+  ready: 'bg-[var(--amp-semantic-bg-subtle)]',
+  generating:
+    'amp-history-thumb--generating bg-[length:200%_100%] bg-[linear-gradient(90deg,var(--amp-semantic-bg-subtle)_0%,var(--amp-semantic-bg-raised)_50%,var(--amp-semantic-bg-subtle)_100%)]',
+  error: 'bg-[var(--amp-semantic-bg-error-subtle)]',
+  locked:
+    'bg-[linear-gradient(135deg,var(--amp-semantic-bg-accent-subtle),var(--amp-semantic-accent-soft,var(--amp-semantic-bg-accent-subtle)))]',
+  win: 'bg-[var(--amp-semantic-bg-success-subtle)]',
+};
+
+interface GenerationChipProps {
+  generation: GenerationItem;
+  onSelect?: (genId: string) => void;
+  onThumbSelect?: (genId: string, variantId: string) => void;
+}
+
+const GenerationChip: React.FC<GenerationChipProps> = ({
+  generation,
+  onSelect,
+  onThumbSelect,
+}) => {
+  const visibleThumbs = generation.thumbs.slice(0, 4);
+  const overflow = generation.thumbs.length - visibleThumbs.length;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect?.(generation.id)}
+      aria-label={`Select ${generation.label}`}
+      aria-current={generation.current ? 'true' : undefined}
+      className={cn(
+        'group flex shrink-0 flex-col gap-1 rounded-md border px-2.5 py-1.5 text-left',
+        'transition-colors duration-150',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1',
+        'focus-visible:ring-[var(--amp-semantic-border-focus)]',
+        generation.current
+          ? 'border-[var(--amp-semantic-border-accent)] bg-[var(--amp-semantic-bg-accent-subtle)]'
+          : 'border-[var(--amp-semantic-border-default)] bg-[var(--amp-semantic-bg-surface)] hover:bg-[var(--amp-semantic-bg-subtle)]',
+      )}
+    >
+      <div className="flex items-center gap-1.5">
+        <span
+          className={cn(
+            'text-xs font-semibold',
+            generation.current
+              ? 'text-[var(--amp-semantic-text-accent)]'
+              : 'text-[var(--amp-semantic-text-default)]',
+          )}
+        >
+          {generation.label}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-1" aria-hidden="false">
+        {visibleThumbs.map((thumb) => (
+          <span
+            key={thumb.id}
+            role={onThumbSelect ? 'button' : undefined}
+            tabIndex={onThumbSelect ? 0 : undefined}
+            aria-label={onThumbSelect ? `Variant ${thumb.id} (${thumb.status})` : undefined}
+            onClick={(e) => {
+              if (!onThumbSelect) return;
+              e.stopPropagation();
+              onThumbSelect(generation.id, thumb.id);
+            }}
+            onKeyDown={(e) => {
+              if (!onThumbSelect) return;
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                onThumbSelect(generation.id, thumb.id);
+              }
+            }}
+            className={cn(
+              baseThumb,
+              thumbStatusClasses[thumb.status],
+              onThumbSelect &&
+                'cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--amp-semantic-border-focus)]',
+              thumb.status === 'generating' && '[animation:amp-history-shimmer_1.4s_linear_infinite]',
+            )}
+            data-status={thumb.status}
+          >
+            {thumb.status === 'win' && (
+              <span
+                aria-hidden="true"
+                className="absolute right-0.5 top-0.5 h-1 w-1 rounded-full bg-[var(--amp-semantic-status-success)]"
+              />
+            )}
+            {thumb.status === 'error' && (
+              <span
+                aria-hidden="true"
+                className="absolute right-0 top-0 h-1.5 w-1.5 rounded-bl-[3px] bg-[var(--amp-semantic-status-error)]"
+              />
+            )}
+          </span>
+        ))}
+        {overflow > 0 && (
+          <span
+            aria-label={`${overflow} more variants`}
+            className="text-[10px] text-[var(--amp-semantic-text-tertiary)]"
+          >
+            +{overflow}
+          </span>
+        )}
+      </div>
+
+      {generation.summary && (
+        <span className="text-[10px] text-[var(--amp-semantic-text-tertiary)]">
+          {generation.summary}
+        </span>
+      )}
+    </button>
+  );
+};
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export const HistoryStrip = React.forwardRef<HTMLDivElement, HistoryStripProps>(
+  ({ generations, onSelect, onThumbSelect, className, ...rest }, ref) => {
+    useInjectedKeyframes();
+    const isEmpty = generations.length === 0;
+
+    return (
+      <div
+        ref={ref}
+        role="region"
+        aria-label="Variant history"
+        className={cn(
+          'flex w-full items-center gap-2 overflow-x-auto whitespace-nowrap',
+          'border-b border-[var(--amp-semantic-border-subtle)]',
+          'bg-[var(--amp-semantic-bg-surface)]',
+          'px-3 py-2',
+          className,
+        )}
+        {...rest}
+      >
+        <span
+          className="shrink-0 text-[11px] font-semibold uppercase tracking-wide text-[var(--amp-semantic-text-tertiary)]"
+          aria-hidden="true"
+        >
+          Variants
+        </span>
+
+        {isEmpty ? (
+          <span
+            data-testid="history-strip-empty"
+            className="shrink-0 rounded-md border border-dashed border-[var(--amp-semantic-border-default)] px-2 py-1 text-xs text-[var(--amp-semantic-text-tertiary)]"
+          >
+            No generations yet
+          </span>
+        ) : (
+          generations.map((gen, i) => (
+            <React.Fragment key={gen.id}>
+              <GenerationChip
+                generation={gen}
+                onSelect={onSelect}
+                onThumbSelect={onThumbSelect}
+              />
+              {i < generations.length - 1 && (
+                <span
+                  aria-hidden="true"
+                  className="shrink-0 text-xs text-[var(--amp-semantic-text-tertiary)]"
+                >
+                  &rarr;
+                </span>
+              )}
+            </React.Fragment>
+          ))
+        )}
+      </div>
+    );
+  },
+);
+
+HistoryStrip.displayName = 'HistoryStrip';

--- a/packages/ui/src/components/HistoryStrip/index.ts
+++ b/packages/ui/src/components/HistoryStrip/index.ts
@@ -1,0 +1,7 @@
+export { HistoryStrip } from './HistoryStrip';
+export type {
+  HistoryStripProps,
+  GenerationItem,
+  VariantThumb,
+  VariantThumbStatus,
+} from './HistoryStrip';

--- a/packages/ui/src/components/VariantCard/VariantCard.stories.tsx
+++ b/packages/ui/src/components/VariantCard/VariantCard.stories.tsx
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { VariantCard } from './VariantCard';
+
+const meta = {
+  title: 'Studio v2/VariantCard',
+  component: VariantCard,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    status: { type: 'beta' },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 320, height: 240 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof VariantCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  args: {
+    state: 'empty',
+    name: 'V1',
+    lensTag: 'editorial',
+    statusText: '⌘1',
+  },
+};
+
+export const Generating: Story = {
+  args: {
+    state: 'generating',
+    name: 'V2',
+    lensTag: 'spatial',
+    statusText: 'generating · 3.2s',
+  },
+};
+
+export const Ready: Story = {
+  args: {
+    state: 'ready',
+    name: 'V1',
+    lensTag: 'editorial',
+    statusText: '⌘1',
+    scoreLabel: '●● 91 council',
+    scoreVariant: 'good',
+    actions: [
+      { id: 'lock', label: 'Lock', onClick: () => undefined },
+      { id: 'fork', label: 'Fork', onClick: () => undefined },
+    ],
+    children: (
+      <div
+        style={{
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'serif',
+          fontSize: 28,
+        }}
+      >
+        Editorial mock
+      </div>
+    ),
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    ...(Ready.args ?? {}),
+    state: 'ready',
+    name: 'V1',
+    selected: true,
+    onClick: () => undefined,
+  },
+};
+
+export const Error: Story = {
+  args: {
+    state: 'error',
+    name: 'V3',
+    lensTag: 'minimal',
+    statusText: 'retry',
+    errorMessage: 'Generation timed out after 30s',
+    onRetry: () => undefined,
+  },
+};
+
+export const ScoreVariants: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 12, gridTemplateColumns: 'repeat(3, 1fr)' }}>
+      <VariantCard
+        state="ready"
+        name="V1"
+        lensTag="good"
+        scoreLabel="●● 91 council"
+        scoreVariant="good"
+      >
+        <div style={{ padding: 16 }}>good</div>
+      </VariantCard>
+      <VariantCard
+        state="ready"
+        name="V2"
+        lensTag="neutral"
+        scoreLabel="● 64 council"
+        scoreVariant="neutral"
+      >
+        <div style={{ padding: 16 }}>neutral</div>
+      </VariantCard>
+      <VariantCard
+        state="ready"
+        name="V3"
+        lensTag="bad"
+        scoreLabel="○ 38 council"
+        scoreVariant="bad"
+      >
+        <div style={{ padding: 16 }}>bad</div>
+      </VariantCard>
+    </div>
+  ),
+  args: {
+    state: 'ready',
+    name: 'V1',
+  },
+};

--- a/packages/ui/src/components/VariantCard/VariantCard.test.tsx
+++ b/packages/ui/src/components/VariantCard/VariantCard.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { VariantCard } from './VariantCard';
+
+afterEach(cleanup);
+
+describe('VariantCard', () => {
+  it('renders the name and lens tag', () => {
+    render(<VariantCard state="empty" name="V1" lensTag="editorial" />);
+    expect(screen.getByText('V1')).toBeDefined();
+    expect(screen.getByTestId('variant-card-lens').textContent).toBe('editorial');
+  });
+
+  it('renders status text in header', () => {
+    render(
+      <VariantCard state="generating" name="V2" statusText="generating · 3.2s" />,
+    );
+    expect(screen.getByTestId('variant-card-status').textContent).toBe(
+      'generating · 3.2s',
+    );
+  });
+
+  it('empty state renders the empty placeholder', () => {
+    render(<VariantCard state="empty" name="V1" />);
+    expect(screen.getByTestId('variant-card-body-empty')).toBeDefined();
+    expect(screen.getByText('No variant yet')).toBeDefined();
+  });
+
+  it('generating state renders the shimmer body with role="status"', () => {
+    render(<VariantCard state="generating" name="V1" />);
+    const generating = screen.getByTestId('variant-card-body-generating');
+    expect(generating).toBeDefined();
+    expect(generating.getAttribute('role')).toBe('status');
+    expect(generating.getAttribute('aria-label')).toBe('Generating variant V1');
+  });
+
+  it('ready state renders children in the body slot', () => {
+    render(
+      <VariantCard state="ready" name="V1">
+        <div data-testid="ready-body">hello</div>
+      </VariantCard>,
+    );
+    expect(screen.getByTestId('ready-body')).toBeDefined();
+  });
+
+  it('error state renders role="alert" with the supplied message', () => {
+    render(
+      <VariantCard
+        state="error"
+        name="V1"
+        errorMessage="Generation timed out"
+      />,
+    );
+    const errorBody = screen.getByTestId('variant-card-body-error');
+    expect(errorBody.getAttribute('role')).toBe('alert');
+    expect(screen.getByText('Generation timed out')).toBeDefined();
+  });
+
+  it('error state renders Retry button only when onRetry is provided', () => {
+    const onRetry = vi.fn();
+    const { rerender } = render(
+      <VariantCard state="error" name="V1" errorMessage="failed" />,
+    );
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+    rerender(
+      <VariantCard
+        state="error"
+        name="V1"
+        errorMessage="failed"
+        onRetry={onRetry}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('Retry click does NOT propagate to card onClick', () => {
+    const onClick = vi.fn();
+    const onRetry = vi.fn();
+    render(
+      <VariantCard
+        state="error"
+        name="V1"
+        errorMessage="failed"
+        onRetry={onRetry}
+        onClick={onClick}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('renders score label with the correct variant data attribute', () => {
+    render(
+      <VariantCard
+        state="ready"
+        name="V1"
+        scoreLabel="●● 91 council"
+        scoreVariant="good"
+      />,
+    );
+    const score = screen.getByTestId('variant-card-score');
+    expect(score.textContent).toBe('●● 91 council');
+    expect(score.getAttribute('data-score-variant')).toBe('good');
+  });
+
+  it('renders one footer button per action and fires onClick', () => {
+    const lock = vi.fn();
+    const fork = vi.fn();
+    render(
+      <VariantCard
+        state="ready"
+        name="V1"
+        actions={[
+          { id: 'l', label: 'Lock', onClick: lock },
+          { id: 'f', label: 'Fork', onClick: fork },
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Lock' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Fork' }));
+    expect(lock).toHaveBeenCalledTimes(1);
+    expect(fork).toHaveBeenCalledTimes(1);
+  });
+
+  it('action click does NOT bubble to the card onClick', () => {
+    const onClick = vi.fn();
+    const lock = vi.fn();
+    render(
+      <VariantCard
+        state="ready"
+        name="V1"
+        onClick={onClick}
+        actions={[{ id: 'l', label: 'Lock', onClick: lock }]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Lock' }));
+    expect(lock).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('clicking the card fires onClick', () => {
+    const onClick = vi.fn();
+    render(<VariantCard state="ready" name="V1" onClick={onClick} />);
+    const card = screen.getByRole('button', { name: 'Variant V1' });
+    fireEvent.click(card);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('Enter / Space on the card fires onClick', () => {
+    const onClick = vi.fn();
+    render(<VariantCard state="ready" name="V1" onClick={onClick} />);
+    const card = screen.getByRole('button', { name: 'Variant V1' });
+    fireEvent.keyDown(card, { key: 'Enter' });
+    fireEvent.keyDown(card, { key: ' ' });
+    expect(onClick).toHaveBeenCalledTimes(2);
+  });
+
+  it('selected state sets aria-pressed=true (when interactive)', () => {
+    render(
+      <VariantCard state="ready" name="V1" selected onClick={() => undefined} />,
+    );
+    const card = screen.getByRole('button', { name: 'Variant V1' });
+    expect(card.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('non-interactive cards render as group, not button', () => {
+    render(<VariantCard state="ready" name="V1" />);
+    expect(screen.queryByRole('button', { name: 'Variant V1' })).toBeNull();
+    expect(screen.getByRole('group', { name: 'Variant V1' })).toBeDefined();
+  });
+
+  it('exposes data-state for testing / styling hooks', () => {
+    const { rerender } = render(<VariantCard state="empty" name="V1" />);
+    expect(screen.getByRole('group').getAttribute('data-state')).toBe('empty');
+    rerender(<VariantCard state="generating" name="V1" />);
+    expect(screen.getByRole('group').getAttribute('data-state')).toBe('generating');
+  });
+});

--- a/packages/ui/src/components/VariantCard/VariantCard.tsx
+++ b/packages/ui/src/components/VariantCard/VariantCard.tsx
@@ -1,0 +1,305 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+/**
+ * VariantCard — canvas variant primitive for Studio v2.
+ *
+ * A single variant is the unit of generation: it owns a state machine
+ * (empty / generating / ready / error), a header (name + lens tag + status),
+ * a body (children slot, shimmer when generating, retry when error), and a
+ * footer (score + actions). Selection is owned by the parent grid; the card
+ * renders the visual selected affordance when `selected={true}`.
+ *
+ * Keyframes (shimmer + pulse) are scoped to this component and injected once
+ * per page, id-guarded — no external CSS file is required.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type VariantCardState = 'empty' | 'generating' | 'ready' | 'error';
+
+export interface VariantCardAction {
+  id: string;
+  label: string;
+  onClick: () => void;
+}
+
+export type VariantCardScoreVariant = 'good' | 'neutral' | 'bad';
+
+export interface VariantCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onClick'> {
+  state: VariantCardState;
+  selected?: boolean;
+  name: string;
+  lensTag?: string;
+  statusText?: string;
+  scoreLabel?: string;
+  scoreVariant?: VariantCardScoreVariant;
+  actions?: VariantCardAction[];
+  onClick?: () => void;
+  errorMessage?: string;
+  onRetry?: () => void;
+  children?: React.ReactNode;
+  className?: string;
+}
+
+// ─── Keyframes (shimmer + pulse) ─────────────────────────────────────────────
+
+const STYLE_ID = 'amp-variant-card-keyframes';
+const styleSheet = `
+@keyframes amp-variant-shimmer {
+  0%   { background-position: -120% 0; }
+  100% { background-position: 220% 0; }
+}
+@keyframes amp-variant-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.65; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .amp-variant-shimmer { animation: none !important; background: var(--amp-semantic-bg-subtle) !important; }
+  .amp-variant-pulse   { animation: none !important; opacity: 1 !important; }
+}
+`;
+
+function useInjectedKeyframes() {
+  React.useEffect(() => {
+    if (typeof document === 'undefined') return;
+    if (document.getElementById(STYLE_ID)) return;
+    const el = document.createElement('style');
+    el.id = STYLE_ID;
+    el.textContent = styleSheet;
+    document.head.appendChild(el);
+  }, []);
+}
+
+// ─── Score styling ───────────────────────────────────────────────────────────
+
+const scoreVariantClasses: Record<VariantCardScoreVariant, string> = {
+  good: 'text-[var(--amp-semantic-status-success)]',
+  neutral: 'text-[var(--amp-semantic-text-secondary)]',
+  bad: 'text-[var(--amp-semantic-status-error)]',
+};
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export const VariantCard = React.forwardRef<HTMLDivElement, VariantCardProps>(
+  (
+    {
+      state,
+      selected = false,
+      name,
+      lensTag,
+      statusText,
+      scoreLabel,
+      scoreVariant = 'neutral',
+      actions,
+      onClick,
+      errorMessage,
+      onRetry,
+      children,
+      className,
+      ...rest
+    },
+    ref,
+  ) => {
+    useInjectedKeyframes();
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!onClick) return;
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onClick();
+      }
+    };
+
+    const interactive = !!onClick;
+
+    return (
+      <div
+        ref={ref}
+        role={interactive ? 'button' : 'group'}
+        tabIndex={interactive ? 0 : undefined}
+        aria-pressed={interactive ? selected : undefined}
+        aria-label={`Variant ${name}${lensTag ? ` — ${lensTag}` : ''}`}
+        onClick={onClick}
+        onKeyDown={handleKeyDown}
+        data-state={state}
+        data-selected={selected}
+        className={cn(
+          'flex h-full w-full flex-col overflow-hidden rounded-lg border',
+          'bg-[var(--amp-semantic-bg-surface)]',
+          'transition-shadow duration-150',
+          interactive && 'cursor-pointer hover:shadow-md',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+          'focus-visible:ring-[var(--amp-semantic-border-focus)]',
+          selected
+            ? 'border-[var(--amp-semantic-border-accent)] shadow-md'
+            : 'border-[var(--amp-semantic-border-default)]',
+          className,
+        )}
+        {...rest}
+      >
+        {/* ── Header ── */}
+        <header
+          className={cn(
+            'flex shrink-0 items-center gap-2 border-b px-3 py-2',
+            selected
+              ? 'border-[var(--amp-semantic-border-accent)] bg-[var(--amp-semantic-bg-accent-subtle)]'
+              : 'border-[var(--amp-semantic-border-subtle)] bg-[var(--amp-semantic-bg-surface)]',
+          )}
+        >
+          <span
+            className={cn(
+              'text-sm font-semibold',
+              selected
+                ? 'text-[var(--amp-semantic-text-accent)]'
+                : 'text-[var(--amp-semantic-text-default)]',
+            )}
+          >
+            {name}
+          </span>
+          {lensTag && (
+            <span
+              className={cn(
+                'rounded-full px-1.5 py-0.5 text-[10px] font-medium',
+                'bg-[var(--amp-semantic-bg-subtle)] text-[var(--amp-semantic-text-secondary)]',
+              )}
+              data-testid="variant-card-lens"
+            >
+              {lensTag}
+            </span>
+          )}
+          {statusText && (
+            <span
+              className={cn(
+                'ml-auto text-[11px]',
+                state === 'generating'
+                  ? 'amp-variant-pulse text-[var(--amp-semantic-text-secondary)] [animation:amp-variant-pulse_1.4s_ease-in-out_infinite]'
+                  : 'text-[var(--amp-semantic-text-tertiary)]',
+              )}
+              data-testid="variant-card-status"
+            >
+              {statusText}
+            </span>
+          )}
+        </header>
+
+        {/* ── Body ── */}
+        <div
+          className={cn(
+            'relative min-h-[120px] flex-1',
+            'bg-[var(--amp-semantic-bg-canvas,var(--amp-semantic-bg-base))]',
+          )}
+          data-testid="variant-card-body"
+        >
+          {state === 'empty' && (
+            <div
+              data-testid="variant-card-body-empty"
+              className="flex h-full w-full items-center justify-center p-4 text-xs text-[var(--amp-semantic-text-tertiary)]"
+            >
+              No variant yet
+            </div>
+          )}
+
+          {state === 'generating' && (
+            <div
+              data-testid="variant-card-body-generating"
+              role="status"
+              aria-live="polite"
+              aria-label={`Generating variant ${name}`}
+              className={cn(
+                'amp-variant-shimmer h-full w-full',
+                'bg-[length:200%_100%]',
+                'bg-[linear-gradient(90deg,var(--amp-semantic-bg-subtle)_0%,var(--amp-semantic-bg-raised)_50%,var(--amp-semantic-bg-subtle)_100%)]',
+                '[animation:amp-variant-shimmer_1.6s_linear_infinite]',
+              )}
+            />
+          )}
+
+          {state === 'error' && (
+            <div
+              data-testid="variant-card-body-error"
+              role="alert"
+              className="flex h-full w-full flex-col items-center justify-center gap-2 p-4 text-center"
+            >
+              <span className="text-xs font-medium text-[var(--amp-semantic-status-error)]">
+                {errorMessage ?? 'Generation failed'}
+              </span>
+              {onRetry && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRetry();
+                  }}
+                  className={cn(
+                    'rounded-md px-2.5 py-1 text-xs font-medium',
+                    'bg-[var(--amp-semantic-bg-subtle)] text-[var(--amp-semantic-text-default)]',
+                    'hover:bg-[var(--amp-semantic-bg-raised)]',
+                    'focus-visible:outline-none focus-visible:ring-2',
+                    'focus-visible:ring-[var(--amp-semantic-border-focus)]',
+                  )}
+                >
+                  Retry
+                </button>
+              )}
+            </div>
+          )}
+
+          {state === 'ready' && children}
+        </div>
+
+        {/* ── Footer ── */}
+        {(scoreLabel || (actions && actions.length > 0)) && (
+          <footer
+            className={cn(
+              'flex shrink-0 items-center gap-2 border-t px-3 py-2',
+              'border-[var(--amp-semantic-border-subtle)]',
+              'bg-[var(--amp-semantic-bg-surface)]',
+            )}
+          >
+            {scoreLabel && (
+              <span
+                className={cn(
+                  'text-[11px] font-medium',
+                  scoreVariantClasses[scoreVariant],
+                )}
+                data-testid="variant-card-score"
+                data-score-variant={scoreVariant}
+              >
+                {scoreLabel}
+              </span>
+            )}
+            {actions && actions.length > 0 && (
+              <div className="ml-auto flex items-center gap-1">
+                {actions.map((action) => (
+                  <button
+                    key={action.id}
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      action.onClick();
+                    }}
+                    className={cn(
+                      'rounded-md px-2 py-1 text-[11px] font-medium',
+                      'text-[var(--amp-semantic-text-secondary)]',
+                      'hover:bg-[var(--amp-semantic-bg-subtle)]',
+                      'hover:text-[var(--amp-semantic-text-default)]',
+                      'focus-visible:outline-none focus-visible:ring-2',
+                      'focus-visible:ring-[var(--amp-semantic-border-focus)]',
+                    )}
+                  >
+                    {action.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </footer>
+        )}
+      </div>
+    );
+  },
+);
+
+VariantCard.displayName = 'VariantCard';

--- a/packages/ui/src/components/VariantCard/index.ts
+++ b/packages/ui/src/components/VariantCard/index.ts
@@ -1,0 +1,7 @@
+export { VariantCard } from './VariantCard';
+export type {
+  VariantCardProps,
+  VariantCardState,
+  VariantCardAction,
+  VariantCardScoreVariant,
+} from './VariantCard';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -532,3 +532,45 @@ export type { FieldErrorProps } from './components/FieldError';
 // FormSection
 export { FormSection } from './components/FormSection';
 export type { FormSectionProps } from './components/FormSection';
+
+// ─── Studio v2 primitives (Wave 2) ───────────────────────────────────
+// Foundational primitives composing the new Magic Studio v2 layout —
+// brief strip header, generation-history rail, council critique rail,
+// and the variant card with its state machine. See pixel-agent for the
+// Studio v2 product spec.
+
+// BriefStrip
+export { BriefStrip } from './components/BriefStrip';
+export type {
+  BriefStripProps,
+  BriefChipItem,
+  BriefChipKind,
+} from './components/BriefStrip';
+
+// HistoryStrip
+export { HistoryStrip } from './components/HistoryStrip';
+export type {
+  HistoryStripProps,
+  GenerationItem,
+  VariantThumb,
+  VariantThumbStatus,
+} from './components/HistoryStrip';
+
+// CouncilRail
+export { CouncilRail, CouncilCard, CouncilSummary } from './components/CouncilRail';
+export type {
+  CouncilRailProps,
+  CouncilCardProps,
+  CouncilSummaryProps,
+  AgentVerdict,
+  CouncilVerdict,
+} from './components/CouncilRail';
+
+// VariantCard
+export { VariantCard } from './components/VariantCard';
+export type {
+  VariantCardProps,
+  VariantCardState,
+  VariantCardAction,
+  VariantCardScoreVariant,
+} from './components/VariantCard';


### PR DESCRIPTION
## Summary

Adds the 4 foundational primitives composing the new **Magic Studio v2** layout in `@amplify-ai/ui`. These were a hard mandate — Studio v2 cannot be built until these primitives exist in the design system.

All four are status `beta`, since `2.8.0`, and follow the existing repo conventions (token-only colors, Tailwind classes, `cn` util, scoped keyframes via id-guarded `useInjectedKeyframes` pattern matching `Marquee`).

### Components

| Component | What | Sub-pieces | Footprint |
|---|---|---|---|
| `BriefStrip` | Horizontal chip strip representing the user brief | Composes existing `Chip`-style tokens; inline NL parser on Enter | 7 chip kinds + locked + Expand affordance |
| `HistoryStrip` | Horizontal timeline of generation cycles | `GenerationChip` (internal), 5 thumb statuses (ready/generating/error/locked/win) with branch arrows | shimmer on `generating`; current-gen accent border |
| `CouncilRail` | Per-agent verdict rail | `CouncilCard` + `CouncilSummary` exported | summary gradient, `disagreementsOnly` collapse, ⌘/ ask affordance |
| `VariantCard` | Canvas variant primitive with state machine | Header + body (state-driven) + footer | states: empty/generating/ready/error; shimmer + pulse keyframes scoped to component |

### Quality bar

- **TypeScript strict**: no `any`; all prop types exported from `src/index.ts`.
- **Token-only colors**: every color reads from `var(--amp-semantic-*)`; **zero hardcoded hex** in component sources (verified by grep).
- **Storybook**: 5+ stories per component, namespaced under `Studio v2/<Name>` so they segregate cleanly from the existing waves.
- **Vitest**: 54 new tests; full workspace 174 / 174 green.
- **A11y**: each component has explicit `role` + `aria-label` regions, keyboard interaction (Enter/Space) tested, `prefers-reduced-motion` honoured for shimmer/pulse, error states use `role="alert"`, generating states use `role="status"` + `aria-live="polite"`.
- **Contracts**: 109 contracts emit (was 105); each new component surfaces with `lifecycle.status=beta` and `notes` describing the Wave-2 / Studio-v2 origin.

### Files

```
packages/ui/src/components/
  BriefStrip/{BriefStrip.tsx, BriefStrip.test.tsx, BriefStrip.stories.tsx, index.ts}
  HistoryStrip/{HistoryStrip.tsx, HistoryStrip.test.tsx, HistoryStrip.stories.tsx, index.ts}
  CouncilRail/{CouncilRail.tsx, CouncilRail.test.tsx, CouncilRail.stories.tsx, index.ts}
  VariantCard/{VariantCard.tsx, VariantCard.test.tsx, VariantCard.stories.tsx, index.ts}
packages/ui/src/index.ts          (additive — Studio v2 section appended)
packages/ui/component-status.json (4 new beta entries; nothing modified)
```

### Pre-commit gates (run locally in worktree)

| Gate | Result |
|---|---|
| `npm run test` (workspace) | 174 / 174 passed (26 files) |
| `npm run build -w packages/ui` | tsup ESM + DTS clean; contracts manifest green |
| `npm run validate` (root) | 0 errors / 0 warnings |
| `npm run lint -w packages/ui` | **pre-existing failure** — eslint v9 has no `eslint.config.*` in repo. Confirmed broken on `main` HEAD too; not introduced here. |

### Notes for reviewers

- **`onSelect` rename**: the existing `HTMLAttributes<HTMLDivElement>['onSelect']` clashes with `HistoryStripProps.onSelect`, so the prop is `Omit<..., 'onSelect'>`'d in the public type. Same pattern other components in the repo use. No behavioural impact.
- **No jest-axe**: the repo currently doesn't depend on `jest-axe` and no other component uses it. I followed the existing convention (explicit role/aria-label assertions in vitest) rather than introduce a new dev dep — happy to add `jest-axe` in a follow-up PR if the team wants to standardise on it.
- **Lock glyph and Expand glyph**: BriefStrip uses HTML entities (`&#128274;` 🔒, `&#10530;` ⤢) so the chips render without an icon dep. CouncilRail uses `&#8984;/` for the ⌘/ affordance.
- **Scoped keyframes**: `HistoryStrip` and `VariantCard` each inject their own keyframes once per page via id-guarded `<style>` (matches `Marquee`'s pattern). `prefers-reduced-motion` disables the animation in both.
- **Subcomponents**: `CouncilCard` and `CouncilSummary` are exported alongside `CouncilRail` so call sites can compose custom layouts; the rail itself is the recommended entry point.

### Test plan

- [ ] `npm install && npm run build -w packages/ui` builds clean
- [ ] `npm run test -w packages/ui` shows 174 / 174 passing
- [ ] `npm run storybook` shows the 4 new stories under "Studio v2"
- [ ] Storybook a11y addon shows zero violations on all 4 stories
- [ ] Token sync (Pixel) picks up new components on next cycle (no manual action expected — driven by `dist/contracts.json`)

Refs: `pixel-agent` Studio v2 product spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)