### PR TITLE
feat(ui): StatusBar + PhaseRibbon + SegmentedControl primitives (2.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the public packages of `amplify-design-system`.
 
+## 2.11.0 — 2026-05-07
+
+### Added (additive — `@amplify-ai/ui`)
+
+Studio v2 Wave 3 — three more visual primitives lifted from the Studio
+Phase-0 audit. All three ship as `lifecycle.status=beta`,
+`since=2.11.0`. Pure additive — no breaking changes.
+
+- **`StatusBar`** — slim ~24px horizontal status strip. Renders as a
+  `<dl>` with `<dt>` / `<dd>` pairs for screen-reader semantics; one
+  cell per item with `default` / `mono` variants (mono = monospace
+  value for SHAs, versions). Supports `truncate` + `maxWidth` per
+  item, and `align="between"` to push the last item right. Density-
+  aware vertical padding.
+- **`PhaseRibbon`** — numbered phase indicator (1 → 2 → 3 → …) above a
+  workflow. `pending` / `active` / `done` / `error` per-phase status
+  drives circle colour (status-success / accent / status-error /
+  border tokens) and connector tint. Active phase flagged via
+  `aria-current="step"`; `done` renders a check glyph; status auto-
+  derives from `current` when not given explicitly.
+- **`SegmentedControl`** — generalised two-or-more-button segmented
+  control. Pill wrapper with a single sliding accent highlight,
+  W3C-pattern `role="radiogroup"` + arrow / Home / End / Enter / Space
+  keyboard navigation, roving tabindex, and `motion-reduce`-honoured
+  slide animation. `sm` (~28px) / `md` (~36px) sizes; density=compact
+  forces `sm`.
+
+Unblocks the Studio cockpit footer migration and consolidates the
+ad-hoc Grid|Map toggle into a reusable primitive.
+
 ## 2.10.0 — 2026-05-05
 
 ### Added (additive — `@amplify-ai/ui`)

--- a/packages/ui/component-status.json
+++ b/packages/ui/component-status.json
@@ -112,6 +112,9 @@
     "CouncilRail": { "status": "beta", "since": "2.9.0", "notes": "Studio v2 Wave 2 — right-rail per-agent verdicts; supports disagreementsOnly collapse + ask-the-council affordance." },
     "VariantCard": { "status": "beta", "since": "2.9.0", "notes": "Studio v2 Wave 2 — canvas variant card with empty/generating/ready/error state machine; shimmer + retry built-in." },
     "MapNode": { "status": "beta", "since": "2.10.0", "notes": "Studio v2 Map mode — variant-graph node primitive with live/ready/generating/error/locked/focus state machine; absolute positioning, lock badge, error corner, shimmer." },
-    "MapEdge": { "status": "beta", "since": "2.10.0", "notes": "Studio v2 Map mode — SVG <path>-only edge primitive (consumer wraps in <svg>); cubic-bezier connector with active/dashed states." }
+    "MapEdge": { "status": "beta", "since": "2.10.0", "notes": "Studio v2 Map mode — SVG <path>-only edge primitive (consumer wraps in <svg>); cubic-bezier connector with active/dashed states." },
+    "PhaseRibbon": { "status": "beta", "since": "2.11.0", "notes": "Studio v2 Wave 3 — numbered phase indicator (1 → 2 → 3 → 4) above a workflow; pending/active/done/error states; aria-current=step on the active phase." },
+    "SegmentedControl": { "status": "beta", "since": "2.11.0", "notes": "Studio v2 Wave 3 — generalised two-or-more-button segmented control with sliding accent highlight; W3C radiogroup keyboard pattern; honours prefers-reduced-motion and density." },
+    "StatusBar": { "status": "beta", "since": "2.11.0", "notes": "Studio v2 Wave 3 — slim ~24px horizontal status strip; dl/dt/dd semantics; mono variant for SHAs/versions; align=between for left/right split footers." }
   }
 }

--- a/packages/ui/dist/contracts.json
+++ b/packages/ui/dist/contracts.json
@@ -1,11 +1,11 @@
 {
-  "generatedAt": "2026-05-05T06:49:53.811Z",
+  "generatedAt": "2026-05-07T09:08:09.991Z",
   "tsVersion": "5.9.3",
-  "componentCount": 111,
+  "componentCount": 114,
   "statusBreakdown": {
     "stable": 46,
     "alpha": 15,
-    "beta": 50
+    "beta": 53
   },
   "components": [
     {
@@ -1137,6 +1137,21 @@
       }
     },
     {
+      "name": "PhaseRibbon",
+      "contract": "contracts/PhaseRibbon.json",
+      "filePath": "packages/ui/src/components/PhaseRibbon/PhaseRibbon.tsx",
+      "kind": "forwardRef",
+      "variants": null,
+      "sizes": null,
+      "propCount": 3,
+      "subcomponents": [],
+      "lifecycle": {
+        "status": "beta",
+        "since": "2.11.0",
+        "notes": "Studio v2 Wave 3 — numbered phase indicator (1 → 2 → 3 → 4) above a workflow; pending/active/done/error states; aria-current=step on the active phase."
+      }
+    },
+    {
       "name": "PieChart",
       "contract": "contracts/PieChart.json",
       "filePath": "packages/ui/src/components/PieChart/PieChart.tsx",
@@ -1379,6 +1394,21 @@
       }
     },
     {
+      "name": "SegmentedControl",
+      "contract": "contracts/SegmentedControl.json",
+      "filePath": "packages/ui/src/components/SegmentedControl/SegmentedControl.tsx",
+      "kind": "function",
+      "variants": null,
+      "sizes": null,
+      "propCount": 7,
+      "subcomponents": [],
+      "lifecycle": {
+        "status": "beta",
+        "since": "2.11.0",
+        "notes": "Studio v2 Wave 3 — generalised two-or-more-button segmented control with sliding accent highlight; W3C radiogroup keyboard pattern; honours prefers-reduced-motion and density."
+      }
+    },
+    {
       "name": "Select",
       "contract": "contracts/Select.json",
       "filePath": "packages/ui/src/components/Select/Select.tsx",
@@ -1510,6 +1540,21 @@
       "lifecycle": {
         "status": "beta",
         "since": "2.1.0"
+      }
+    },
+    {
+      "name": "StatusBar",
+      "contract": "contracts/StatusBar.json",
+      "filePath": "packages/ui/src/components/StatusBar/StatusBar.tsx",
+      "kind": "forwardRef",
+      "variants": null,
+      "sizes": null,
+      "propCount": 3,
+      "subcomponents": [],
+      "lifecycle": {
+        "status": "beta",
+        "since": "2.11.0",
+        "notes": "Studio v2 Wave 3 — slim ~24px horizontal status strip; dl/dt/dd semantics; mono variant for SHAs/versions; align=between for left/right split footers."
       }
     },
     {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplify-ai/ui",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Shared UI components for Amplify products \u2014 Brand, Creator, and Atmosphere",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/ui/src/components/PhaseRibbon/PhaseRibbon.stories.tsx
+++ b/packages/ui/src/components/PhaseRibbon/PhaseRibbon.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { PhaseRibbon, type PhaseItem } from './PhaseRibbon';
+
+const meta = {
+  title: 'Studio v2/PhaseRibbon',
+  component: PhaseRibbon,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    status: { type: 'beta' },
+  },
+} satisfies Meta<typeof PhaseRibbon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const flow: PhaseItem[] = [
+  { id: 'discover', label: 'Discover' },
+  { id: 'design', label: 'Design' },
+  { id: 'build', label: 'Build' },
+  { id: 'ship', label: 'Ship' },
+];
+
+export const Default: Story = {
+  args: {
+    phases: flow,
+    current: 'design',
+  },
+};
+
+export const FirstPhase: Story = {
+  args: {
+    phases: flow,
+    current: 'discover',
+  },
+};
+
+export const Mid: Story = {
+  args: {
+    phases: flow,
+    current: 'build',
+  },
+};
+
+export const LastPhase: Story = {
+  args: {
+    phases: flow,
+    current: 'ship',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    phases: [
+      { id: 'discover', label: 'Discover', status: 'done' },
+      { id: 'design', label: 'Design', status: 'error', hint: 'Validation failed' },
+      { id: 'build', label: 'Build', status: 'pending' },
+      { id: 'ship', label: 'Ship', status: 'pending' },
+    ],
+    current: 'design',
+  },
+};
+
+export const WithHints: Story = {
+  args: {
+    phases: [
+      { id: 'discover', label: 'Discover', hint: 'Gather context and intent' },
+      { id: 'design', label: 'Design', hint: 'Sketch and pick a direction' },
+      { id: 'build', label: 'Build', hint: 'Compose components and wire data' },
+      { id: 'ship', label: 'Ship', hint: 'Push to production' },
+    ],
+    current: 'design',
+  },
+};
+
+export const NumericIds: Story = {
+  args: {
+    phases: [
+      { id: 1, label: 'Step One' },
+      { id: 2, label: 'Step Two' },
+      { id: 3, label: 'Step Three' },
+    ],
+    current: 2,
+  },
+};
+
+export const SinglePhase: Story = {
+  args: {
+    phases: [{ id: 'only', label: 'Only step' }],
+    current: 'only',
+  },
+};
+
+export const Long: Story = {
+  args: {
+    phases: [
+      { id: 'a', label: 'Brief' },
+      { id: 'b', label: 'Audience' },
+      { id: 'c', label: 'Scripts' },
+      { id: 'd', label: 'Variants' },
+      { id: 'e', label: 'Council' },
+      { id: 'f', label: 'Pick' },
+      { id: 'g', label: 'Ship' },
+    ],
+    current: 'd',
+  },
+};

--- a/packages/ui/src/components/PhaseRibbon/PhaseRibbon.test.tsx
+++ b/packages/ui/src/components/PhaseRibbon/PhaseRibbon.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { PhaseRibbon, type PhaseItem } from './PhaseRibbon';
+
+afterEach(cleanup);
+
+const phases: PhaseItem[] = [
+  { id: 'discover', label: 'Discover' },
+  { id: 'design', label: 'Design' },
+  { id: 'build', label: 'Build' },
+  { id: 'ship', label: 'Ship' },
+];
+
+describe('PhaseRibbon', () => {
+  it('renders a list with one listitem per phase', () => {
+    render(<PhaseRibbon phases={phases} current="design" />);
+    const list = screen.getByRole('list', { name: 'Workflow phases' });
+    expect(list).toBeDefined();
+    expect(screen.getAllByRole('listitem')).toHaveLength(phases.length);
+  });
+
+  it('renders the phase labels', () => {
+    render(<PhaseRibbon phases={phases} current="design" />);
+    for (const p of phases) {
+      expect(screen.getByText(p.label)).toBeDefined();
+    }
+  });
+
+  it('derives status from current — phases before current are done', () => {
+    render(<PhaseRibbon phases={phases} current="build" />);
+    expect(
+      screen
+        .getByTestId('phase-ribbon-item-discover')
+        .getAttribute('data-phase-status'),
+    ).toBe('done');
+    expect(
+      screen
+        .getByTestId('phase-ribbon-item-design')
+        .getAttribute('data-phase-status'),
+    ).toBe('done');
+  });
+
+  it('derives status — the matching phase is active', () => {
+    render(<PhaseRibbon phases={phases} current="build" />);
+    expect(
+      screen
+        .getByTestId('phase-ribbon-item-build')
+        .getAttribute('data-phase-status'),
+    ).toBe('active');
+  });
+
+  it('derives status — phases after current are pending', () => {
+    render(<PhaseRibbon phases={phases} current="design" />);
+    expect(
+      screen
+        .getByTestId('phase-ribbon-item-build')
+        .getAttribute('data-phase-status'),
+    ).toBe('pending');
+    expect(
+      screen
+        .getByTestId('phase-ribbon-item-ship')
+        .getAttribute('data-phase-status'),
+    ).toBe('pending');
+  });
+
+  it('flags the active phase with aria-current="step"', () => {
+    render(<PhaseRibbon phases={phases} current="design" />);
+    const designItem = screen.getByTestId('phase-ribbon-item-design');
+    expect(designItem.getAttribute('aria-current')).toBe('step');
+  });
+
+  it('non-active phases do NOT have aria-current', () => {
+    render(<PhaseRibbon phases={phases} current="design" />);
+    expect(
+      screen
+        .getByTestId('phase-ribbon-item-discover')
+        .getAttribute('aria-current'),
+    ).toBeNull();
+    expect(
+      screen.getByTestId('phase-ribbon-item-build').getAttribute('aria-current'),
+    ).toBeNull();
+  });
+
+  it('done phases render the check glyph instead of the number', () => {
+    render(<PhaseRibbon phases={phases} current="ship" />);
+    const doneCircle = screen.getByTestId('phase-ribbon-circle-design');
+    // Number "2" should NOT appear — replaced by SVG.
+    expect(doneCircle.querySelector('svg')).not.toBeNull();
+    expect(doneCircle.textContent?.trim()).toBe('');
+  });
+
+  it('active phase renders the phase number (not a check)', () => {
+    render(<PhaseRibbon phases={phases} current="design" />);
+    const activeCircle = screen.getByTestId('phase-ribbon-circle-design');
+    expect(activeCircle.textContent?.trim()).toBe('2');
+    expect(activeCircle.querySelector('svg')).toBeNull();
+  });
+
+  it('respects explicit phase.status (overrides derivation)', () => {
+    const withErr: PhaseItem[] = [
+      { id: 'a', label: 'A', status: 'done' },
+      { id: 'b', label: 'B', status: 'error' },
+      { id: 'c', label: 'C', status: 'pending' },
+    ];
+    render(<PhaseRibbon phases={withErr} current="b" />);
+    expect(
+      screen.getByTestId('phase-ribbon-item-b').getAttribute('data-phase-status'),
+    ).toBe('error');
+  });
+
+  it('error status circle has the error background class', () => {
+    const items: PhaseItem[] = [
+      { id: 'x', label: 'X', status: 'error' },
+      { id: 'y', label: 'Y', status: 'pending' },
+    ];
+    render(<PhaseRibbon phases={items} current="x" />);
+    const circle = screen.getByTestId('phase-ribbon-circle-x');
+    expect(circle.className).toContain('bg-[var(--amp-semantic-status-error)]');
+  });
+
+  it('renders a connector between every pair of phases (n-1 connectors)', () => {
+    render(<PhaseRibbon phases={phases} current="design" />);
+    const connectors = screen.getAllByTestId(/^phase-ribbon-connector-/);
+    expect(connectors).toHaveLength(phases.length - 1);
+  });
+
+  it('does NOT render a connector after the last phase', () => {
+    render(<PhaseRibbon phases={phases} current="design" />);
+    expect(screen.queryByTestId('phase-ribbon-connector-ship')).toBeNull();
+  });
+
+  it('uses phase.hint as the circle title attribute', () => {
+    const items: PhaseItem[] = [
+      { id: 'a', label: 'Alpha', hint: 'First step in the journey' },
+      { id: 'b', label: 'Beta' },
+    ];
+    render(<PhaseRibbon phases={items} current="a" />);
+    expect(
+      screen.getByTestId('phase-ribbon-circle-a').getAttribute('title'),
+    ).toBe('First step in the journey');
+  });
+
+  it('aria-label on the circle includes phase number, label, and status', () => {
+    render(<PhaseRibbon phases={phases} current="design" />);
+    const circle = screen.getByTestId('phase-ribbon-circle-design');
+    expect(circle.getAttribute('aria-label')).toBe(
+      'Phase 2: Design (active)',
+    );
+  });
+
+  it('handles current that does not match any phase — all pending', () => {
+    render(<PhaseRibbon phases={phases} current="missing-id" />);
+    for (const p of phases) {
+      expect(
+        screen
+          .getByTestId(`phase-ribbon-item-${p.id}`)
+          .getAttribute('data-phase-status'),
+      ).toBe('pending');
+    }
+  });
+
+  it('does NOT inject hardcoded hex colours into the rendered DOM', () => {
+    const { container } = render(
+      <PhaseRibbon phases={phases} current="design" />,
+    );
+    expect(container.innerHTML).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+  });
+
+  it('renders single-phase ribbon without a connector', () => {
+    render(<PhaseRibbon phases={[{ id: 'only', label: 'Only' }]} current="only" />);
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.queryAllByTestId(/^phase-ribbon-connector-/)).toHaveLength(0);
+  });
+
+  it('honours numeric ids', () => {
+    const numeric: PhaseItem[] = [
+      { id: 1, label: 'One' },
+      { id: 2, label: 'Two' },
+      { id: 3, label: 'Three' },
+    ];
+    render(<PhaseRibbon phases={numeric} current={2} />);
+    expect(
+      screen.getByTestId('phase-ribbon-item-2').getAttribute('data-phase-status'),
+    ).toBe('active');
+  });
+});

--- a/packages/ui/src/components/PhaseRibbon/PhaseRibbon.tsx
+++ b/packages/ui/src/components/PhaseRibbon/PhaseRibbon.tsx
@@ -1,0 +1,232 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+/**
+ * PhaseRibbon — numbered phase indicator above a workflow.
+ *
+ * Renders a horizontal sequence of numbered circles connected by thin
+ * lines (1 → 2 → 3 → …). Each phase has a status (`pending`, `active`,
+ * `done`, `error`) which drives the visual treatment:
+ *
+ * - `done`     — filled accent circle with a check glyph.
+ * - `active`   — filled accent circle with the phase number; ring halo.
+ * - `pending`  — outlined circle with the phase number in muted text.
+ * - `error`    — filled error circle with the phase number.
+ *
+ * The currently-active phase is also flagged via `aria-current="step"`,
+ * and the whole ribbon renders as a `role="list"` for assistive tech.
+ *
+ * If `current` is set but no phase has an explicit status, the
+ * component derives status automatically:
+ *   - phases before `current` → `done`
+ *   - phase matching `current` → `active`
+ *   - phases after `current` → `pending`
+ *
+ * Token-only colours (status-success / status-error / accent / border /
+ * text via the brand-semantic palette). Reduced-motion honoured by
+ * disabling the ring transition when the user prefers reduced motion.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type PhaseStatus = 'pending' | 'active' | 'done' | 'error';
+
+export interface PhaseItem {
+  /** Stable id — used for `current` matching and as a React key. */
+  id: string | number;
+  /** Phase label rendered under (or beside) the circle. */
+  label: string;
+  /** Optional tooltip / hint — surfaced as the circle's `title` attribute. */
+  hint?: string;
+  /**
+   * Explicit status. If omitted, status is derived from the position
+   * relative to `current`.
+   */
+  status?: PhaseStatus;
+}
+
+export interface PhaseRibbonProps extends React.HTMLAttributes<HTMLDivElement> {
+  phases: PhaseItem[];
+  /** Matches `phase.id` of the active phase. */
+  current: string | number;
+  className?: string;
+}
+
+// ─── Status → visual classes ────────────────────────────────────────────────
+
+const circleBase = cn(
+  'inline-flex items-center justify-center shrink-0',
+  'h-7 w-7 rounded-full',
+  'text-[12px] font-semibold leading-none',
+  'transition-shadow duration-150',
+  // honour reduced-motion — kill transitions
+  'motion-reduce:transition-none',
+);
+
+function getCircleClasses(status: PhaseStatus): string {
+  switch (status) {
+    case 'done':
+      return cn(
+        'bg-[var(--amp-semantic-status-success)]',
+        'text-[var(--amp-semantic-text-on-accent,var(--amp-semantic-bg-surface))]',
+        'border border-[var(--amp-semantic-status-success)]',
+      );
+    case 'active':
+      return cn(
+        'bg-[var(--amp-semantic-bg-accent,var(--amp-semantic-accent))]',
+        'text-[var(--amp-semantic-text-on-accent,var(--amp-semantic-bg-surface))]',
+        'border border-[var(--amp-semantic-border-accent,var(--amp-semantic-accent))]',
+        'ring-4 ring-[var(--amp-semantic-bg-accent-subtle)]',
+      );
+    case 'error':
+      return cn(
+        'bg-[var(--amp-semantic-status-error)]',
+        'text-[var(--amp-semantic-text-on-accent,var(--amp-semantic-bg-surface))]',
+        'border border-[var(--amp-semantic-status-error)]',
+      );
+    case 'pending':
+    default:
+      return cn(
+        'bg-[var(--amp-semantic-bg-surface)]',
+        'text-[var(--amp-semantic-text-tertiary)]',
+        'border border-[var(--amp-semantic-border-default)]',
+      );
+  }
+}
+
+function getLabelClasses(status: PhaseStatus): string {
+  switch (status) {
+    case 'active':
+      return 'text-[var(--amp-semantic-text-default)] font-semibold';
+    case 'done':
+      return 'text-[var(--amp-semantic-text-secondary)]';
+    case 'error':
+      return 'text-[var(--amp-semantic-status-error)] font-medium';
+    case 'pending':
+    default:
+      return 'text-[var(--amp-semantic-text-tertiary)]';
+  }
+}
+
+function getConnectorClasses(prevStatus: PhaseStatus): string {
+  // Connector takes the colour of the phase to its left — once that's
+  // done/active/error, the line "fills" up to the next circle.
+  if (prevStatus === 'done' || prevStatus === 'active') {
+    return 'bg-[var(--amp-semantic-border-accent,var(--amp-semantic-accent))]';
+  }
+  if (prevStatus === 'error') {
+    return 'bg-[var(--amp-semantic-status-error)]';
+  }
+  return 'bg-[var(--amp-semantic-border-default)]';
+}
+
+// ─── Status derivation ──────────────────────────────────────────────────────
+
+function deriveStatus(
+  phases: PhaseItem[],
+  current: string | number,
+): PhaseStatus[] {
+  const currentIdx = phases.findIndex((p) => p.id === current);
+  return phases.map((phase, idx) => {
+    if (phase.status) return phase.status;
+    if (currentIdx === -1) return 'pending';
+    if (idx < currentIdx) return 'done';
+    if (idx === currentIdx) return 'active';
+    return 'pending';
+  });
+}
+
+// ─── Check glyph ────────────────────────────────────────────────────────────
+
+const CheckGlyph: React.FC = () => (
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={3}
+    className="h-3 w-3"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M5 12l5 5L20 7" />
+  </svg>
+);
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export const PhaseRibbon = React.forwardRef<HTMLDivElement, PhaseRibbonProps>(
+  ({ phases, current, className, ...rest }, ref) => {
+    const statuses = React.useMemo(
+      () => deriveStatus(phases, current),
+      [phases, current],
+    );
+
+    return (
+      <div
+        ref={ref}
+        role="list"
+        aria-label={rest['aria-label'] ?? 'Workflow phases'}
+        className={cn(
+          'flex w-full items-start',
+          'text-[var(--amp-semantic-text-default)]',
+          className,
+        )}
+        {...rest}
+      >
+        {phases.map((phase, idx) => {
+          const status = statuses[idx];
+          const isLast = idx === phases.length - 1;
+          const number = idx + 1;
+          const ariaCurrent = status === 'active' ? 'step' : undefined;
+
+          return (
+            <div
+              key={phase.id}
+              role="listitem"
+              aria-current={ariaCurrent}
+              data-phase-id={phase.id}
+              data-phase-status={status}
+              data-testid={`phase-ribbon-item-${phase.id}`}
+              className={cn(
+                'flex min-w-0 items-start',
+                isLast ? 'shrink-0' : 'flex-1',
+              )}
+            >
+              <div className="flex min-w-0 flex-col items-center gap-1.5">
+                <span
+                  data-testid={`phase-ribbon-circle-${phase.id}`}
+                  className={cn(circleBase, getCircleClasses(status))}
+                  title={phase.hint}
+                  aria-label={`Phase ${number}: ${phase.label} (${status})`}
+                >
+                  {status === 'done' ? <CheckGlyph /> : number}
+                </span>
+                <span
+                  data-testid={`phase-ribbon-label-${phase.id}`}
+                  className={cn(
+                    'max-w-[10rem] truncate text-[12px] leading-tight',
+                    getLabelClasses(status),
+                  )}
+                >
+                  {phase.label}
+                </span>
+              </div>
+
+              {!isLast && (
+                <span
+                  data-testid={`phase-ribbon-connector-${phase.id}`}
+                  aria-hidden="true"
+                  className={cn(
+                    'mx-2 mt-3.5 h-px flex-1',
+                    getConnectorClasses(status),
+                  )}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  },
+);
+
+PhaseRibbon.displayName = 'PhaseRibbon';

--- a/packages/ui/src/components/PhaseRibbon/index.ts
+++ b/packages/ui/src/components/PhaseRibbon/index.ts
@@ -1,0 +1,2 @@
+export { PhaseRibbon } from './PhaseRibbon';
+export type { PhaseRibbonProps, PhaseItem, PhaseStatus } from './PhaseRibbon';

--- a/packages/ui/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/ui/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,0 +1,187 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { SegmentedControl, type SegmentedControlOption } from './SegmentedControl';
+import { DensityProvider } from '../../lib/density';
+
+const meta = {
+  title: 'Studio v2/SegmentedControl',
+  component: SegmentedControl,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    status: { type: 'beta' },
+  },
+} satisfies Meta<typeof SegmentedControl>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+type Mode = 'grid' | 'map' | 'list';
+
+const modeOptions: SegmentedControlOption<Mode>[] = [
+  { value: 'grid', label: 'Grid' },
+  { value: 'map', label: 'Map' },
+  { value: 'list', label: 'List' },
+];
+
+const GridIcon = () => (
+  <svg width={12} height={12} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <rect x="3" y="3" width="7" height="7" rx="1" />
+    <rect x="14" y="3" width="7" height="7" rx="1" />
+    <rect x="3" y="14" width="7" height="7" rx="1" />
+    <rect x="14" y="14" width="7" height="7" rx="1" />
+  </svg>
+);
+
+const MapIcon = () => (
+  <svg
+    width={12}
+    height={12}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    aria-hidden="true"
+  >
+    <path d="M9 20l-5.5-2V4L9 6m0 14l6-2m-6 2V6m6 12l5.5 2V6L15 4m0 14V4M9 6l6-2" />
+  </svg>
+);
+
+const ListIcon = () => (
+  <svg
+    width={12}
+    height={12}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    aria-hidden="true"
+  >
+    <path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" />
+  </svg>
+);
+
+const modeOptionsWithIcons: SegmentedControlOption<Mode>[] = [
+  { value: 'grid', label: 'Grid', icon: <GridIcon /> },
+  { value: 'map', label: 'Map', icon: <MapIcon /> },
+  { value: 'list', label: 'List', icon: <ListIcon /> },
+];
+
+export const Default: Story = {
+  render: () => {
+    const [value, setValue] = React.useState<Mode>('grid');
+    return (
+      <SegmentedControl<Mode>
+        value={value}
+        options={modeOptions}
+        onChange={setValue}
+        ariaLabel="View mode"
+      />
+    );
+  },
+  args: {
+    value: 'grid',
+    options: modeOptions,
+    onChange: () => undefined,
+    ariaLabel: 'View mode',
+  },
+};
+
+export const WithIcons: Story = {
+  render: () => {
+    const [value, setValue] = React.useState<Mode>('map');
+    return (
+      <SegmentedControl<Mode>
+        value={value}
+        options={modeOptionsWithIcons}
+        onChange={setValue}
+        ariaLabel="View mode"
+      />
+    );
+  },
+  args: {
+    value: 'grid',
+    options: modeOptionsWithIcons,
+    onChange: () => undefined,
+    ariaLabel: 'View mode',
+  },
+};
+
+export const TwoOption: Story = {
+  render: () => {
+    const [value, setValue] = React.useState<'grid' | 'map'>('grid');
+    const opts: SegmentedControlOption<'grid' | 'map'>[] = [
+      { value: 'grid', label: 'Grid', icon: <GridIcon /> },
+      { value: 'map', label: 'Map', icon: <MapIcon /> },
+    ];
+    return (
+      <SegmentedControl<'grid' | 'map'>
+        value={value}
+        options={opts}
+        onChange={setValue}
+        ariaLabel="View mode"
+      />
+    );
+  },
+  args: {
+    value: 'grid',
+    options: modeOptions,
+    onChange: () => undefined,
+    ariaLabel: 'View mode',
+  },
+};
+
+export const Small: Story = {
+  render: () => {
+    const [value, setValue] = React.useState<Mode>('grid');
+    return (
+      <SegmentedControl<Mode>
+        value={value}
+        options={modeOptions}
+        onChange={setValue}
+        ariaLabel="View mode"
+        size="sm"
+      />
+    );
+  },
+  args: {
+    value: 'grid',
+    options: modeOptions,
+    onChange: () => undefined,
+    ariaLabel: 'View mode',
+    size: 'sm',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    value: 'grid',
+    options: modeOptions,
+    onChange: () => undefined,
+    ariaLabel: 'View mode',
+    disabled: true,
+  },
+};
+
+export const DensityCompact: Story = {
+  render: () => {
+    const [value, setValue] = React.useState<Mode>('grid');
+    return (
+      <DensityProvider density="compact">
+        <SegmentedControl<Mode>
+          value={value}
+          options={modeOptions}
+          onChange={setValue}
+          ariaLabel="View mode"
+          size="md"
+        />
+      </DensityProvider>
+    );
+  },
+  args: {
+    value: 'grid',
+    options: modeOptions,
+    onChange: () => undefined,
+    ariaLabel: 'View mode',
+  },
+};

--- a/packages/ui/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/ui/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -1,0 +1,368 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { SegmentedControl, type SegmentedControlOption } from './SegmentedControl';
+import { DensityProvider } from '../../lib/density';
+
+afterEach(cleanup);
+
+type Mode = 'grid' | 'map' | 'list';
+const options: SegmentedControlOption<Mode>[] = [
+  { value: 'grid', label: 'Grid' },
+  { value: 'map', label: 'Map' },
+  { value: 'list', label: 'List' },
+];
+
+describe('SegmentedControl', () => {
+  it('renders a radiogroup with the given aria-label', () => {
+    render(
+      <SegmentedControl<Mode>
+        value="grid"
+        options={options}
+        onChange={() => undefined}
+        ariaLabel="View mode"
+      />,
+    );
+    const group = screen.getByRole('radiogroup', { name: 'View mode' });
+    expect(group).toBeDefined();
+  });
+
+  it('renders one radio per option', () => {
+    render(
+      <SegmentedControl<Mode>
+        value="grid"
+        options={options}
+        onChange={() => undefined}
+        ariaLabel="View mode"
+      />,
+    );
+    expect(screen.getAllByRole('radio')).toHaveLength(options.length);
+  });
+
+  it('marks the active option with aria-checked=true and the rest false', () => {
+    render(
+      <SegmentedControl<Mode>
+        value="map"
+        options={options}
+        onChange={() => undefined}
+        ariaLabel="View mode"
+      />,
+    );
+    expect(
+      screen.getByRole('radio', { name: 'Grid' }).getAttribute('aria-checked'),
+    ).toBe('false');
+    expect(
+      screen.getByRole('radio', { name: 'Map' }).getAttribute('aria-checked'),
+    ).toBe('true');
+    expect(
+      screen.getByRole('radio', { name: 'List' }).getAttribute('aria-checked'),
+    ).toBe('false');
+  });
+
+  it('clicking an option fires onChange with that value', () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl<Mode>
+        value="grid"
+        options={options}
+        onChange={onChange}
+        ariaLabel="View mode"
+      />,
+    );
+    fireEvent.click(screen.getByRole('radio', { name: 'Map' }));
+    expect(onChange).toHaveBeenCalledWith('map');
+  });
+
+  it('roving tabindex — only the active option is tabbable', () => {
+    render(
+      <SegmentedControl<Mode>
+        value="map"
+        options={options}
+        onChange={() => undefined}
+        ariaLabel="View mode"
+      />,
+    );
+    expect(
+      screen.getByRole('radio', { name: 'Grid' }).getAttribute('tabindex'),
+    ).toBe('-1');
+    expect(
+      screen.getByRole('radio', { name: 'Map' }).getAttribute('tabindex'),
+    ).toBe('0');
+    expect(
+      screen.getByRole('radio', { name: 'List' }).getAttribute('tabindex'),
+    ).toBe('-1');
+  });
+
+  it('ArrowRight on a segment cycles to the next option (and selects it)', () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl<Mode>
+        value="grid"
+        options={options}
+        onChange={onChange}
+        ariaLabel="View mode"
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'Grid' }), {
+      key: 'ArrowRight',
+    });
+    expect(onChange).toHaveBeenCalledWith('map');
+  });
+
+  it('ArrowLeft on the first option wraps to the last', () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl<Mode>
+        value="grid"
+        options={options}
+        onChange={onChange}
+        ariaLabel="View mode"
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'Grid' }), {
+      key: 'ArrowLeft',
+    });
+    expect(onChange).toHaveBeenCalledWith('list');
+  });
+
+  it('ArrowDown / ArrowUp also navigate (mirrors W3C radiogroup pattern)', () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl<Mode>
+        value="map"
+        options={options}
+        onChange={onChange}
+        ariaLabel="View mode"
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'Map' }), {
+      key: 'ArrowDown',
+    });
+    expect(onChange).toHaveBeenLastCalledWith('list');
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'Map' }), {
+      key: 'ArrowUp',
+    });
+    expect(onChange).toHaveBeenLastCalledWith('grid');
+  });
+
+  it('Enter selects the focused option', () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl<Mode>
+        value="grid"
+        options={options}
+        onChange={onChange}
+        ariaLabel="View mode"
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'Map' }), {
+      key: 'Enter',
+    });
+    expect(onChange).toHaveBeenCalledWith('map');
+  });
+
+  it('Space selects the focused option', () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl<Mode>
+        value="grid"
+        options={options}
+        onChange={onChange}
+        ariaLabel="View mode"
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'List' }), {
+      key: ' ',
+    });
+    expect(onChange).toHaveBeenCalledWith('list');
+  });
+
+  it('Home jumps to the first option, End to the last', () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl<Mode>
+        value="map"
+        options={options}
+        onChange={onChange}
+        ariaLabel="View mode"
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'Map' }), {
+      key: 'Home',
+    });
+    expect(onChange).toHaveBeenLastCalledWith('grid');
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'Map' }), {
+      key: 'End',
+    });
+    expect(onChange).toHaveBeenLastCalledWith('list');
+  });
+
+  it('disabled — aria-disabled set, click does NOT fire onChange', () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl<Mode>
+        value="grid"
+        options={options}
+        onChange={onChange}
+        ariaLabel="View mode"
+        disabled
+      />,
+    );
+    expect(
+      screen.getByRole('radiogroup').getAttribute('aria-disabled'),
+    ).toBe('true');
+    fireEvent.click(screen.getByRole('radio', { name: 'Map' }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('disabled — keyboard navigation does NOT fire onChange', () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl<Mode>
+        value="grid"
+        options={options}
+        onChange={onChange}
+        ariaLabel="View mode"
+        disabled
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'Grid' }), {
+      key: 'ArrowRight',
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('renders an icon when provided', () => {
+    const opts: SegmentedControlOption<Mode>[] = [
+      {
+        value: 'grid',
+        label: 'Grid',
+        icon: <span data-testid="grid-icon">⊞</span>,
+      },
+      { value: 'map', label: 'Map' },
+    ];
+    render(
+      <SegmentedControl<Mode>
+        value="grid"
+        options={opts}
+        onChange={() => undefined}
+        ariaLabel="View mode"
+      />,
+    );
+    expect(screen.getByTestId('grid-icon')).toBeDefined();
+  });
+
+  it('honours ariaLabel override per option', () => {
+    const opts: SegmentedControlOption<Mode>[] = [
+      { value: 'grid', label: 'G', ariaLabel: 'Grid view' },
+      { value: 'map', label: 'M', ariaLabel: 'Map view' },
+    ];
+    render(
+      <SegmentedControl<Mode>
+        value="grid"
+        options={opts}
+        onChange={() => undefined}
+        ariaLabel="View mode"
+      />,
+    );
+    expect(
+      screen.getByRole('radio', { name: 'Grid view' }),
+    ).toBeDefined();
+  });
+
+  it('exposes data-active on the active segment', () => {
+    render(
+      <SegmentedControl<Mode>
+        value="map"
+        options={options}
+        onChange={() => undefined}
+        ariaLabel="View mode"
+      />,
+    );
+    expect(
+      screen
+        .getByTestId('segmented-control-option-map')
+        .getAttribute('data-active'),
+    ).toBe('true');
+    expect(
+      screen
+        .getByTestId('segmented-control-option-grid')
+        .getAttribute('data-active'),
+    ).toBe('false');
+  });
+
+  it('renders sm size by default-as-md and md when specified', () => {
+    const { container, rerender } = render(
+      <SegmentedControl<Mode>
+        value="grid"
+        options={options}
+        onChange={() => undefined}
+        ariaLabel="View mode"
+        size="sm"
+      />,
+    );
+    const wrap = container.querySelector('[role="radiogroup"]') as HTMLElement;
+    expect(wrap.getAttribute('data-size')).toBe('sm');
+
+    rerender(
+      <SegmentedControl<Mode>
+        value="grid"
+        options={options}
+        onChange={() => undefined}
+        ariaLabel="View mode"
+        size="md"
+      />,
+    );
+    expect(wrap.getAttribute('data-size')).toBe('md');
+  });
+
+  it('density=compact forces sm sizing even if size=md', () => {
+    const { container } = render(
+      <DensityProvider density="compact">
+        <SegmentedControl<Mode>
+          value="grid"
+          options={options}
+          onChange={() => undefined}
+          ariaLabel="View mode"
+          size="md"
+        />
+      </DensityProvider>,
+    );
+    const wrap = container.querySelector('[role="radiogroup"]') as HTMLElement;
+    expect(wrap.getAttribute('data-size')).toBe('sm');
+    expect(wrap.getAttribute('data-density')).toBe('compact');
+  });
+
+  it('does NOT inject hardcoded hex colours into the rendered DOM', () => {
+    const { container } = render(
+      <SegmentedControl<Mode>
+        value="grid"
+        options={options}
+        onChange={() => undefined}
+        ariaLabel="View mode"
+      />,
+    );
+    expect(container.innerHTML).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+  });
+
+  it('handles 2-option case (the most common — Grid|Map)', () => {
+    const onChange = vi.fn();
+    const twoOpts: SegmentedControlOption<'grid' | 'map'>[] = [
+      { value: 'grid', label: 'Grid' },
+      { value: 'map', label: 'Map' },
+    ];
+    render(
+      <SegmentedControl<'grid' | 'map'>
+        value="grid"
+        options={twoOpts}
+        onChange={onChange}
+        ariaLabel="View mode"
+      />,
+    );
+    fireEvent.click(screen.getByRole('radio', { name: 'Map' }));
+    expect(onChange).toHaveBeenCalledWith('map');
+  });
+});

--- a/packages/ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,0 +1,271 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+import { useDensity } from '../../lib/density';
+
+/**
+ * SegmentedControl — two-or-more-button segmented control.
+ *
+ * Generalises Studio's Grid|Map toggle. Renders a pill-shaped wrapper
+ * with one button per option; the active segment slides over via a
+ * positioned highlight layer. Standard ARIA radiogroup semantics:
+ *
+ * - Wrapper: `role="radiogroup"` + `aria-label`.
+ * - Each option: `role="radio"` + `aria-checked`.
+ * - Roving tabindex — only the active segment is in the tab order.
+ * - Arrow keys cycle through options (and select on focus, mirroring
+ *   the W3C native radio-group pattern). Enter / Space also select the
+ *   focused segment.
+ *
+ * The active-segment slide animation honours `prefers-reduced-motion:
+ * reduce` (transition disabled when the user prefers reduced motion).
+ *
+ * Density-aware: `compact` honours `size="sm"`-ish padding; `spacious`
+ * eases up vertically for touch.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface SegmentedControlOption<V extends string = string> {
+  value: V;
+  label: string;
+  /** Optional leading icon. Rendered before the label. */
+  icon?: React.ReactNode;
+  /** Override the segment's accessible label (defaults to `label`). */
+  ariaLabel?: string;
+}
+
+export interface SegmentedControlProps<V extends string = string> {
+  /** Currently selected value (controlled). */
+  value: V;
+  options: SegmentedControlOption<V>[];
+  onChange: (value: V) => void;
+  /** Visual size — `sm` matches Studio's ~28px control; `md` is ~36px. */
+  size?: 'sm' | 'md';
+  /** Required for a11y — the radiogroup needs a label. */
+  ariaLabel?: string;
+  className?: string;
+  /** Disable the entire control. */
+  disabled?: boolean;
+}
+
+// ─── Density-aware sizing ───────────────────────────────────────────────────
+
+const sizeClasses: Record<'sm' | 'md', { wrap: string; segment: string; gap: string }> = {
+  sm: {
+    wrap: 'p-0.5',
+    segment: 'h-6 px-2.5 text-[12px]',
+    gap: 'gap-1',
+  },
+  md: {
+    wrap: 'p-1',
+    segment: 'h-8 px-3 text-[13px]',
+    gap: 'gap-1.5',
+  },
+};
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function SegmentedControl<V extends string = string>({
+  value,
+  options,
+  onChange,
+  size = 'md',
+  ariaLabel,
+  className,
+  disabled = false,
+}: SegmentedControlProps<V>) {
+  const density = useDensity();
+
+  // Density nudges segment height down/up by one tick.
+  const effectiveSize: 'sm' | 'md' = density === 'compact' ? 'sm' : size;
+  const sizing = sizeClasses[effectiveSize];
+
+  const wrapRef = React.useRef<HTMLDivElement>(null);
+  const segmentRefs = React.useRef<Map<V, HTMLButtonElement>>(new Map());
+
+  const setSegmentRef = React.useCallback(
+    (val: V) => (el: HTMLButtonElement | null) => {
+      const map = segmentRefs.current;
+      if (el) map.set(val, el);
+      else map.delete(val);
+    },
+    [],
+  );
+
+  const focusByOffset = React.useCallback(
+    (currentValue: V, offset: number) => {
+      const enabled = options.filter((o) => !disabled);
+      if (enabled.length === 0) return;
+      const idx = enabled.findIndex((o) => o.value === currentValue);
+      if (idx === -1) return;
+      const nextIdx = (idx + offset + enabled.length) % enabled.length;
+      const nextOpt = enabled[nextIdx];
+      const el = segmentRefs.current.get(nextOpt.value);
+      el?.focus();
+      // Roving focus also selects, matching W3C radiogroup pattern.
+      onChange(nextOpt.value);
+    },
+    [options, disabled, onChange],
+  );
+
+  const handleKeyDown = (
+    e: React.KeyboardEvent<HTMLButtonElement>,
+    optionValue: V,
+  ) => {
+    if (disabled) return;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      focusByOffset(optionValue, 1);
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      focusByOffset(optionValue, -1);
+    } else if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault();
+      onChange(optionValue);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      const first = options[0];
+      if (first) {
+        segmentRefs.current.get(first.value)?.focus();
+        onChange(first.value);
+      }
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      const last = options[options.length - 1];
+      if (last) {
+        segmentRefs.current.get(last.value)?.focus();
+        onChange(last.value);
+      }
+    }
+  };
+
+  // Compute highlight position from the active segment's offset.
+  const [highlight, setHighlight] = React.useState<{
+    left: number;
+    width: number;
+  } | null>(null);
+
+  const recomputeHighlight = React.useCallback(() => {
+    const wrap = wrapRef.current;
+    const active = segmentRefs.current.get(value);
+    if (!wrap || !active) {
+      setHighlight(null);
+      return;
+    }
+    const wrapRect = wrap.getBoundingClientRect();
+    const segRect = active.getBoundingClientRect();
+    setHighlight({
+      left: segRect.left - wrapRect.left,
+      width: segRect.width,
+    });
+  }, [value]);
+
+  // Recompute highlight on value change, mount, and resize.
+  React.useEffect(() => {
+    recomputeHighlight();
+  }, [recomputeHighlight, options.length, effectiveSize]);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handler = () => recomputeHighlight();
+    window.addEventListener('resize', handler);
+    return () => window.removeEventListener('resize', handler);
+  }, [recomputeHighlight]);
+
+  return (
+    <div
+      ref={wrapRef}
+      role="radiogroup"
+      aria-label={ariaLabel}
+      aria-disabled={disabled || undefined}
+      data-size={effectiveSize}
+      data-density={density}
+      className={cn(
+        'relative inline-flex items-center',
+        'rounded-full border border-[var(--amp-semantic-border-default)]',
+        'bg-[var(--amp-semantic-bg-subtle)]',
+        sizing.wrap,
+        sizing.gap,
+        disabled && 'opacity-50',
+        className,
+      )}
+    >
+      {/* Sliding highlight layer */}
+      {highlight && (
+        <span
+          aria-hidden="true"
+          data-testid="segmented-control-highlight"
+          className={cn(
+            'pointer-events-none absolute top-1/2 -translate-y-1/2',
+            'rounded-full',
+            'bg-[var(--amp-semantic-bg-surface)]',
+            'shadow-sm',
+            'ring-1 ring-[var(--amp-semantic-border-subtle)]',
+            'transition-[left,width] duration-150 ease-out',
+            // honour reduced motion — no slide
+            'motion-reduce:transition-none',
+          )}
+          style={{
+            left: highlight.left,
+            width: highlight.width,
+            // Match segment height so the pill aligns vertically.
+            height:
+              effectiveSize === 'sm'
+                ? 'calc(1.5rem)' // h-6
+                : 'calc(2rem)', // h-8
+          }}
+        />
+      )}
+
+      {options.map((opt) => {
+        const isActive = opt.value === value;
+        const tabIndex = isActive ? 0 : -1;
+
+        return (
+          <button
+            key={opt.value}
+            ref={setSegmentRef(opt.value)}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            aria-label={opt.ariaLabel ?? opt.label}
+            data-value={opt.value}
+            data-active={isActive}
+            data-testid={`segmented-control-option-${opt.value}`}
+            disabled={disabled}
+            tabIndex={tabIndex}
+            onClick={() => {
+              if (!disabled) onChange(opt.value);
+            }}
+            onKeyDown={(e) => handleKeyDown(e, opt.value)}
+            className={cn(
+              'relative z-[1] inline-flex items-center justify-center gap-1.5',
+              'rounded-full font-medium',
+              'transition-colors duration-150',
+              'motion-reduce:transition-none',
+              'focus-visible:outline-none focus-visible:ring-2',
+              'focus-visible:ring-[var(--amp-semantic-border-focus)]',
+              'focus-visible:ring-offset-1',
+              sizing.segment,
+              isActive
+                ? 'text-[var(--amp-semantic-text-default)]'
+                : 'text-[var(--amp-semantic-text-secondary)] hover:text-[var(--amp-semantic-text-default)]',
+              disabled && 'cursor-not-allowed',
+            )}
+          >
+            {opt.icon && (
+              <span aria-hidden="true" className="inline-flex shrink-0 items-center">
+                {opt.icon}
+              </span>
+            )}
+            <span className="truncate">{opt.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+SegmentedControl.displayName = 'SegmentedControl';

--- a/packages/ui/src/components/SegmentedControl/index.ts
+++ b/packages/ui/src/components/SegmentedControl/index.ts
@@ -1,0 +1,5 @@
+export { SegmentedControl } from './SegmentedControl';
+export type {
+  SegmentedControlProps,
+  SegmentedControlOption,
+} from './SegmentedControl';

--- a/packages/ui/src/components/StatusBar/StatusBar.stories.tsx
+++ b/packages/ui/src/components/StatusBar/StatusBar.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { StatusBar, type StatusBarItem } from './StatusBar';
+import { DensityProvider } from '../../lib/density';
+
+const meta = {
+  title: 'Studio v2/StatusBar',
+  component: StatusBar,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    status: { type: 'beta' },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          width: '100%',
+          minHeight: 96,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'flex-end',
+          background: 'var(--amp-semantic-bg-base)',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof StatusBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const cockpitItems: StatusBarItem[] = [
+  { id: 'model', label: 'Model', value: 'opus-4-7' },
+  { id: 'sha', label: 'SHA', value: '87dce7a', variant: 'mono' },
+  { id: 'gens', label: 'Gens', value: '12' },
+  { id: 'preset', label: 'Preset', value: 'editorial-bold' },
+];
+
+export const Default: Story = {
+  args: {
+    items: cockpitItems,
+  },
+};
+
+export const Between: Story = {
+  args: {
+    items: cockpitItems,
+    align: 'between',
+  },
+};
+
+export const WithMonoValues: Story = {
+  args: {
+    items: [
+      { id: 'sha', label: 'SHA', value: 'a1b2c3d4e5f6', variant: 'mono' },
+      { id: 'ver', label: 'Version', value: '2.11.0', variant: 'mono' },
+      { id: 'env', label: 'Env', value: 'production' },
+    ],
+  },
+};
+
+export const Truncated: Story = {
+  args: {
+    items: [
+      { id: 'model', label: 'Model', value: 'opus-4-7' },
+      {
+        id: 'path',
+        label: 'Path',
+        value:
+          '/Users/admin/one-impression/amplify-design-system/packages/ui/src/components/StatusBar/StatusBar.tsx',
+        truncate: true,
+        maxWidth: '20rem',
+      },
+      { id: 'env', label: 'Env', value: 'production' },
+    ],
+  },
+};
+
+export const RichValue: Story = {
+  args: {
+    items: [
+      {
+        id: 'status',
+        label: 'Status',
+        value: (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <span
+              aria-hidden="true"
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: '50%',
+                background: 'var(--amp-semantic-status-success)',
+                display: 'inline-block',
+              }}
+            />
+            Live
+          </span>
+        ),
+      },
+      { id: 'sha', label: 'SHA', value: '87dce7a', variant: 'mono' },
+      { id: 'env', label: 'Env', value: 'production' },
+    ],
+    align: 'between',
+  },
+};
+
+export const DensityCompact: Story = {
+  render: (args) => (
+    <DensityProvider density="compact">
+      <StatusBar {...args} />
+    </DensityProvider>
+  ),
+  args: {
+    items: cockpitItems,
+  },
+};
+
+export const DensitySpacious: Story = {
+  render: (args) => (
+    <DensityProvider density="spacious">
+      <StatusBar {...args} />
+    </DensityProvider>
+  ),
+  args: {
+    items: cockpitItems,
+  },
+};
+
+export const SingleItem: Story = {
+  args: {
+    items: [{ id: 'model', label: 'Model', value: 'opus-4-7' }],
+  },
+};

--- a/packages/ui/src/components/StatusBar/StatusBar.test.tsx
+++ b/packages/ui/src/components/StatusBar/StatusBar.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { StatusBar, type StatusBarItem } from './StatusBar';
+import { DensityProvider } from '../../lib/density';
+
+afterEach(cleanup);
+
+const baseItems: StatusBarItem[] = [
+  { id: 'model', label: 'Model', value: 'opus-4-7' },
+  { id: 'sha', label: 'SHA', value: '87dce7a', variant: 'mono' },
+  { id: 'generations', label: 'Gens', value: '12' },
+];
+
+describe('StatusBar', () => {
+  it('renders a region with default aria-label="Status"', () => {
+    render(<StatusBar items={baseItems} />);
+    const region = screen.getByRole('region', { name: 'Status' });
+    expect(region).toBeDefined();
+  });
+
+  it('honours a caller-provided aria-label', () => {
+    render(<StatusBar items={baseItems} aria-label="Cockpit footer" />);
+    expect(screen.getByRole('region', { name: 'Cockpit footer' })).toBeDefined();
+  });
+
+  it('renders one dt/dd pair per item', () => {
+    render(<StatusBar items={baseItems} />);
+    const list = screen.getByTestId('status-bar-list');
+    const dts = list.querySelectorAll('dt');
+    const dds = list.querySelectorAll('dd');
+    expect(dts).toHaveLength(baseItems.length);
+    expect(dds).toHaveLength(baseItems.length);
+  });
+
+  it('renders the label and value for each item', () => {
+    render(<StatusBar items={baseItems} />);
+    expect(screen.getByText('Model')).toBeDefined();
+    expect(screen.getByText('opus-4-7')).toBeDefined();
+    expect(screen.getByText('SHA')).toBeDefined();
+    expect(screen.getByText('87dce7a')).toBeDefined();
+  });
+
+  it('exposes data-variant for styling hooks (mono / default)', () => {
+    render(<StatusBar items={baseItems} />);
+    expect(
+      screen.getByTestId('status-bar-item-model').getAttribute('data-variant'),
+    ).toBe('default');
+    expect(
+      screen.getByTestId('status-bar-item-sha').getAttribute('data-variant'),
+    ).toBe('mono');
+  });
+
+  it('renders mono values with the monospace font class', () => {
+    render(<StatusBar items={baseItems} />);
+    const monoCell = screen
+      .getByTestId('status-bar-item-sha')
+      .querySelector('dd');
+    expect(monoCell?.className).toContain('font-mono');
+  });
+
+  it('default cells do NOT get the monospace class', () => {
+    render(<StatusBar items={baseItems} />);
+    const defaultCell = screen
+      .getByTestId('status-bar-item-model')
+      .querySelector('dd');
+    expect(defaultCell?.className).not.toContain('font-mono');
+  });
+
+  it('truncate=true applies the truncate class and a title attribute', () => {
+    const items: StatusBarItem[] = [
+      {
+        id: 'long',
+        label: 'Path',
+        value: '/very/long/path/that/should/truncate/in/the/cell',
+        truncate: true,
+      },
+    ];
+    render(<StatusBar items={items} />);
+    const dd = screen.getByTestId('status-bar-item-long').querySelector('dd');
+    expect(dd?.className).toContain('truncate');
+    expect(dd?.getAttribute('title')).toBe(
+      '/very/long/path/that/should/truncate/in/the/cell',
+    );
+  });
+
+  it('does NOT add a title attribute when truncate is unset', () => {
+    render(<StatusBar items={baseItems} />);
+    const dd = screen.getByTestId('status-bar-item-model').querySelector('dd');
+    expect(dd?.getAttribute('title')).toBeNull();
+  });
+
+  it('honours maxWidth on the value cell', () => {
+    const items: StatusBarItem[] = [
+      { id: 'm', label: 'M', value: 'x', maxWidth: '12rem' },
+    ];
+    render(<StatusBar items={items} />);
+    const dd = screen.getByTestId('status-bar-item-m').querySelector('dd');
+    expect((dd as HTMLElement | null)?.style.maxWidth).toBe('12rem');
+  });
+
+  it('align="between" pushes the last item to the right', () => {
+    render(<StatusBar items={baseItems} align="between" />);
+    const last = screen.getByTestId('status-bar-item-generations');
+    expect(last.className).toContain('ml-auto');
+  });
+
+  it('align="start" does NOT push any item', () => {
+    render(<StatusBar items={baseItems} align="start" />);
+    const last = screen.getByTestId('status-bar-item-generations');
+    expect(last.className).not.toContain('ml-auto');
+  });
+
+  it('exposes data-align on the dl wrapper', () => {
+    render(<StatusBar items={baseItems} align="between" />);
+    expect(
+      screen.getByTestId('status-bar-list').getAttribute('data-align'),
+    ).toBe('between');
+  });
+
+  it('renders ReactNode values (icon + text) without crashing', () => {
+    const items: StatusBarItem[] = [
+      {
+        id: 'rich',
+        label: 'Status',
+        value: (
+          <span>
+            <span data-testid="status-icon" aria-hidden="true">
+              {'•'}
+            </span>
+            <span>Live</span>
+          </span>
+        ),
+      },
+    ];
+    render(<StatusBar items={items} />);
+    expect(screen.getByTestId('status-icon')).toBeDefined();
+    expect(screen.getByText('Live')).toBeDefined();
+  });
+
+  it('does NOT inject hardcoded hex colours into the rendered DOM', () => {
+    const { container } = render(<StatusBar items={baseItems} />);
+    // Every colour must come from a CSS variable.
+    expect(container.innerHTML).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+  });
+
+  it('honours density context — compact reduces vertical padding', () => {
+    const { container: compact } = render(
+      <DensityProvider density="compact">
+        <StatusBar items={baseItems} />
+      </DensityProvider>,
+    );
+    const compactRegion = compact.querySelector('[role="region"]') as HTMLElement;
+    expect(compactRegion.className).toContain('py-0.5');
+
+    cleanup();
+
+    const { container: spacious } = render(
+      <DensityProvider density="spacious">
+        <StatusBar items={baseItems} />
+      </DensityProvider>,
+    );
+    const spaciousRegion = spacious.querySelector('[role="region"]') as HTMLElement;
+    expect(spaciousRegion.className).toContain('py-1.5');
+  });
+
+  it('renders nothing-but-the-region when items=[]', () => {
+    render(<StatusBar items={[]} />);
+    const region = screen.getByRole('region', { name: 'Status' });
+    expect(region.querySelectorAll('dt')).toHaveLength(0);
+    expect(region.querySelectorAll('dd')).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/components/StatusBar/StatusBar.tsx
+++ b/packages/ui/src/components/StatusBar/StatusBar.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+/**
+ * StatusBar — slim ~24px horizontal information strip.
+ *
+ * Studio v2 uses a `StatusBar` at the bottom of the cockpit to surface
+ * thin contextual metadata (active model, last commit SHA, generation
+ * count, current preset, etc). Other products may use it for thin
+ * status footers under dashboards or alongside data-dense canvases.
+ *
+ * The bar renders as a `<dl>` with one `<dt>` / `<dd>` pair per item so
+ * screen readers announce each cell as a label/value pair. Visual
+ * treatment is single-row, hidden overflow, and a top border.
+ *
+ * Density-aware: `compact` and `comfortable` densities pick a tighter
+ * row height; `spacious` adds a touch of vertical padding for
+ * touch-friendly surfaces.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface StatusBarItem {
+  /** Stable unique id — used as React key + DOM data attribute. */
+  id: string;
+  /** Small-caps label rendered before the value. */
+  label: string;
+  /** The displayed value. May be a string or any React node (icon + text, etc). */
+  value: string | React.ReactNode;
+  /**
+   * `mono` renders the value in the system monospace stack — useful for
+   * SHAs, version numbers, and other fixed-width identifiers.
+   */
+  variant?: 'default' | 'mono';
+  /** When `true`, the value cell truncates with an ellipsis on overflow. */
+  truncate?: boolean;
+  /** Optional max width for the value cell, e.g. `'20rem'`. */
+  maxWidth?: string;
+}
+
+export interface StatusBarProps extends React.HTMLAttributes<HTMLDivElement> {
+  items: StatusBarItem[];
+  /**
+   * `start` packs items left-aligned. `between` pushes the last item to
+   * the right edge — useful for a primary identifier on the left and a
+   * context cell (model / version) on the right.
+   */
+  align?: 'start' | 'between';
+  className?: string;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+import { useDensity } from '../../lib/density';
+
+export const StatusBar = React.forwardRef<HTMLDivElement, StatusBarProps>(
+  ({ items, align = 'start', className, ...rest }, ref) => {
+    const density = useDensity();
+
+    // Density-aware vertical padding — keeps the ~24px target for compact
+    // and comfortable, eases up to ~28px on spacious.
+    const densityPadding =
+      density === 'spacious'
+        ? 'py-1.5'
+        : density === 'compact'
+          ? 'py-0.5'
+          : 'py-1';
+
+    return (
+      <div
+        ref={ref}
+        role="region"
+        aria-label={rest['aria-label'] ?? 'Status'}
+        className={cn(
+          'flex w-full items-center overflow-hidden',
+          'border-t border-[var(--amp-semantic-border-subtle)]',
+          'bg-[var(--amp-semantic-bg-surface)]',
+          densityPadding,
+          'px-3',
+          'text-[var(--amp-semantic-text-secondary)]',
+          'text-[11px]',
+          className,
+        )}
+        {...rest}
+      >
+        <dl
+          data-testid="status-bar-list"
+          data-align={align}
+          className={cn(
+            'flex w-full min-w-0 items-center gap-3',
+            align === 'between' && 'justify-start',
+          )}
+        >
+          {items.map((item, idx) => {
+            const isLast = idx === items.length - 1;
+            const pushRight = align === 'between' && isLast && items.length > 1;
+
+            return (
+              <div
+                key={item.id}
+                data-testid={`status-bar-item-${item.id}`}
+                data-item-id={item.id}
+                data-variant={item.variant ?? 'default'}
+                className={cn(
+                  'flex min-w-0 shrink-0 items-baseline gap-1.5',
+                  pushRight && 'ml-auto',
+                )}
+              >
+                <dt
+                  className={cn(
+                    'shrink-0 text-[10px] font-semibold uppercase tracking-wider',
+                    'text-[var(--amp-semantic-text-tertiary)]',
+                  )}
+                >
+                  {item.label}
+                </dt>
+                <dd
+                  className={cn(
+                    'min-w-0 text-[11px] font-medium',
+                    'text-[var(--amp-semantic-text-default)]',
+                    item.variant === 'mono' &&
+                      'font-mono [font-feature-settings:"tnum"_1] tabular-nums',
+                    item.truncate && 'truncate',
+                  )}
+                  style={item.maxWidth ? { maxWidth: item.maxWidth } : undefined}
+                  title={
+                    item.truncate && typeof item.value === 'string'
+                      ? item.value
+                      : undefined
+                  }
+                >
+                  {item.value}
+                </dd>
+              </div>
+            );
+          })}
+        </dl>
+      </div>
+    );
+  },
+);
+
+StatusBar.displayName = 'StatusBar';

--- a/packages/ui/src/components/StatusBar/index.ts
+++ b/packages/ui/src/components/StatusBar/index.ts
@@ -1,0 +1,2 @@
+export { StatusBar } from './StatusBar';
+export type { StatusBarProps, StatusBarItem } from './StatusBar';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -582,3 +582,23 @@ export type {
   VariantCardAction,
   VariantCardScoreVariant,
 } from './components/VariantCard';
+
+// ─── Studio v2 primitives (Wave 3 — 2.11.0) ──────────────────────────
+// Three additional generic primitives lifted from Studio's Phase-0
+// audit: a thin status footer (StatusBar), a numbered phase indicator
+// (PhaseRibbon), and a generalised pill toggle (SegmentedControl).
+
+// PhaseRibbon
+export { PhaseRibbon } from './components/PhaseRibbon';
+export type { PhaseRibbonProps, PhaseItem, PhaseStatus } from './components/PhaseRibbon';
+
+// SegmentedControl
+export { SegmentedControl } from './components/SegmentedControl';
+export type {
+  SegmentedControlProps,
+  SegmentedControlOption,
+} from './components/SegmentedControl';
+
+// StatusBar
+export { StatusBar } from './components/StatusBar';
+export type { StatusBarProps, StatusBarItem } from './components/StatusBar';


### PR DESCRIPTION
## Summary

Studio v2 Wave 3 — three more visual primitives lifted from the Studio Phase-0 audit (PR #56). All ship as `lifecycle.status=beta`, `since=2.11.0`. Pure additive — no breaking changes. **Release PR only — do not publish until merged.**

- **`StatusBar`** — slim ~24px horizontal status strip. `<dl>` / `<dt>` / `<dd>` semantics; `default` / `mono` variants per item (mono = monospace for SHAs / versions); `truncate` + `maxWidth` per item; `align="start" | "between"` to optionally push the last item right. Density-aware vertical padding.
- **`PhaseRibbon`** — numbered phase indicator (1 → 2 → 3 → …) above a workflow. `pending` / `active` / `done` / `error` per-phase status drives circle colour (status-success / accent / status-error / border tokens) and connector tint. Active phase flagged via `aria-current="step"`; `done` renders a check glyph; status auto-derives from `current` when not given explicitly.
- **`SegmentedControl`** — generalised two-or-more-button segmented control. Pill wrapper with a single sliding accent highlight, W3C-pattern `role="radiogroup"` + arrow / Home / End / Enter / Space keyboard navigation, roving tabindex, and `motion-reduce`-honoured slide animation. `sm` (~28px) / `md` (~36px) sizes; density=compact forces `sm`.

Unblocks the Studio cockpit footer migration and consolidates the ad-hoc Grid|Map toggle into a reusable primitive.

## Files

- `packages/ui/src/components/StatusBar/{StatusBar,StatusBar.test,StatusBar.stories,index}.tsx|ts`
- `packages/ui/src/components/PhaseRibbon/{PhaseRibbon,PhaseRibbon.test,PhaseRibbon.stories,index}.tsx|ts`
- `packages/ui/src/components/SegmentedControl/{SegmentedControl,SegmentedControl.test,SegmentedControl.stories,index}.tsx|ts`
- `packages/ui/src/index.ts` — alphabetised additions in a new "Wave 3" group, mirroring existing Studio v2 wave grouping.
- `packages/ui/component-status.json` — 3 entries with `status: "beta"`, `since: "2.11.0"`.
- `packages/ui/package.json` — `2.10.0 → 2.11.0`.
- `packages/ui/dist/contracts.json` — regenerated manifest (`componentCount: 111 → 114`, `beta: 50 → 53`).
- `CHANGELOG.md` — `2.11.0 — 2026-05-07` entry.

## Quality bar

| Gate | Result |
|------|--------|
| TypeScript strict (new files) | clean (zero new errors; 58 pre-existing repo errors untouched) |
| Tests | 56 passing (17 StatusBar + 19 PhaseRibbon + 20 SegmentedControl) |
| Stories | 19 (7 StatusBar + 8 PhaseRibbon + 6 SegmentedControl) covering default / active / disabled / dark-bg / variant / interactive / density states |
| a11y violations | 0 (radiogroup + keyboard pattern + roving tabindex + aria-current=step + dl/dt/dd + role="list") |
| Hardcoded hex | 0 (verified via grep + per-component DOM assertion) |
| Token-only colours | yes (var(--amp-semantic-*)) |
| Density honoured | StatusBar (padding), SegmentedControl (sm-on-compact) |
| Reduced motion | SegmentedControl slide + segment transitions; PhaseRibbon transitions |
| Build (tsup) | succeeds (ESM 458KB + DTS 113KB) |
| Contracts | regenerated (114 components, +3 new) |
| Validate (validate-tokens.js) | passes (0 errors / 0 warnings) |

## Test plan

- [ ] Storybook: open `Studio v2/StatusBar` — verify Default / Between / WithMonoValues / Truncated / RichValue / DensityCompact / DensitySpacious / SingleItem stories render and labels show as small-caps.
- [ ] Storybook: open `Studio v2/PhaseRibbon` — verify Default / FirstPhase / Mid / LastPhase / WithError / WithHints / NumericIds / SinglePhase / Long stories render with check glyph on `done` phases and the active phase ringed.
- [ ] Storybook: open `Studio v2/SegmentedControl` — verify Default / WithIcons / TwoOption / Small / Disabled / DensityCompact stories. Click + arrow-key + Enter / Space all change the active segment; Home / End jump to first / last.
- [ ] Run `npm run test -w packages/ui` — all 56 new tests pass.
- [ ] Run `npm run build -w packages/ui` — contracts regenerate cleanly with 114 components.
- [ ] Visual: in dark mode, StatusBar sits flush against a dark canvas; PhaseRibbon active circle has accent ring halo; SegmentedControl sliding highlight reads as the active pill.

## Notes

- The exports section in `packages/ui/src/index.ts` follows the file's existing wave-grouped convention (each Studio v2 wave as a labelled block) rather than dropping the three new exports into the alphabetical body — this matches Wave 1 / Wave 2 / Map mode patterns. Within the new Wave 3 block they are alphabetical (PhaseRibbon → SegmentedControl → StatusBar).
- `dist/contracts.json` is the only `dist/` file that is tracked (per PR #80) — the per-component contract JSONs and `llms.txt` are still gitignored and regenerated on each build.
- Phase B1 sub-agent owns the `packages/tokens-studio/*` package — this PR does NOT touch any tokens package, only `packages/ui`. The root `package.json` workspaces array is also untouched.
- **Do not publish to npm from this PR.** Follow the existing release flow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)