### PR TITLE
feat(tokens): 23 new tokens for Studio v0 cockpit (layout / aspect / shadow)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 All notable changes to the public packages of `amplify-design-system`.
 
+## 2.11.3 — 2026-05-09
+
+### Added — Studio v0 cockpit tokens (Option D mockup)
+
+Adds 23 tokens required by the Studio v0 cockpit (`magic-studio/docs/mockups/option-d.html`,
+spec at `magic-studio/docs/mockups/OPTION_D_SPEC.md`). Layout + aspect tokens are scoped
+to `@amplify-ai/tokens-studio` (cockpit-only); the 4 new shadow / semantic tokens land in
+`@amplify-ai/tokens-foundation` so brand, atmosphere, and creator inherit them via the
+existing cascade.
+
+#### `@amplify-ai/tokens-studio` (`theme.layout.*`, 8 new)
+- `--amp-studio-theme-layout-topbar-h: 56px`
+- `--amp-studio-theme-layout-thread-max-w: 1180px`
+- `--amp-studio-theme-layout-composer-max-w: 980px`
+- `--amp-studio-theme-layout-flow-sidebar-w: 260px`
+- `--amp-studio-theme-layout-flow-sidebar-rail-w: 44px`
+- `--amp-studio-theme-layout-history-panel-w: 360px`
+- `--amp-studio-theme-layout-variant-card-h: 580px`
+- `--amp-studio-theme-layout-variant-card-w: 268px`
+
+#### `@amplify-ai/tokens-studio` (`theme.aspect.*`, 10 new)
+- `--amp-studio-theme-aspect-iphone-15-pro-max: 1 / 2.17`
+- `--amp-studio-theme-aspect-iphone-15-pro: 1 / 2.17`
+- `--amp-studio-theme-aspect-galaxy-s24: 1 / 2.17`
+- `--amp-studio-theme-aspect-ipad-pro-13: 1 / 1.33`
+- `--amp-studio-theme-aspect-ipad-air: 1 / 1.44`
+- `--amp-studio-theme-aspect-apple-watch-ultra: 1 / 1.22`
+- `--amp-studio-theme-aspect-apple-watch-9: 1 / 1.22`
+- `--amp-studio-theme-aspect-mac: 1.6 / 1`
+- `--amp-studio-theme-aspect-mac-1280: 1.6 / 1`
+- `--amp-studio-theme-aspect-flow-thumb: 160 / 100`
+
+#### `@amplify-ai/tokens-foundation` (semantic + shadow primitives, 4 new)
+- `--amp-semantic-color-info-soft` — light: `rgba(37, 99, 235, 0.08)`, dark: `rgba(59, 130, 246, 0.12)` (subtle info background)
+- `--amp-shadow-ring-accent` — `0 0 0 2px var(--amp-semantic-border-accent)` (focus / selection ring)
+- `--amp-shadow-composer` — `0 -4px 12px -4px rgba(28, 25, 23, 0.08)` (sticky composer upward shadow)
+- `--amp-shadow-device` — `0 12px 32px -8px rgba(28, 25, 23, 0.18), 0 4px 12px -4px rgba(28, 25, 23, 0.10)` (device-frame drop shadow)
+
+Note: `--amp-semantic-border-accent` (#5 in the spec list) already exists in
+`tokens-foundation/semantic/colors-{light,dark}.json` and was not duplicated.
+Total new tokens emitted: 23 (8 layout + 10 aspect + 1 semantic + 3 shadow + 1 reused existing).
+
+### Versioned
+
+- `@amplify-ai/tokens-foundation`: `2.1.2` → `2.1.3`
+- `@amplify-ai/tokens-studio`: `1.0.2` → `1.0.3`
+
 ## 2.11.2 — 2026-05-08
 
 ### Fixed (extended `--amp-semantic-*` alias block — all token packages)

--- a/packages/tokens-foundation/package.json
+++ b/packages/tokens-foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplify-ai/tokens-foundation",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "type": "module",
   "description": "Amplify Design System — shared foundation tokens (spacing, radii, shadows, motion, surfaces, borders, fluid type, breakpoints, z-index)",
   "main": "dist/tokens.js",

--- a/packages/tokens-foundation/tokens/primitives/shadows.json
+++ b/packages/tokens-foundation/tokens/primitives/shadows.json
@@ -18,6 +18,10 @@
 
     "accent-sm": { "$value": "0 1px 4px 0 rgba(101, 49, 255, 0.15)", "$description": "Coloured accent shadow — subtle (focus rings, hover hint)" },
     "accent-md": { "$value": "0 4px 12px -2px rgba(101, 49, 255, 0.25)", "$description": "Coloured accent shadow — standard (CTAs, active cards)" },
-    "accent-lg": { "$value": "0 10px 25px -4px rgba(101, 49, 255, 0.35)", "$description": "Coloured accent shadow — bold (hero cards, premium emphasis)" }
+    "accent-lg": { "$value": "0 10px 25px -4px rgba(101, 49, 255, 0.35)", "$description": "Coloured accent shadow — bold (hero cards, premium emphasis)" },
+
+    "ring-accent": { "$value": "0 0 0 2px var(--amp-semantic-border-accent)", "$description": "Accent focus / selection ring (Studio v0 cockpit; consumes semantic.border-accent runtime variable)" },
+    "composer":    { "$value": "0 -4px 12px -4px rgba(28, 25, 23, 0.08)", "$description": "Subtle upward shadow for sticky composers / bottom bars (Studio v0 cockpit)" },
+    "device":      { "$value": "0 12px 32px -8px rgba(28, 25, 23, 0.18), 0 4px 12px -4px rgba(28, 25, 23, 0.10)", "$description": "Drop shadow under variant device frames (Studio v0 cockpit)" }
   }
 }

--- a/packages/tokens-foundation/tokens/semantic/colors-dark.json
+++ b/packages/tokens-foundation/tokens/semantic/colors-dark.json
@@ -32,6 +32,8 @@
     "status-error":         { "$value": "{color.red.500}" },
     "status-error-bg":      { "$value": "rgba(239, 68, 68, 0.12)" },
     "status-info":          { "$value": "{color.blue.500}" },
-    "status-info-bg":       { "$value": "rgba(59, 130, 246, 0.12)" }
+    "status-info-bg":       { "$value": "rgba(59, 130, 246, 0.12)" },
+
+    "color-info-soft":      { "$value": "rgba(59, 130, 246, 0.12)", "$description": "Subtle informational background tint — Studio v0 cockpit info panels / hints (mirrors status-info-bg on dark)" }
   }
 }

--- a/packages/tokens-foundation/tokens/semantic/colors-light.json
+++ b/packages/tokens-foundation/tokens/semantic/colors-light.json
@@ -32,6 +32,8 @@
     "status-error":         { "$value": "{color.red.600}" },
     "status-error-bg":      { "$value": "rgba(220, 38, 38, 0.08)" },
     "status-info":          { "$value": "{color.blue.600}" },
-    "status-info-bg":       { "$value": "rgba(37, 99, 235, 0.08)" }
+    "status-info-bg":       { "$value": "rgba(37, 99, 235, 0.08)" },
+
+    "color-info-soft":      { "$value": "rgba(37, 99, 235, 0.08)", "$description": "Subtle informational background tint — Studio v0 cockpit info panels / hints (mirrors status-info-bg, exposed under semantic.color-* for product consumers)" }
   }
 }

--- a/packages/tokens-studio/package.json
+++ b/packages/tokens-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplify-ai/tokens-studio",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Amplify Magic Studio design tokens — Studio cockpit chrome, mirror/Map-mode voices, status scale; consumed only by studio.amplify.club",
   "main": "dist/tokens.js",
   "exports": {

--- a/packages/tokens-studio/tokens/theme-dark.json
+++ b/packages/tokens-studio/tokens/theme-dark.json
@@ -13,10 +13,32 @@
     },
     "layout": {
       "$type": "dimension",
-      "toolbar-h":      { "$value": "56px" },
-      "drawer-h":       { "$value": "48px" },
-      "drawer-h-open":  { "$value": "240px" },
-      "pane-left-w":    { "$value": "30%" }
+      "toolbar-h":          { "$value": "56px" },
+      "drawer-h":           { "$value": "48px" },
+      "drawer-h-open":      { "$value": "240px" },
+      "pane-left-w":        { "$value": "30%" },
+      "topbar-h":           { "$value": "56px",   "$description": "Studio v0 cockpit top bar height (Option D mockup)" },
+      "thread-max-w":       { "$value": "1180px", "$description": "Studio v0 cockpit thread / main column max width" },
+      "composer-max-w":     { "$value": "980px",  "$description": "Studio v0 sticky composer max width" },
+      "flow-sidebar-w":     { "$value": "260px",  "$description": "Studio v0 flow sidebar expanded width" },
+      "flow-sidebar-rail-w":{ "$value": "44px",   "$description": "Studio v0 flow sidebar collapsed rail width" },
+      "history-panel-w":    { "$value": "360px",  "$description": "Studio v0 history / runs panel width" },
+      "variant-card-h":     { "$value": "580px",  "$description": "Studio v0 variant card height" },
+      "variant-card-w":     { "$value": "268px",  "$description": "Studio v0 variant card width" }
+    },
+    "aspect": {
+      "$type": "dimension",
+      "$description": "Studio v0 device-frame aspect ratios for variant previews (Option D mockup) — values identical across themes",
+      "iphone-15-pro-max":  { "$value": "1 / 2.17" },
+      "iphone-15-pro":      { "$value": "1 / 2.17" },
+      "galaxy-s24":         { "$value": "1 / 2.17" },
+      "ipad-pro-13":        { "$value": "1 / 1.33" },
+      "ipad-air":           { "$value": "1 / 1.44" },
+      "apple-watch-ultra":  { "$value": "1 / 1.22" },
+      "apple-watch-9":      { "$value": "1 / 1.22" },
+      "mac":                { "$value": "1.6 / 1" },
+      "mac-1280":           { "$value": "1.6 / 1" },
+      "flow-thumb":         { "$value": "160 / 100" }
     },
     "map": {
       "$type": "color",

--- a/packages/tokens-studio/tokens/theme-light.json
+++ b/packages/tokens-studio/tokens/theme-light.json
@@ -13,10 +13,32 @@
     },
     "layout": {
       "$type": "dimension",
-      "toolbar-h":      { "$value": "56px",  "$description": "Top toolbar chrome height — paired with --studio-toolbar-h" },
-      "drawer-h":       { "$value": "48px",  "$description": "Bottom drawer collapsed height — paired with --studio-drawer-h" },
-      "drawer-h-open":  { "$value": "240px", "$description": "Bottom drawer expanded height — paired with --studio-drawer-h-open" },
-      "pane-left-w":    { "$value": "30%",   "$description": "Left brief pane width — paired with --studio-pane-left-w" }
+      "toolbar-h":          { "$value": "56px",   "$description": "Top toolbar chrome height — paired with --studio-toolbar-h" },
+      "drawer-h":           { "$value": "48px",   "$description": "Bottom drawer collapsed height — paired with --studio-drawer-h" },
+      "drawer-h-open":      { "$value": "240px",  "$description": "Bottom drawer expanded height — paired with --studio-drawer-h-open" },
+      "pane-left-w":        { "$value": "30%",    "$description": "Left brief pane width — paired with --studio-pane-left-w" },
+      "topbar-h":           { "$value": "56px",   "$description": "Studio v0 cockpit top bar height (Option D mockup)" },
+      "thread-max-w":       { "$value": "1180px", "$description": "Studio v0 cockpit thread / main column max width (Option D mockup)" },
+      "composer-max-w":     { "$value": "980px",  "$description": "Studio v0 sticky composer max width (Option D mockup)" },
+      "flow-sidebar-w":     { "$value": "260px",  "$description": "Studio v0 flow sidebar expanded width (Option D mockup)" },
+      "flow-sidebar-rail-w":{ "$value": "44px",   "$description": "Studio v0 flow sidebar collapsed rail width (Option D mockup)" },
+      "history-panel-w":    { "$value": "360px",  "$description": "Studio v0 history / runs panel width (Option D mockup)" },
+      "variant-card-h":     { "$value": "580px",  "$description": "Studio v0 variant card height (Option D mockup)" },
+      "variant-card-w":     { "$value": "268px",  "$description": "Studio v0 variant card width (Option D mockup)" }
+    },
+    "aspect": {
+      "$type": "dimension",
+      "$description": "Studio v0 device-frame aspect ratios for variant previews (Option D mockup)",
+      "iphone-15-pro-max":  { "$value": "1 / 2.17",  "$description": "iPhone 15 Pro Max device frame aspect" },
+      "iphone-15-pro":      { "$value": "1 / 2.17",  "$description": "iPhone 15 Pro device frame aspect" },
+      "galaxy-s24":         { "$value": "1 / 2.17",  "$description": "Samsung Galaxy S24 device frame aspect" },
+      "ipad-pro-13":        { "$value": "1 / 1.33",  "$description": "iPad Pro 13\" device frame aspect" },
+      "ipad-air":           { "$value": "1 / 1.44",  "$description": "iPad Air device frame aspect" },
+      "apple-watch-ultra":  { "$value": "1 / 1.22",  "$description": "Apple Watch Ultra device frame aspect" },
+      "apple-watch-9":      { "$value": "1 / 1.22",  "$description": "Apple Watch Series 9 device frame aspect" },
+      "mac":                { "$value": "1.6 / 1",   "$description": "MacBook / desktop landscape aspect" },
+      "mac-1280":           { "$value": "1.6 / 1",   "$description": "MacBook / desktop 1280-wide aspect" },
+      "flow-thumb":         { "$value": "160 / 100", "$description": "Flow thumbnail aspect (Studio v0 cockpit)" }
     },
     "map": {
       "$type": "color",


### PR DESCRIPTION
## Summary

Adds 23 design tokens needed by the Studio v0 cockpit (`magic-studio/docs/mockups/option-d.html`; spec at `magic-studio/docs/mockups/OPTION_D_SPEC.md`, merged via magic-studio#85).

## Token placement decision

Followed the task default (studio-prefixed for cockpit-only chrome; foundation for product-agnostic primitives) plus the existing token hierarchy already established in this repo.

| Category | Count | Package | Reason |
|---|---|---|---|
| `theme.layout.*` | 8 | `@amplify-ai/tokens-studio` | Cockpit chrome dimensions — only Studio consumes them |
| `theme.aspect.*` | 10 | `@amplify-ai/tokens-studio` | Variant device-frame ratios specific to Studio's variant gallery |
| `semantic.color-info-soft` | 1 | `@amplify-ai/tokens-foundation` | Generic info-tint background — useful for brand / atmosphere / creator too |
| `shadow.{ring-accent,composer,device}` | 3 | `@amplify-ai/tokens-foundation` | Generic elevation primitives — should cascade to every product |
| `semantic.border-accent` | 1 (reused) | already in `tokens-foundation` | The 5th semantic token in the spec — already exists in `colors-{light,dark}.json`. Not duplicated. `--amp-shadow-ring-accent` consumes it via `var()` at runtime. |

Total emitted: 23 new CSS custom properties (8 + 10 + 1 + 3 + 1 reused).

## Tokens added

### `@amplify-ai/tokens-studio` — `theme.layout.*` (8)
- `--amp-studio-theme-layout-topbar-h: 56px`
- `--amp-studio-theme-layout-thread-max-w: 1180px`
- `--amp-studio-theme-layout-composer-max-w: 980px`
- `--amp-studio-theme-layout-flow-sidebar-w: 260px`
- `--amp-studio-theme-layout-flow-sidebar-rail-w: 44px`
- `--amp-studio-theme-layout-history-panel-w: 360px`
- `--amp-studio-theme-layout-variant-card-h: 580px`
- `--amp-studio-theme-layout-variant-card-w: 268px`

### `@amplify-ai/tokens-studio` — `theme.aspect.*` (10)
- `--amp-studio-theme-aspect-iphone-15-pro-max: 1 / 2.17`
- `--amp-studio-theme-aspect-iphone-15-pro: 1 / 2.17`
- `--amp-studio-theme-aspect-galaxy-s24: 1 / 2.17`
- `--amp-studio-theme-aspect-ipad-pro-13: 1 / 1.33`
- `--amp-studio-theme-aspect-ipad-air: 1 / 1.44`
- `--amp-studio-theme-aspect-apple-watch-ultra: 1 / 1.22`
- `--amp-studio-theme-aspect-apple-watch-9: 1 / 1.22`
- `--amp-studio-theme-aspect-mac: 1.6 / 1`
- `--amp-studio-theme-aspect-mac-1280: 1.6 / 1`
- `--amp-studio-theme-aspect-flow-thumb: 160 / 100`

### `@amplify-ai/tokens-foundation` — semantic + shadow (4 new + 1 reused)
- `--amp-semantic-color-info-soft` — light `rgba(37, 99, 235, 0.08)`, dark `rgba(59, 130, 246, 0.12)`
- `--amp-shadow-ring-accent` — `0 0 0 2px var(--amp-semantic-border-accent)`
- `--amp-shadow-composer` — `0 -4px 12px -4px rgba(28, 25, 23, 0.08)`
- `--amp-shadow-device` — `0 12px 32px -8px rgba(28, 25, 23, 0.18), 0 4px 12px -4px rgba(28, 25, 23, 0.10)`
- `--amp-semantic-border-accent` — already exists, reused as-is

## Versioning

- `@amplify-ai/tokens-foundation`: `2.1.2` → `2.1.3`
- `@amplify-ai/tokens-studio`:     `1.0.2` → `1.0.3`

## Verification

- `npm run build`    — 5 token packages built; all 23 tokens emitted in `:root`, `[data-theme="dark"]`, and `@media (prefers-color-scheme: dark)` blocks. Foundation cascade verified through brand / atmosphere / creator (`--amp-{prefix}-shadow-ring-accent` etc).
- `npm run validate` — 0 errors / 0 warnings; all references resolve for both themes across all 5 token packages.
- `npm test`         — 263 / 263 passing in `@amplify-ai/ui`.
- `npm run lint`     — fails with **pre-existing** infra issues (`mcp-server` missing `@types/node`; `ui` missing `eslint.config.js` for ESLint v9). Both fail identically on `origin/main` — unrelated to this change.

## Publish (action required)

After merge, both bumped packages need `npm publish --access public --otp=<CODE>`. **OTP recovery codes from earlier in the session are exhausted** (npm rejects single-use codes after first use). User to generate fresh codes / authenticate before publish step.

## Test plan

- [ ] CI green
- [ ] Token drift check passes (Pixel `token-sync.ts`)
- [ ] After publish: `magic-studio` repo pulls `@amplify-ai/tokens-studio@1.0.3` and `@amplify-ai/tokens-foundation@2.1.3` and verifies `option-d.html` chrome consumes the new vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)