### PR TITLE
feat(tokens-studio): new @amplify-ai/tokens-studio package (1.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the public packages of `amplify-design-system`.
 
+## Unreleased
+
+### Added (new package — `@amplify-ai/tokens-studio@1.0.0`)
+
+Studio-specific tokens package — used only by `studio.amplify.club`. Inherits primitives from tokens-foundation; layers Studio cockpit semantics on top. Sibling to `tokens-brand` / `tokens-creator` / `tokens-atmosphere`.
+
+- **16 lifted variables** sourced verbatim from the Phase-0 token audit (`magic-studio/docs/audits/phase-0-tokens.md`):
+  - 5 chrome colour semantics — `--amp-studio-theme-color-{bg,fg,muted,border,accent}` — back the existing `--studio-*` consumer aliases.
+  - 4 layout dimensions — `--amp-studio-theme-layout-{toolbar-h,drawer-h,drawer-h-open,pane-left-w}` — back `--studio-toolbar-h` etc. (intentional raw `px` per `magic-studio/CLAUDE.md` Rule 2).
+  - 7 Mirror / Map-mode voice colours — `--amp-studio-theme-map-voice-{pixel,aria,heimdall,atlas,sentinel,penny,zara}` — back `--mirror-voice-*`.
+- **6-entry status scale** — `--amp-studio-status-{success,warning,error}` plus `-bg` variants — replaces the 10 raw hex literals (`#10b981`, `#f59e0b`, `#d4524d`, `#b45309`) called out as `❌` in the Phase-0 audit's status-indicator cluster.
+- Light + dark themes; Studio is dark-default but both modes are emitted.
+- Five build outputs (`variables.css`, `variables.scss`, `tokens.json`, `tokens.js`, `tailwind.css`) via the shared `scripts/build-tokens.js studio` entrypoint.
+- This PR is release-prep only — package is **not** published to npm. Phase D in `magic-studio` will swap the in-repo `:root { --studio-* / --mirror-* }` definitions for an `@import "@amplify-ai/tokens-studio/css"` plus a small consumer-alias block (~16 lines) once this package is on the registry.
+- `scripts/validate-tokens.js` now includes `tokens-studio` in cross-package reference-integrity checks; `scripts/build-tokens.js` accepts `studio` as a valid entrypoint.
+
+Pure additive — no breaking change to any existing package.
+
 ## 2.10.0 — 2026-05-05
 
 ### Added (additive — `@amplify-ai/ui`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,10 @@
       "resolved": "packages/tokens-foundation",
       "link": true
     },
+    "node_modules/@amplify-ai/tokens-studio": {
+      "resolved": "packages/tokens-studio",
+      "link": true
+    },
     "node_modules/@amplify-ai/ui": {
       "resolved": "packages/ui",
       "link": true
@@ -10893,9 +10897,19 @@
         "@amplify-ai/tokens-foundation": "^2.1.0"
       }
     },
+    "packages/tokens-studio": {
+      "name": "@amplify-ai/tokens-studio",
+      "version": "1.0.0",
+      "dependencies": {
+        "@amplify-ai/tokens-foundation": "^2.1.0"
+      },
+      "devDependencies": {
+        "style-dictionary": "^4.3.0"
+      }
+    },
     "packages/ui": {
       "name": "@amplify-ai/ui",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "dependencies": {
         "clsx": "^2.1.0",
         "tailwind-merge": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:brand": "npm run build -w packages/tokens-brand",
     "build:creator": "npm run build -w packages/tokens-creator",
     "build:atmosphere": "npm run build -w packages/tokens-atmosphere",
+    "build:studio": "npm run build -w packages/tokens-studio",
     "lint": "npm run lint --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
     "clean": "rm -rf packages/*/dist",

--- a/packages/tokens-studio/README.md
+++ b/packages/tokens-studio/README.md
@@ -1,0 +1,59 @@
+# @amplify-ai/tokens-studio
+
+Studio-specific design tokens — used only by `studio.amplify.club`. Inherits primitives from tokens-foundation; layers Studio cockpit semantics on top.
+
+## What's in here
+
+- **Cockpit chrome** (`--amp-studio-theme-color-{bg,fg,muted,border,accent}`) — the 5 surface/text/border/accent semantics that the `--studio-*` consumer aliases resolve to.
+- **Layout dimensions** (`--amp-studio-theme-layout-{toolbar-h,drawer-h,drawer-h-open,pane-left-w}`) — the 4 chrome heights/widths that are intentional raw `px` per `magic-studio/CLAUDE.md` Rule 2.
+- **Mirror / Map-mode voices** (`--amp-studio-theme-map-voice-{pixel,aria,heimdall,atlas,sentinel,penny,zara}`) — per-agent voice colours surfaced in the Council rail.
+- **Status scale** (`--amp-studio-status-{success,warning,error}` + `-bg` variants) — replaces the 10 raw hex literals (`#10b981`, `#f59e0b`, `#d4524d`, …) called out in the Phase-0 audit.
+
+## Usage
+
+```css
+/* magic-studio/src/app/globals.css */
+@import "@amplify-ai/tokens-studio/css";
+
+:root {
+  /* Phase-D consumer aliases — keep byte-identical to avoid touching ~282 use sites. */
+  --studio-bg:             var(--amp-studio-theme-color-bg);
+  --studio-fg:             var(--amp-studio-theme-color-fg);
+  --studio-muted:          var(--amp-studio-theme-color-muted);
+  --studio-border:         var(--amp-studio-theme-color-border);
+  --studio-accent:         var(--amp-studio-theme-color-accent);
+  --studio-toolbar-h:      var(--amp-studio-theme-layout-toolbar-h);
+  --studio-drawer-h:       var(--amp-studio-theme-layout-drawer-h);
+  --studio-drawer-h-open:  var(--amp-studio-theme-layout-drawer-h-open);
+  --studio-pane-left-w:    var(--amp-studio-theme-layout-pane-left-w);
+
+  --mirror-voice-pixel:    var(--amp-studio-theme-map-voice-pixel);
+  --mirror-voice-aria:     var(--amp-studio-theme-map-voice-aria);
+  --mirror-voice-heimdall: var(--amp-studio-theme-map-voice-heimdall);
+  --mirror-voice-atlas:    var(--amp-studio-theme-map-voice-atlas);
+  --mirror-voice-sentinel: var(--amp-studio-theme-map-voice-sentinel);
+  --mirror-voice-penny:    var(--amp-studio-theme-map-voice-penny);
+  --mirror-voice-zara:     var(--amp-studio-theme-map-voice-zara);
+}
+```
+
+Status badges then reference `var(--amp-studio-status-success)` etc. directly — no consumer alias needed because they're new (replacing raw hex).
+
+## Outputs
+
+`build.js` delegates to the shared `scripts/build-tokens.js` and emits five artifacts under `dist/`:
+
+| File | Purpose |
+|---|---|
+| `variables.css`  | CSS custom properties for `:root` + `[data-theme="dark"]` overrides |
+| `variables.scss` | Same tokens as SCSS variables |
+| `tokens.json`    | Flat JSON map (machine-consumable) |
+| `tokens.js`      | ES-module exports (camelCase) |
+| `tailwind.css`   | Tailwind v4 `@theme` preset |
+
+## Provenance
+
+The 16 lifted variables were sourced verbatim from the Phase-0 token audit
+(`magic-studio/docs/audits/phase-0-tokens.md`). Phase D in `magic-studio` swaps the in-repo
+`:root { --studio-* / --mirror-* }` definitions for an `@import "@amplify-ai/tokens-studio/css"`
+plus the consumer-alias block above.

--- a/packages/tokens-studio/build.js
+++ b/packages/tokens-studio/build.js
@@ -1,0 +1,7 @@
+// Delegates to shared build script
+import { execSync } from 'child_process';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '../..');
+execSync(`node ${join(root, 'scripts/build-tokens.js')} studio`, { stdio: 'inherit' });

--- a/packages/tokens-studio/package.json
+++ b/packages/tokens-studio/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@amplify-ai/tokens-studio",
+  "version": "1.0.0",
+  "description": "Amplify Magic Studio design tokens — Studio cockpit chrome, mirror/Map-mode voices, status scale; consumed only by studio.amplify.club",
+  "main": "dist/tokens.js",
+  "exports": {
+    "./css": "./dist/variables.css",
+    "./scss": "./dist/variables.scss",
+    "./tailwind": "./dist/tailwind.css",
+    "./json": "./dist/tokens.json",
+    "./js": "./dist/tokens.js",
+    ".": "./dist/tokens.js"
+  },
+  "scripts": {
+    "build": "node build.js"
+  },
+  "dependencies": {
+    "@amplify-ai/tokens-foundation": "^2.1.0"
+  },
+  "devDependencies": {
+    "style-dictionary": "^4.3.0"
+  },
+  "files": [
+    "dist/",
+    "tokens/"
+  ]
+}

--- a/packages/tokens-studio/tokens/theme-dark.json
+++ b/packages/tokens-studio/tokens/theme-dark.json
@@ -1,0 +1,41 @@
+{
+  "theme": {
+    "$description": "Magic Studio — Dark theme (cockpit chrome + Mirror voices). Studio is dark-default; this is the canonical mode.",
+    "product": "studio",
+    "mode": "dark",
+    "color": {
+      "$type": "color",
+      "bg":             { "$value": "{semantic.bg-surface}",   "$description": "Studio surface background (dark)" },
+      "fg":             { "$value": "{semantic.text-primary}", "$description": "Studio default foreground (dark)" },
+      "muted":          { "$value": "{semantic.text-secondary}", "$description": "Studio muted text (dark)" },
+      "border":         { "$value": "{semantic.border-default}", "$description": "Studio default border (dark)" },
+      "accent":         { "$value": "{semantic.accent}",       "$description": "Studio action primary (dark)" }
+    },
+    "layout": {
+      "$type": "dimension",
+      "toolbar-h":      { "$value": "56px" },
+      "drawer-h":       { "$value": "48px" },
+      "drawer-h-open":  { "$value": "240px" },
+      "pane-left-w":    { "$value": "30%" }
+    },
+    "map": {
+      "$type": "color",
+      "voice-pixel":    { "$value": "{color.violet.500}", "$description": "Pixel agent voice (dark — softer violet)" },
+      "voice-aria":     { "$value": "{color.amber.500}" },
+      "voice-heimdall": { "$value": "{color.blue.500}" },
+      "voice-atlas":    { "$value": "{color.stone.300}",  "$description": "Atlas — flipped lighter on dark for legibility" },
+      "voice-sentinel": { "$value": "{color.red.500}" },
+      "voice-penny":    { "$value": "{color.green.500}" },
+      "voice-zara":     { "$value": "{color.rose.500}" }
+    }
+  },
+  "status": {
+    "$type": "color",
+    "success":         { "$value": "{semantic.status-success}" },
+    "success-bg":      { "$value": "{semantic.status-success-bg}" },
+    "warning":         { "$value": "{semantic.status-warning}" },
+    "warning-bg":      { "$value": "{semantic.status-warning-bg}" },
+    "error":           { "$value": "{semantic.status-error}" },
+    "error-bg":        { "$value": "{semantic.status-error-bg}" }
+  }
+}

--- a/packages/tokens-studio/tokens/theme-light.json
+++ b/packages/tokens-studio/tokens/theme-light.json
@@ -1,0 +1,43 @@
+{
+  "theme": {
+    "$description": "Magic Studio — Light theme (cockpit chrome + Mirror voices). Inherits primitives from tokens-foundation; layers Studio cockpit semantics on top.",
+    "product": "studio",
+    "mode": "light",
+    "color": {
+      "$type": "color",
+      "bg":             { "$value": "{semantic.bg-surface}",   "$description": "Studio surface background — paired with --studio-bg consumer alias" },
+      "fg":             { "$value": "{semantic.text-primary}", "$description": "Studio default foreground — paired with --studio-fg" },
+      "muted":          { "$value": "{semantic.text-secondary}", "$description": "Studio muted text — paired with --studio-muted" },
+      "border":         { "$value": "{semantic.border-default}", "$description": "Studio default border — paired with --studio-border" },
+      "accent":         { "$value": "{semantic.accent}",       "$description": "Studio action primary — paired with --studio-accent" }
+    },
+    "layout": {
+      "$type": "dimension",
+      "toolbar-h":      { "$value": "56px",  "$description": "Top toolbar chrome height — paired with --studio-toolbar-h" },
+      "drawer-h":       { "$value": "48px",  "$description": "Bottom drawer collapsed height — paired with --studio-drawer-h" },
+      "drawer-h-open":  { "$value": "240px", "$description": "Bottom drawer expanded height — paired with --studio-drawer-h-open" },
+      "pane-left-w":    { "$value": "30%",   "$description": "Left brief pane width — paired with --studio-pane-left-w" }
+    },
+    "map": {
+      "$type": "color",
+      "$description": "Mirror / Map-mode voice colours — one per agent voice in the Council rail",
+      "voice-pixel":    { "$value": "{color.violet.600}", "$description": "Pixel agent voice — paired with --mirror-voice-pixel" },
+      "voice-aria":     { "$value": "{color.amber.500}",  "$description": "Aria agent voice — paired with --mirror-voice-aria" },
+      "voice-heimdall": { "$value": "{color.blue.500}",   "$description": "Heimdall agent voice — paired with --mirror-voice-heimdall" },
+      "voice-atlas":    { "$value": "{color.stone.100}",  "$description": "Atlas agent voice — paired with --mirror-voice-atlas" },
+      "voice-sentinel": { "$value": "{color.red.500}",    "$description": "Sentinel agent voice — paired with --mirror-voice-sentinel" },
+      "voice-penny":    { "$value": "{color.green.500}",  "$description": "Penny agent voice — paired with --mirror-voice-penny" },
+      "voice-zara":     { "$value": "{color.rose.500}",   "$description": "Zara agent voice — paired with --mirror-voice-zara" }
+    }
+  },
+  "status": {
+    "$type": "color",
+    "$description": "Studio status indicator scale — replaces the 10 raw hex literals in magic-studio/src/app/globals.css (status badges, off-system, promote-link, flow-status-pill).",
+    "success":         { "$value": "{semantic.status-success}",    "$description": "Live / positive / 'real' status indicator (was #10b981)" },
+    "success-bg":      { "$value": "{semantic.status-success-bg}", "$description": "Success status surface tint" },
+    "warning":         { "$value": "{semantic.status-warning}",    "$description": "Preview / off-system / pending status (was #f59e0b)" },
+    "warning-bg":      { "$value": "{semantic.status-warning-bg}", "$description": "Warning status surface tint" },
+    "error":           { "$value": "{semantic.status-error}",      "$description": "Flow error / failure status (was #d4524d)" },
+    "error-bg":        { "$value": "{semantic.status-error-bg}",   "$description": "Error status surface tint" }
+  }
+}

--- a/scripts/build-tokens.js
+++ b/scripts/build-tokens.js
@@ -23,7 +23,7 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
 
-const VALID_PACKAGES = ['foundation', 'brand', 'atmosphere', 'creator'];
+const VALID_PACKAGES = ['foundation', 'brand', 'atmosphere', 'creator', 'studio'];
 const pkg = process.argv[2];
 if (!pkg || !VALID_PACKAGES.includes(pkg)) {
   console.error(`Usage: node scripts/build-tokens.js <${VALID_PACKAGES.join('|')}>`);

--- a/scripts/validate-tokens.js
+++ b/scripts/validate-tokens.js
@@ -91,7 +91,7 @@ function findBrokenRefs(obj, root, prefix = '') {
 // ── Validation ──
 console.log('\n=== Token Package Validation (W3C DTCG) ===\n');
 
-const packages = ['tokens-foundation', 'tokens-brand', 'tokens-creator', 'tokens-atmosphere'];
+const packages = ['tokens-foundation', 'tokens-brand', 'tokens-creator', 'tokens-atmosphere', 'tokens-studio'];
 for (const pkg of packages) {
   const tokensDir = join(PACKAGES_DIR, pkg, 'tokens');
   if (!existsSync(tokensDir)) {
@@ -165,7 +165,7 @@ for (const theme of ['light', 'dark']) {
   }
 
   // Check each product's theme file against foundation
-  for (const pkg of ['tokens-brand', 'tokens-atmosphere', 'tokens-creator']) {
+  for (const pkg of ['tokens-brand', 'tokens-atmosphere', 'tokens-creator', 'tokens-studio']) {
     const themeFile = join(PACKAGES_DIR, pkg, 'tokens', `theme-${theme}.json`);
     if (!existsSync(themeFile)) continue;
 


### PR DESCRIPTION
## Summary

Phase 0 of the Magic Studio token migration. Adds `@amplify-ai/tokens-studio@1.0.0` — a sibling to `tokens-brand` / `tokens-creator` / `tokens-atmosphere` that holds Studio-specific tokens.

- **16 lifted variables** sourced verbatim from the Phase-0 token audit (`magic-studio/docs/audits/phase-0-tokens.md`):
  - 5 chrome colour semantics (`--amp-studio-theme-color-{bg,fg,muted,border,accent}`)
  - 4 layout dimensions (`--amp-studio-theme-layout-{toolbar-h,drawer-h,drawer-h-open,pane-left-w}`)
  - 7 Mirror / Map-mode voice colours (`--amp-studio-theme-map-voice-{pixel,aria,heimdall,atlas,sentinel,penny,zara}`)
- **6-entry status scale** (`--amp-studio-status-{success,warning,error}` + `-bg` variants) — replaces the 10 raw hex literals (`#10b981`, `#f59e0b`, `#d4524d`, `#b45309`) called out as ❌ in the Phase-0 audit's status-indicator cluster.
- Light + dark themes; Studio is dark-default but both modes are emitted.

## What's in scope

- `packages/tokens-studio/{package.json,build.js,README.md,tokens/theme-light.json,tokens/theme-dark.json}` — new package, mirrors `packages/tokens-brand/` structure exactly.
- `scripts/build-tokens.js` — `studio` added to `VALID_PACKAGES`.
- `scripts/validate-tokens.js` — `tokens-studio` added to package list + reference-integrity loop.
- `package.json` — new `build:studio` script. Workspaces glob (`packages/*`) already auto-picks up the new package; no glob change needed.
- `CHANGELOG.md` — Unreleased entry.

## What's NOT in scope (per parent task spec)

- `magic-studio/*` — Phase D codemod handles consumer-side migration to `@import "@amplify-ai/tokens-studio/css"` plus a ~16-line consumer-alias shim (so all ~282 `var(--studio-*)` and `var(--mirror-*)` use sites stay byte-identical).
- `packages/ui/*` — sibling sub-agent's scope (Phase B2).
- npm publish — release-prep only.
- Other tokens packages (brand / creator / atmosphere) — untouched.

## Test plan

- [x] `npm install` from root — workspace wired up cleanly.
- [x] `npm run build:studio` — emits 5 artifacts to `packages/tokens-studio/dist/`.
- [x] `npm run build` — full monorepo build green (foundation, brand, atmosphere, creator, marketing, **studio**, ui).
- [x] `npm run validate` — all reference-integrity checks pass for `tokens-studio` light + dark.
- [x] `npm run test` — 202/202 passing across 28 test files.
- [ ] Eyeball `packages/tokens-studio/dist/variables.css` after build to confirm all 16 + 6 status vars present in `:root` and `[data-theme="dark"]` blocks (verified locally — sample below):

```
--amp-studio-theme-color-bg: #FFFFFF;
--amp-studio-theme-color-fg: #1C1917;
--amp-studio-theme-layout-toolbar-h: 56px;
--amp-studio-theme-map-voice-pixel: #7C3AED;
--amp-studio-status-success: #059669;
--amp-studio-status-success-bg: rgba(5, 150, 105, 0.08);
```

Note: pre-existing `npm run lint` failure (ESLint v9 config-format break in `packages/ui/`) is unrelated to this PR — verified by stashing changes and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)