### PR TITLE
fix(tokens-foundation): emit --amp-semantic-* aliases so Canvas primitives render in all apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the public packages of `amplify-design-system`.
 
+## 2.11.1 — 2026-05-08
+
+### Fixed (`@amplify-ai/tokens-foundation@2.1.1` and all product token packages)
+
+Canvas v2 primitives in `@amplify-ai/ui` (`BriefStrip`, `HistoryStrip`,
+`CouncilRail`, `VariantCard`, `StatusBar`, `SegmentedControl`) hard-code
+Tailwind arbitrary classes referencing a product-agnostic
+`--amp-semantic-*` family (e.g. `bg-[var(--amp-semantic-bg-accent-subtle)]`,
+`text-[var(--amp-semantic-text-default)]`). That family was not emitted
+by any token package — only product-prefixed
+`--amp-{brand,atmosphere,creator,studio}-semantic-*` was — so every
+primitive rendered unstyled in every consumer.
+
+`scripts/build-tokens.js` now appends a 26-entry alias block to every
+package's `dist/variables.css`. Each alias resolves to the product-
+prefixed source in the same package via `var()` indirection, so dark
+mode cascades automatically and the alias is always theme-correct for
+whichever product CSS is loaded. For `tokens-foundation` (unprefixed
+`amp` namespace), identity aliases are skipped to avoid self-cycles.
+
+This replaces the per-app hotfix in `magic-studio/src/app/globals.css`
+(One-Impression/magic-studio#66) — that block can be deleted in a
+follow-up PR after this lands and is published.
+
+Source: `magic-studio/docs/pixel-brief/STUDIO_DESIGN_PLAN.md` §3.1.
+
 ## 2.11.0 — 2026-05-07
 
 ### Added (additive — `@amplify-ai/ui`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10885,7 +10885,7 @@
     },
     "packages/tokens-foundation": {
       "name": "@amplify-ai/tokens-foundation",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }

--- a/packages/tokens-foundation/package.json
+++ b/packages/tokens-foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplify-ai/tokens-foundation",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "description": "Amplify Design System — shared foundation tokens (spacing, radii, shadows, motion, surfaces, borders, fluid type, breakpoints, z-index)",
   "main": "dist/tokens.js",

--- a/scripts/build-tokens.js
+++ b/scripts/build-tokens.js
@@ -276,7 +276,84 @@ export const spacing = ${JSON.stringify(spacing, null, 2)};
 `;
 }
 
-// 7. Dark mode CSS — loads dark semantic + dark product theme, outputs [data-theme="dark"] block
+// 7. Product-agnostic semantic aliases — emits --amp-semantic-* aliases that
+//    resolve to whichever product theme is loaded. Canvas v2 primitives in
+//    @amplify-ai/ui (BriefStrip, HistoryStrip, CouncilRail, VariantCard,
+//    StatusBar, SegmentedControl) hard-code Tailwind arbitrary classes
+//    referencing the agnostic --amp-semantic-* family. Without these aliases,
+//    every primitive renders unstyled in every consumer.
+//
+//    Mechanism:
+//    - For every product package (brand/atmosphere/creator/studio), each
+//      alias points to the product-prefixed source: `--amp-semantic-bg-surface:
+//      var(--amp-brand-semantic-bg-surface)` etc. Dark mode cascades
+//      automatically through the var() indirection.
+//    - For foundation, source vars are already `--amp-semantic-*` (foundation
+//      uses the unprefixed `amp` namespace). We emit only aliases whose
+//      target name differs from the source name; identity aliases would
+//      create self-referencing CSS variables.
+//
+//    Source: STUDIO_DESIGN_PLAN.md §3.1 (Magic Studio docs). Replaces the
+//    per-app hotfix in magic-studio/src/app/globals.css.
+const SEMANTIC_ALIASES = [
+  // Backgrounds
+  ['bg-surface',          'semantic-bg-surface'],
+  ['bg-base',             'semantic-bg-primary'],
+  ['bg-canvas',           'semantic-bg-sunken'],
+  ['bg-subtle',           'semantic-bg-sunken'],
+  ['bg-raised',           'semantic-bg-raised'],
+  ['bg-accent-subtle',    'semantic-accent-subtle'],
+  ['bg-success-subtle',   'semantic-status-success-bg'],
+  ['bg-warning-subtle',   'semantic-status-warning-bg'],
+  ['bg-error-subtle',     'semantic-status-error-bg'],
+  ['bg-info-subtle',      'semantic-status-info-bg'],
+  // Text
+  ['text-default',        'semantic-text-primary'],
+  ['text-secondary',      'semantic-text-secondary'],
+  ['text-tertiary',       'semantic-text-muted'],
+  ['text-inverse',        'semantic-text-inverse'],
+  ['text-accent',         'semantic-text-accent'],
+  // Status
+  ['status-success',      'semantic-status-success'],
+  ['status-warning',      'semantic-status-warning'],
+  ['status-error',        'semantic-status-error'],
+  ['status-info',         'semantic-status-info'],
+  // Borders
+  ['border-default',      'semantic-border-default'],
+  ['border-strong',       'semantic-border-strong'],
+  ['border-subtle',       'semantic-border-subtle'],
+  ['border-accent',       'semantic-border-accent'],
+  ['border-success',      'semantic-status-success'],
+  ['border-focus',        'semantic-border-focus'],
+  // Accent
+  ['accent-soft',         'semantic-accent-light'],
+];
+
+function buildSemanticAliases() {
+  const lines = [
+    '',
+    '/* ──────────────────────────────────────────────────────────────────',
+    '   Product-agnostic semantic aliases — resolve to active product theme.',
+    '   Consumed by Canvas v2 primitives in @amplify-ai/ui via Tailwind',
+    '   arbitrary classes (e.g. bg-[var(--amp-semantic-bg-accent-subtle)]).',
+    '   Dark mode cascades through var() indirection automatically.',
+    '   ────────────────────────────────────────────────────────────────── */',
+    ':root {',
+  ];
+  for (const [aliasName, sourceName] of SEMANTIC_ALIASES) {
+    const target = `--amp-semantic-${aliasName}`;
+    const source = `--${PREFIX}-${sourceName}`;
+    // Skip identity aliases (foundation case) — `--amp-semantic-bg-surface:
+    // var(--amp-semantic-bg-surface)` would self-cycle. Foundation already
+    // emits these names directly in the main :root block above.
+    if (target === source) continue;
+    lines.push(`  ${target}: var(${source});`);
+  }
+  lines.push('}', '');
+  return lines.join('\n');
+}
+
+// 8. Dark mode CSS — loads dark semantic + dark product theme, outputs [data-theme="dark"] block
 function buildDarkCSS() {
   const darkSemanticFile = join(semanticDir, 'colors-dark.json');
   const darkThemeFile = join(packageDir, 'theme-dark.json');
@@ -314,8 +391,9 @@ function buildDarkCSS() {
 
 // ── Write outputs ──
 const lightCSS = buildCSS();
+const aliasCSS = buildSemanticAliases();
 const darkCSS = buildDarkCSS();
-writeFileSync(join(distDir, 'variables.css'), lightCSS + darkCSS);
+writeFileSync(join(distDir, 'variables.css'), lightCSS + aliasCSS + darkCSS);
 writeFileSync(join(distDir, 'variables.scss'), buildSCSS());
 writeFileSync(join(distDir, 'tokens.json'), buildJSON());
 writeFileSync(join(distDir, 'tokens.js'), buildJS());


### PR DESCRIPTION
## Summary
Lifts the `--amp-semantic-*` → product-prefixed-semantic alias block UPSTREAM into the shared token build (`scripts/build-tokens.js`, owned by `@amplify-ai/tokens-foundation`) so every product (brand / atmosphere / creator / studio) gets it for free.

## Why
Every Canvas v2 primitive (`BriefStrip`, `HistoryStrip`, `CouncilRail`, `VariantCard`, `StatusBar`, `SegmentedControl`) hard-codes Tailwind arbitrary classes like `bg-[var(--amp-semantic-bg-accent-subtle)]`, `text-[var(--amp-semantic-text-default)]`, `border-[var(--amp-semantic-border-success)]`. The product-agnostic `--amp-semantic-*` family with these names was not emitted by any token package — only the product-prefixed `--amp-{brand,atmosphere,creator,studio}-semantic-*` family was — so every primitive rendered unstyled in every consumer.

A short-term per-app hotfix shipped in `magic-studio/src/app/globals.css` (One-Impression/magic-studio#66). This PR makes the alias the upstream default so the per-app duplication can be deleted.

Source spec: `magic-studio/docs/pixel-brief/STUDIO_DESIGN_PLAN.md` §3.1 — 26 alias entries used verbatim.

## Mechanism
**Mechanism A (theme-aware via package-of-import)**, lifted into the shared build script.

`scripts/build-tokens.js` now appends a `:root { ... }` alias block to every package's `dist/variables.css` after the main token emission. Each alias points the agnostic `--amp-semantic-<name>` to its product-prefixed source `--amp-<prefix>-semantic-<name>` via `var()` indirection. So when an app imports `@amplify-ai/tokens-brand/css`, it gets `--amp-semantic-bg-accent-subtle: var(--amp-brand-semantic-accent-subtle)`; atmosphere imports get the atmosphere-prefixed source; creator gets creator-prefixed; studio gets studio-prefixed. Dark mode cascades automatically through the `var()` indirection because the source variables are already theme-aware.

For `tokens-foundation` (which uses the unprefixed `amp` namespace), identity aliases like `--amp-semantic-bg-surface: var(--amp-semantic-bg-surface)` would self-cycle, so those are skipped — foundation already emits the matching names directly. Only the 12 NEW agnostic names that don't exist in foundation's emission (`bg-base`, `bg-canvas`, `bg-subtle`, `bg-accent-subtle`, `bg-{success,warning,error,info}-subtle`, `text-default`, `text-tertiary`, `border-success`, `accent-soft`) are added to foundation.

Why Mechanism A over Mechanism B (foundation-only emission referencing brand-prefixed sources): Mechanism B would couple foundation to brand and would only work in apps that import both `@amplify-ai/tokens-foundation/css` and `@amplify-ai/tokens-brand/css`. Apps today import only their product's tokens (e.g. `magic-studio` imports `tokens-brand/css` + `tokens-studio/css`, not foundation directly). Mechanism A keeps the alias block self-contained in whichever product's CSS is actually loaded.

## Files changed
- `scripts/build-tokens.js` — new `SEMANTIC_ALIASES` table + `buildSemanticAliases()` function emitting the 26-entry block; output appended to `variables.css` between the light and dark blocks.
- `packages/tokens-foundation/package.json` — version 2.1.0 → 2.1.1 (patch).
- `package-lock.json` — version sync.
- `CHANGELOG.md` — 2.11.1 entry documenting the fix.

## Test plan
- [x] `npm run build` green for all 7 token / UI packages
- [x] `npm run validate` green (0 errors, 0 warnings, all references resolve)
- [x] `tokens-foundation/dist/variables.css` emits 12 new agnostic aliases (skips identity)
- [x] `tokens-{brand,atmosphere,creator,studio}/dist/variables.css` each emit all 26 aliases pointing to their product-prefixed sources
- [x] `tokens-brand/dist/variables.css` still emits the original `--amp-brand-semantic-*` block (110 brand-semantic declarations preserved — no regression)
- [x] `npm run test -w packages/ui` green (258/258 tests pass across 31 component test files)
- [x] `tsc --noEmit` green for `@amplify-ai/mcp-server`
- [ ] After publish: `magic-studio` bumps `tokens-foundation` (transitive via `tokens-brand`/`tokens-studio`), deletes the alias block from its `globals.css` (separate PR)
- [ ] After publish: visual regression sweep across brand-platform, atmosphere, creator-app to confirm Canvas primitives now render correctly

## Pre-existing CI debt (not introduced by this PR)
`npm run lint` fails on `main` because `@amplify-ai/ui` uses ESLint v9 but ships an `.eslintrc.*` config (ESLint v9 requires `eslint.config.js`). This is unrelated debt; verified by `git stash && npm run lint` on `origin/main` → same failure. CI workflow `ci.yml` does not invoke `npm run lint`, so this does not block the PR.

## Publish status
**Code-only PR. npm publish is gated on the existing publish blocker** tracked in memory `project_canvas_npm_publish_pending.md` — `@amplify-ai` npm org and `NPM_TOKEN` repo secret have not been set up. The `ci.yml` publish step skips with a notice when `NPM_TOKEN` is missing, so merging this PR is safe; the new `tokens-foundation@2.1.1` will publish automatically once the org/token are provisioned.

## Follow-up PRs (after publish unblocks)
1. `magic-studio` — bump `tokens-foundation` (or `tokens-brand`/`tokens-studio` which transitively pull it), delete the alias hotfix block from `src/app/globals.css`.
2. Pending visual regression validation across brand-platform / atmosphere / creator-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)