### PR TITLE
chore(release): publish token packages with --amp-semantic-* alias block (3.0.1 / 2.0.2 / 1.0.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10855,7 +10855,7 @@
     },
     "packages/tokens-atmosphere": {
       "name": "@amplify-ai/tokens-atmosphere",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dependencies": {
         "@amplify-ai/tokens-foundation": "^2.0.1"
       },
@@ -10865,7 +10865,7 @@
     },
     "packages/tokens-brand": {
       "name": "@amplify-ai/tokens-brand",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
         "@amplify-ai/tokens-foundation": "^2.0.1"
       },
@@ -10875,7 +10875,7 @@
     },
     "packages/tokens-creator": {
       "name": "@amplify-ai/tokens-creator",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dependencies": {
         "@amplify-ai/tokens-foundation": "^2.0.1"
       },
@@ -10899,7 +10899,7 @@
     },
     "packages/tokens-studio": {
       "name": "@amplify-ai/tokens-studio",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@amplify-ai/tokens-foundation": "^2.1.0"
       },
@@ -10909,7 +10909,7 @@
     },
     "packages/ui": {
       "name": "@amplify-ai/ui",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "dependencies": {
         "clsx": "^2.1.0",
         "tailwind-merge": "^2.3.0"

--- a/packages/tokens-atmosphere/package.json
+++ b/packages/tokens-atmosphere/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplify-ai/tokens-atmosphere",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Amplify Atmosphere (internal tools) design tokens",
   "main": "dist/tokens.js",
   "exports": {

--- a/packages/tokens-brand/package.json
+++ b/packages/tokens-brand/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amplify-ai/tokens-brand",
-  "version": "3.0.0",
-  "description": "Amplify Brand Platform design tokens \u2014 colors, typography for brand dashboard",
+  "version": "3.0.1",
+  "description": "Amplify Brand Platform design tokens — colors, typography for brand dashboard",
   "main": "dist/tokens.js",
   "exports": {
     "./css": "./dist/variables.css",

--- a/packages/tokens-creator/package.json
+++ b/packages/tokens-creator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amplify-ai/tokens-creator",
-  "version": "2.0.1",
-  "description": "Amplify Creator App design tokens \u2014 SDUI theme colors, typography, and component tokens",
+  "version": "2.0.2",
+  "description": "Amplify Creator App design tokens — SDUI theme colors, typography, and component tokens",
   "main": "dist/tokens.js",
   "exports": {
     "./css": "./dist/variables.css",

--- a/packages/tokens-studio/package.json
+++ b/packages/tokens-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplify-ai/tokens-studio",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Amplify Magic Studio design tokens — Studio cockpit chrome, mirror/Map-mode voices, status scale; consumed only by studio.amplify.club",
   "main": "dist/tokens.js",
   "exports": {

--- a/packages/ui/dist/contracts.json
+++ b/packages/ui/dist/contracts.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-08T18:52:27.093Z",
+  "generatedAt": "2026-05-08T19:04:36.415Z",
   "tsVersion": "5.9.3",
   "componentCount": 114,
   "statusBreakdown": {


### PR DESCRIPTION
## Summary
Bumps + publishes the four product token packages so the agnostic `--amp-semantic-*` alias block emitted by `scripts/build-tokens.js` (introduced in #95) reaches consumers via npm.

| Package | Old | New | Published |
|---|---|---|---|
| `@amplify-ai/tokens-brand` | 3.0.0 | **3.0.1** | ✅ |
| `@amplify-ai/tokens-atmosphere` | 2.0.1 | **2.0.2** | ✅ |
| `@amplify-ai/tokens-creator` | 2.0.1 | **2.0.2** | ✅ |
| `@amplify-ai/tokens-studio` | 1.0.0 | **1.0.1** | ✅ |
| `@amplify-ai/tokens-foundation` | (unchanged) | 2.1.1 | already on npm |
| `@amplify-ai/ui` | (separate) | **2.12.0** | already on npm (#97 polish) |

## Why
After #95 added the `--amp-semantic-*` alias block to every token package's `dist/variables.css`, the new builds were on `main` but never republished — so consumers via npm still got the old (alias-free) versions. magic-studio shipped a per-app workaround (One-Impression/magic-studio#66) referencing the agnostic vars locally; this PR makes that workaround unnecessary by getting the alias block onto npm.

## Effect on consumers
- **magic-studio**: bump `tokens-brand` to `^3.0.1` and drop the local alias hotfix in `globals.css` (Phase C of `STUDIO_DESIGN_PLAN.md`).
- **brand-platform / atmosphere / creator-app**: same upgrade path.

## Test plan
- [x] `npm run build` green for all 7 packages
- [x] `npm run validate` green (0 errors / 0 warnings)
- [x] All 4 packages published successfully (npm verified)
- [ ] Downstream PR in magic-studio bumps deps + drops hotfix

🤖 Generated with [Claude Code](https://claude.com/claude-code)