### PR TITLE
feat(ui): Canvas v2.13.0 — 6 new primitives for Studio v0 (LivePaneToggle, ReferenceSnapshotPill, DiffOverlay, FlowContextSidebar, RecentChangesPanel, ReplyAffordance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,97 @@
 
 All notable changes to the public packages of `amplify-design-system`.
 
+## 2.13.0 — 2026-05-08
+
+### Added (additive — `@amplify-ai/ui`)
+
+Studio v0 Wave 4 — six new primitives that ship the Magic Studio
+Option-D cockpit shell. Source-of-truth contracts:
+
+- `magic-studio/docs/mockups/option-d.html` (canonical mockup)
+- `magic-studio/docs/mockups/OPTION_D_SPEC.md` (binding spec)
+- `packages/ui/src/components/FlowSidebar/SPEC.md` (FlowSidebar v0
+  contract from PR #101 — implemented here as `FlowContextSidebar`)
+
+All six ship as `lifecycle.status=beta`, `since=2.13.0`. Pure additive —
+no breaking changes to existing primitives.
+
+- **`LivePaneToggle`** — 3-state segmented control (Live / Variants /
+  Split) for the Studio top bar. Distinct from the generic
+  `SegmentedControl` because it owns pane-state semantics: switching to
+  `live` or `split` is the consumer's signal to mount a live iframe of
+  `liveUrl`. Standard W3C radiogroup keyboard pattern with roving
+  tabindex; data-live-url surface for the consumer's iframe; honours
+  `prefers-reduced-motion`.
+- **`ReferenceSnapshotPill`** — "Reference snapshot · 3:42 PM" pill
+  rendered in the top bar after the first generate. Click opens the
+  original-screenshot modal (consumer-rendered). Time formatting
+  defaults to `Intl.DateTimeFormat` with locale-aware `h:mm a`; can be
+  overridden via `formatTime` for visual-regression-stable Storybook /
+  Chromatic snapshots. ISO `capturedAt` exposed via
+  `data-captured-at`; URL via `data-screenshot-url`.
+- **`DiffOverlay`** — red/green pixel-diff layer over the Live pane.
+  Three modes: `highlight` (translucent multiply bands + legend pill),
+  `swipe` (vertical curtain at `swipePercent` 0–100, defaults 50;
+  `clip-path` for clean curtain reveal), and `side-by-side` (1fr / 1fr
+  grid). `role="img"` with descriptive aria-label.
+- **`FlowContextSidebar`** — left-rail multi-step flow navigator
+  implementing the `FlowSidebar` v0 contract from PR #101 (with
+  Studio-scoped tokens). 260 px expanded / 44 px rail; per-step status
+  (`default` / `in-progress` / `complete` / `skipped`) drives chip
+  treatment + aria-label suffix; roving tabindex; `Enter` / `Space`
+  activate; `Home` / `End` jump first / last; `<a href>` chips render
+  as anchors but still emit `onStepClick`; sticky bottom Apply-to-all
+  action; collapse toggle with `aria-expanded` + `aria-controls`.
+  Empty `steps: []` returns `null` (consumer-gated render).
+- **`RecentChangesPanel`** — right side-panel listing the last N git
+  commits touching a file. 360 px width via
+  `--amp-studio-theme-layout-history-panel-w`; `role="complementary"`
+  with `aria-labelledby` linked to the heading; `Esc` closes; commits
+  with `url` render as `<a target="_blank" rel="noopener>`. Default
+  timestamp formatter uses `Intl.RelativeTimeFormat`; overridable.
+  Includes empty-state + single-commit fallbacks.
+- **`ReplyAffordance`** — hover-revealed pill on a `VariantCard` that
+  pre-fills the composer with `@V<n> (Gen <m>):`. Exposes the
+  reference syntax via `data-ref-syntax`; gen / variant via dedicated
+  data attributes for analytics. Native `<button>` semantics so
+  `Enter` / `Space` activate. Visibility is owned by the parent
+  `VariantCard`'s hover state — this primitive renders unconditionally.
+
+### Token usage
+
+All six primitives consume the existing `--amp-studio-theme-*` and
+`--amp-semantic-*` token surface that ships from
+`@amplify-ai/tokens-studio` 1.0.2 + the `--amp-semantic-*` alias block
+landed in 2.11.2 / 2.12.0. Two token references propose new tokens
+that the matching `tokens-studio` bump (sibling PR — token-bump
+sub-agent) will publish:
+
+- `--amp-studio-theme-layout-history-panel-w` (used by
+  `RecentChangesPanel`; default 360 px fallback).
+- `--amp-studio-theme-layout-flow-step-chip-h` (used by
+  `FlowContextSidebar`; default 64 px fallback).
+
+Both have inline `var(--name, fallback)` defaults, so the components
+render correctly even before the token-bump publishes. The
+`FlowSidebar` SPEC also calls for
+`--amp-studio-theme-layout-flow-sidebar-w` and
+`-flow-sidebar-rail-w` — both are already declared in
+`magic-studio/docs/mockups/OPTION_D_SPEC.md` §7 and ship in the
+sibling token-bump PR.
+
+### Versioned
+
+- `@amplify-ai/ui`: `2.12.0` → `2.13.0`
+
+### Publish gating
+
+This PR does NOT publish `@amplify-ai/ui@2.13.0` to npm. Publish is
+gated on the matching `tokens-studio` PR merging first so consumers
+picking up `@amplify-ai/ui` 2.13.0 alongside `@amplify-ai/tokens-studio`
+get a consistent token surface. The orchestrating coordinator handles
+the sequence.
+
 ## 2.11.2 — 2026-05-08
 
 ### Fixed (extended `--amp-semantic-*` alias block — all token packages)

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,0 +1,61 @@
+# `@amplify-ai/ui` Changelog
+
+Per-package changelog for `@amplify-ai/ui`. The full cross-package
+changelog lives at the repository root (`CHANGELOG.md`); this file
+mirrors the entries that touch this package only.
+
+## 2.13.0 — 2026-05-08
+
+### Added — six new Studio v0 primitives
+
+Studio v0 Wave 4 — six primitives that ship the Magic Studio
+Option-D cockpit shell. Source-of-truth contracts:
+
+- `magic-studio/docs/mockups/option-d.html` (canonical mockup)
+- `magic-studio/docs/mockups/OPTION_D_SPEC.md` (binding spec)
+- `packages/ui/src/components/FlowSidebar/SPEC.md` (FlowSidebar v0
+  contract from PR #101 — implemented here as `FlowContextSidebar`)
+
+All six ship as `lifecycle.status=beta`, `since=2.13.0`. Pure additive —
+no breaking changes to existing primitives.
+
+| Primitive | Main props | Stories |
+|---|---|---|
+| `LivePaneToggle` | `value: 'live' \| 'variants' \| 'split'`, `onChange`, `liveUrl?`, `disabled?` | Default, LiveActive, SplitActive, Disabled |
+| `ReferenceSnapshotPill` | `capturedAt: Date`, `screenshotUrl: string`, `onClick?`, `formatTime?`, `label?` | Default, CustomLabel, PinnedTimeFormat |
+| `DiffOverlay` | `liveScreenshot: string`, `variantScreenshot: string`, `mode: 'highlight' \| 'swipe' \| 'side-by-side'`, `swipePercent?`, `showLegend?` | Highlight, Swipe, SwipeAt70, SideBySide |
+| `FlowContextSidebar` | `flowName`, `steps: FlowStep[]`, `activeStepId`, `collapsed?`, `onStepClick?`, `onCollapse?`, `onApplyToAll?`, `applyToAllLabel?` | Default, MixedStatus, WithApplyToAll, Collapsed, LongList, Empty |
+| `RecentChangesPanel` | `filePath`, `commits: GitCommit[]`, `onClose`, `formatTime?` | Default, Empty, SingleCommit |
+| `ReplyAffordance` | `variantRef: { gen: number; variant: number \| string }`, `onClick`, `label?` | Default, LetterKey, CustomLabel, InVariantCardContext |
+
+### Token references
+
+- All primitives consume the `--amp-studio-theme-*` + `--amp-semantic-*`
+  token surface already shipping from `@amplify-ai/tokens-studio` 1.0.2.
+- `FlowContextSidebar` references three new layout tokens (declared in
+  `magic-studio/docs/mockups/OPTION_D_SPEC.md` §7 and in the sibling
+  `tokens-studio` PR):
+  - `--amp-studio-theme-layout-flow-sidebar-w` (260 px)
+  - `--amp-studio-theme-layout-flow-sidebar-rail-w` (44 px)
+  - `--amp-studio-theme-layout-flow-step-chip-h` (64 px)
+- `RecentChangesPanel` references
+  `--amp-studio-theme-layout-history-panel-w` (360 px).
+- All four have inline `var(--name, fallback)` defaults so the
+  components render correctly even before the token-bump publishes.
+
+### Versioned
+
+- `@amplify-ai/ui`: `2.12.0` → `2.13.0`
+
+### Publish gating
+
+This PR does NOT publish `@amplify-ai/ui@2.13.0` to npm. Publish is
+gated on the matching `tokens-studio` PR merging first so consumers
+picking up `@amplify-ai/ui` 2.13.0 alongside
+`@amplify-ai/tokens-studio` get a consistent token surface. The
+orchestrating coordinator handles the sequence.
+
+## Earlier versions
+
+See the cross-package root changelog
+([`CHANGELOG.md`](../../CHANGELOG.md)) for entries before 2.13.0.

--- a/packages/ui/component-status.json
+++ b/packages/ui/component-status.json
@@ -115,6 +115,12 @@
     "MapEdge": { "status": "beta", "since": "2.10.0", "notes": "Studio v2 Map mode — SVG <path>-only edge primitive (consumer wraps in <svg>); cubic-bezier connector with active/dashed states." },
     "PhaseRibbon": { "status": "beta", "since": "2.11.0", "notes": "Studio v2 Wave 3 — numbered phase indicator (1 → 2 → 3 → 4) above a workflow; pending/active/done/error states; aria-current=step on the active phase." },
     "SegmentedControl": { "status": "beta", "since": "2.11.0", "notes": "Studio v2 Wave 3 — generalised two-or-more-button segmented control with sliding accent highlight; W3C radiogroup keyboard pattern; honours prefers-reduced-motion and density." },
-    "StatusBar": { "status": "beta", "since": "2.11.0", "notes": "Studio v2 Wave 3 — slim ~24px horizontal status strip; dl/dt/dd semantics; mono variant for SHAs/versions; align=between for left/right split footers." }
+    "StatusBar": { "status": "beta", "since": "2.11.0", "notes": "Studio v2 Wave 3 — slim ~24px horizontal status strip; dl/dt/dd semantics; mono variant for SHAs/versions; align=between for left/right split footers." },
+    "LivePaneToggle": { "status": "beta", "since": "2.13.0", "notes": "Studio v0 Wave 4 — 3-state Live/Variants/Split pane control for the Magic Studio cockpit; W3C radiogroup keyboard pattern; data-live-url surface for the consumer's iframe." },
+    "ReferenceSnapshotPill": { "status": "beta", "since": "2.13.0", "notes": "Studio v0 Wave 4 — 'Reference snapshot taken at HH:MM' pill rendered in the Studio top-bar; click opens the original-screenshot modal (consumer-rendered)." },
+    "DiffOverlay": { "status": "beta", "since": "2.13.0", "notes": "Studio v0 Wave 4 — red/green pixel-diff layer over the Live pane; modes: highlight (mix-blend-multiply bands + legend) / swipe (vertical curtain) / side-by-side (1fr/1fr grid)." },
+    "FlowContextSidebar": { "status": "beta", "since": "2.13.0", "notes": "Studio v0 Wave 4 — left-rail multi-step flow navigator implementing FlowSidebar SPEC v0 (PR #101); 260px expanded / 44px rail; status (default/in-progress/complete/skipped); roving tabindex; href|button chips; sticky Apply-to-all." },
+    "RecentChangesPanel": { "status": "beta", "since": "2.13.0", "notes": "Studio v0 Wave 4 — right side-panel listing the last N git commits touching a file; 360px width via --amp-studio-theme-layout-history-panel-w; Esc closes." },
+    "ReplyAffordance": { "status": "beta", "since": "2.13.0", "notes": "Studio v0 Wave 4 — hover-revealed pill on a VariantCard that pre-fills the composer with @V<n> (Gen <m>): for chained iteration." }
   }
 }

--- a/packages/ui/dist/contracts.json
+++ b/packages/ui/dist/contracts.json
@@ -1,11 +1,11 @@
 {
-  "generatedAt": "2026-05-08T19:04:36.415Z",
+  "generatedAt": "2026-05-09T09:58:05.031Z",
   "tsVersion": "5.9.3",
-  "componentCount": 114,
+  "componentCount": 120,
   "statusBreakdown": {
     "stable": 46,
     "alpha": 15,
-    "beta": 53
+    "beta": 59
   },
   "components": [
     {
@@ -496,6 +496,21 @@
       }
     },
     {
+      "name": "DiffOverlay",
+      "contract": "contracts/DiffOverlay.json",
+      "filePath": "packages/ui/src/components/DiffOverlay/DiffOverlay.tsx",
+      "kind": "forwardRef",
+      "variants": null,
+      "sizes": null,
+      "propCount": 7,
+      "subcomponents": [],
+      "lifecycle": {
+        "status": "beta",
+        "since": "2.13.0",
+        "notes": "Studio v0 Wave 4 — red/green pixel-diff layer over the Live pane; modes: highlight (mix-blend-multiply bands + legend) / swipe (vertical curtain) / side-by-side (1fr/1fr grid)."
+      }
+    },
+    {
       "name": "Drawer",
       "contract": "contracts/Drawer.json",
       "filePath": "packages/ui/src/components/Drawer/Drawer.tsx",
@@ -639,6 +654,21 @@
       "lifecycle": {
         "status": "stable",
         "since": "1.0.0"
+      }
+    },
+    {
+      "name": "FlowContextSidebar",
+      "contract": "contracts/FlowContextSidebar.json",
+      "filePath": "packages/ui/src/components/FlowContextSidebar/FlowContextSidebar.tsx",
+      "kind": "function",
+      "variants": null,
+      "sizes": null,
+      "propCount": 9,
+      "subcomponents": [],
+      "lifecycle": {
+        "status": "beta",
+        "since": "2.13.0",
+        "notes": "Studio v0 Wave 4 — left-rail multi-step flow navigator implementing FlowSidebar SPEC v0 (PR #101); 260px expanded / 44px rail; status (default/in-progress/complete/skipped); roving tabindex; href|button chips; sticky Apply-to-all."
       }
     },
     {
@@ -917,6 +947,21 @@
       "lifecycle": {
         "status": "beta",
         "since": "2.3.0"
+      }
+    },
+    {
+      "name": "LivePaneToggle",
+      "contract": "contracts/LivePaneToggle.json",
+      "filePath": "packages/ui/src/components/LivePaneToggle/LivePaneToggle.tsx",
+      "kind": "forwardRef",
+      "variants": null,
+      "sizes": null,
+      "propCount": 6,
+      "subcomponents": [],
+      "lifecycle": {
+        "status": "beta",
+        "since": "2.13.0",
+        "notes": "Studio v0 Wave 4 — 3-state Live/Variants/Split pane control for the Magic Studio cockpit; W3C radiogroup keyboard pattern; data-live-url surface for the consumer's iframe."
       }
     },
     {
@@ -1286,6 +1331,21 @@
       }
     },
     {
+      "name": "RecentChangesPanel",
+      "contract": "contracts/RecentChangesPanel.json",
+      "filePath": "packages/ui/src/components/RecentChangesPanel/RecentChangesPanel.tsx",
+      "kind": "function",
+      "variants": null,
+      "sizes": null,
+      "propCount": 5,
+      "subcomponents": [],
+      "lifecycle": {
+        "status": "beta",
+        "since": "2.13.0",
+        "notes": "Studio v0 Wave 4 — right side-panel listing the last N git commits touching a file; 360px width via --amp-studio-theme-layout-history-panel-w; Esc closes."
+      }
+    },
+    {
       "name": "RecoReason",
       "contract": "contracts/RecoReason.json",
       "filePath": "packages/ui/src/components/RecoReason/RecoReason.tsx",
@@ -1297,6 +1357,36 @@
       "lifecycle": {
         "status": "stable",
         "since": "1.0.0"
+      }
+    },
+    {
+      "name": "ReferenceSnapshotPill",
+      "contract": "contracts/ReferenceSnapshotPill.json",
+      "filePath": "packages/ui/src/components/ReferenceSnapshotPill/ReferenceSnapshotPill.tsx",
+      "kind": "forwardRef",
+      "variants": null,
+      "sizes": null,
+      "propCount": 6,
+      "subcomponents": [],
+      "lifecycle": {
+        "status": "beta",
+        "since": "2.13.0",
+        "notes": "Studio v0 Wave 4 — 'Reference snapshot taken at HH:MM' pill rendered in the Studio top-bar; click opens the original-screenshot modal (consumer-rendered)."
+      }
+    },
+    {
+      "name": "ReplyAffordance",
+      "contract": "contracts/ReplyAffordance.json",
+      "filePath": "packages/ui/src/components/ReplyAffordance/ReplyAffordance.tsx",
+      "kind": "forwardRef",
+      "variants": null,
+      "sizes": null,
+      "propCount": 4,
+      "subcomponents": [],
+      "lifecycle": {
+        "status": "beta",
+        "since": "2.13.0",
+        "notes": "Studio v0 Wave 4 — hover-revealed pill on a VariantCard that pre-fills the composer with @V<n> (Gen <m>): for chained iteration."
       }
     },
     {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplify-ai/ui",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Shared UI components for Amplify products \u2014 Brand, Creator, and Atmosphere",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/ui/src/components/DiffOverlay/DiffOverlay.stories.tsx
+++ b/packages/ui/src/components/DiffOverlay/DiffOverlay.stories.tsx
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { DiffOverlay } from './DiffOverlay';
+
+/**
+ * `DiffOverlay` is the red/green pixel-diff layer painted on top of the
+ * Magic Studio Live pane in the Option-D cockpit
+ * (`magic-studio/docs/mockups/option-d.html`, region R15).
+ *
+ * Mockup region:
+ *
+ * ```html
+ * <div class="diff-overlay" aria-hidden="true"></div>
+ * <div class="diff-legend">
+ *   <div class="lg-row"><span class="sw add"></span>Added</div>
+ *   <div class="lg-row"><span class="sw rm"></span>Removed</div>
+ * </div>
+ * ```
+ *
+ * Spec: `magic-studio/docs/mockups/OPTION_D_SPEC.md` §1 R15, §2 C3, §4 I9.
+ */
+const meta = {
+  title: 'Studio v0/DiffOverlay',
+  component: DiffOverlay,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    status: { type: 'beta' },
+  },
+} satisfies Meta<typeof DiffOverlay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Inline data-URI placeholders so stories render in offline / no-network
+// Chromatic environments without depending on a CDN. Each is a tiny SVG
+// rectangle in a token-friendly grey.
+const liveShot =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 480">' +
+      '<rect width="320" height="480" fill="%23eef0f3"/>' +
+      '<text x="50%" y="50%" font-family="sans-serif" font-size="20" fill="%23222" text-anchor="middle">LIVE PAGE</text>' +
+      '</svg>',
+  );
+const variantShot =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 480">' +
+      '<rect width="320" height="480" fill="%23dde7ff"/>' +
+      '<text x="50%" y="50%" font-family="sans-serif" font-size="20" fill="%23222" text-anchor="middle">VARIANT</text>' +
+      '</svg>',
+  );
+
+const Wrap: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <div style={{ width: 320, height: 480, position: 'relative' }}>{children}</div>
+);
+
+/**
+ * `mode='highlight'` — the canonical Option-D state. Translucent green
+ * (added) and red (removed) bands layered with mix-blend-multiply over
+ * the live page; legend pill top-right.
+ */
+export const Highlight: Story = {
+  render: () => (
+    <Wrap>
+      <DiffOverlay
+        liveScreenshot={liveShot}
+        variantScreenshot={variantShot}
+        mode="highlight"
+      />
+    </Wrap>
+  ),
+  args: {
+    liveScreenshot: liveShot,
+    variantScreenshot: variantShot,
+    mode: 'highlight',
+  },
+};
+
+/**
+ * `mode='swipe'` — vertical curtain at 50% (default). Variant occupies
+ * the left side; live page on the right.
+ */
+export const Swipe: Story = {
+  render: () => (
+    <Wrap>
+      <DiffOverlay
+        liveScreenshot={liveShot}
+        variantScreenshot={variantShot}
+        mode="swipe"
+      />
+    </Wrap>
+  ),
+  args: {
+    liveScreenshot: liveShot,
+    variantScreenshot: variantShot,
+    mode: 'swipe',
+  },
+};
+
+/** `mode='swipe'` curtain at 70% — variant occupies the larger area. */
+export const SwipeAt70: Story = {
+  render: () => (
+    <Wrap>
+      <DiffOverlay
+        liveScreenshot={liveShot}
+        variantScreenshot={variantShot}
+        mode="swipe"
+        swipePercent={70}
+      />
+    </Wrap>
+  ),
+  args: {
+    liveScreenshot: liveShot,
+    variantScreenshot: variantShot,
+    mode: 'swipe',
+    swipePercent: 70,
+  },
+};
+
+/** `mode='side-by-side'` — both screenshots in a 1fr / 1fr grid. */
+export const SideBySide: Story = {
+  render: () => (
+    <Wrap>
+      <DiffOverlay
+        liveScreenshot={liveShot}
+        variantScreenshot={variantShot}
+        mode="side-by-side"
+      />
+    </Wrap>
+  ),
+  args: {
+    liveScreenshot: liveShot,
+    variantScreenshot: variantShot,
+    mode: 'side-by-side',
+  },
+};

--- a/packages/ui/src/components/DiffOverlay/DiffOverlay.test.tsx
+++ b/packages/ui/src/components/DiffOverlay/DiffOverlay.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { DiffOverlay, type DiffOverlayMode } from './DiffOverlay';
+
+afterEach(cleanup);
+
+const LIVE = 'https://shots.example.com/live.png';
+const VARIANT = 'https://shots.example.com/variant.png';
+
+const renderOverlay = (
+  mode: DiffOverlayMode = 'highlight',
+  overrides: Partial<React.ComponentProps<typeof DiffOverlay>> = {},
+) =>
+  render(
+    <DiffOverlay
+      liveScreenshot={LIVE}
+      variantScreenshot={VARIANT}
+      mode={mode}
+      {...overrides}
+    />,
+  );
+
+describe('DiffOverlay', () => {
+  it('always renders the live screenshot as the base layer', () => {
+    renderOverlay('highlight');
+    const live = screen.getByTestId('diff-overlay-live') as HTMLImageElement;
+    expect(live.src).toBe(LIVE);
+  });
+
+  it('mode=highlight renders the red/green band layer + legend by default', () => {
+    renderOverlay('highlight');
+    expect(screen.getByTestId('diff-overlay-highlight')).toBeDefined();
+    expect(screen.getByTestId('diff-overlay-legend')).toBeDefined();
+    expect(screen.queryByTestId('diff-overlay-swipe')).toBeNull();
+    expect(screen.queryByTestId('diff-overlay-side')).toBeNull();
+  });
+
+  it('mode=swipe renders the swipe layer + divider; no highlight band; no default legend', () => {
+    renderOverlay('swipe');
+    expect(screen.getByTestId('diff-overlay-swipe')).toBeDefined();
+    expect(screen.getByTestId('diff-overlay-swipe-divider')).toBeDefined();
+    expect(screen.queryByTestId('diff-overlay-highlight')).toBeNull();
+    expect(screen.queryByTestId('diff-overlay-side')).toBeNull();
+    expect(screen.queryByTestId('diff-overlay-legend')).toBeNull();
+  });
+
+  it('mode=side-by-side renders the side grid; no highlight band; no default legend', () => {
+    renderOverlay('side-by-side');
+    expect(screen.getByTestId('diff-overlay-side')).toBeDefined();
+    expect(screen.queryByTestId('diff-overlay-highlight')).toBeNull();
+    expect(screen.queryByTestId('diff-overlay-swipe')).toBeNull();
+    expect(screen.queryByTestId('diff-overlay-legend')).toBeNull();
+  });
+
+  it('legend can be force-shown for non-highlight modes via showLegend', () => {
+    renderOverlay('swipe', { showLegend: true });
+    expect(screen.getByTestId('diff-overlay-legend')).toBeDefined();
+  });
+
+  it('legend can be hidden for highlight via showLegend=false', () => {
+    renderOverlay('highlight', { showLegend: false });
+    expect(screen.queryByTestId('diff-overlay-legend')).toBeNull();
+  });
+
+  it('swipePercent positions the divider at the given percentage', () => {
+    renderOverlay('swipe', { swipePercent: 70 });
+    const divider = screen.getByTestId('diff-overlay-swipe-divider') as HTMLElement;
+    expect(divider.style.left).toBe('70%');
+  });
+
+  it('swipePercent clamps below 0 to 0 and above 100 to 100', () => {
+    const { rerender } = renderOverlay('swipe', { swipePercent: -25 });
+    expect(
+      (screen.getByTestId('diff-overlay-swipe-divider') as HTMLElement).style.left,
+    ).toBe('0%');
+    rerender(
+      <DiffOverlay
+        liveScreenshot={LIVE}
+        variantScreenshot={VARIANT}
+        mode="swipe"
+        swipePercent={250}
+      />,
+    );
+    expect(
+      (screen.getByTestId('diff-overlay-swipe-divider') as HTMLElement).style.left,
+    ).toBe('100%');
+  });
+
+  it('exposes mode via data-mode attribute', () => {
+    renderOverlay('side-by-side');
+    expect(
+      screen.getByTestId('diff-overlay').getAttribute('data-mode'),
+    ).toBe('side-by-side');
+  });
+
+  it('has role="img" and an accessible name', () => {
+    renderOverlay('highlight');
+    const overlay = screen.getByTestId('diff-overlay');
+    expect(overlay.getAttribute('role')).toBe('img');
+    expect(overlay.getAttribute('aria-label')).toBe('Live vs variant diff');
+  });
+
+  it('honours custom ariaLabel', () => {
+    renderOverlay('highlight', { ariaLabel: 'Order page diff (Gen 3 V2)' });
+    expect(
+      screen.getByTestId('diff-overlay').getAttribute('aria-label'),
+    ).toBe('Order page diff (Gen 3 V2)');
+  });
+
+  it('does NOT inject hardcoded hex colours into the rendered DOM', () => {
+    const { container } = renderOverlay('highlight');
+    expect(container.innerHTML).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+  });
+
+  it('does NOT inject inline px appearance values', () => {
+    const { container } = renderOverlay('highlight');
+    expect(container.innerHTML).not.toMatch(/style="[^"]*\d+px/);
+  });
+});

--- a/packages/ui/src/components/DiffOverlay/DiffOverlay.tsx
+++ b/packages/ui/src/components/DiffOverlay/DiffOverlay.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+/**
+ * DiffOverlay — red/green pixel-diff layer rendered on top of the Magic
+ * Studio Live pane (`magic-studio/docs/mockups/option-d.html`, region R15).
+ *
+ * The overlay surfaces three modes:
+ *
+ * - `highlight` — translucent red (removed) / green (added) bands layered
+ *   on the live page (`mix-blend-mode: multiply`); a small legend pill is
+ *   rendered top-right so users can decode the colours. Matches the
+ *   `.diff-overlay` + `.diff-legend` blocks in the canonical mockup.
+ * - `swipe`     — a vertical curtain at `swipePercent` (0–100) divides
+ *   the variant (left) from the live page (right). Drag handles live in
+ *   the consumer.
+ * - `side-by-side` — renders both screenshots in a 1fr / 1fr grid.
+ *
+ * The component is presentational. It takes the URLs of pre-captured
+ * screenshots; the consumer wires loading states and the live iframe.
+ * Rendering the legend can be disabled with `showLegend={false}`.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type DiffOverlayMode = 'highlight' | 'swipe' | 'side-by-side';
+
+export interface DiffOverlayProps {
+  /** URL of the live (current) page screenshot. */
+  liveScreenshot: string;
+  /** URL of the candidate variant screenshot. */
+  variantScreenshot: string;
+  /** Diff visualisation mode. */
+  mode: DiffOverlayMode;
+  /**
+   * Curtain position 0–100 for `mode='swipe'`. Default 50. Ignored when
+   * mode is not `'swipe'`.
+   */
+  swipePercent?: number;
+  /** When `true`, renders the colour-key pill (default true for `highlight`). */
+  showLegend?: boolean;
+  /** Optional accessible label override. */
+  ariaLabel?: string;
+  /** Optional className passthrough on the outer element. */
+  className?: string;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export const DiffOverlay = React.forwardRef<HTMLDivElement, DiffOverlayProps>(
+  function DiffOverlay(
+    {
+      liveScreenshot,
+      variantScreenshot,
+      mode,
+      swipePercent = 50,
+      showLegend,
+      ariaLabel = 'Live vs variant diff',
+      className,
+    },
+    ref,
+  ) {
+    const clampedSwipe = Math.max(0, Math.min(100, swipePercent));
+    const legendVisible = showLegend ?? mode === 'highlight';
+
+    return (
+      <div
+        ref={ref}
+        role="img"
+        aria-label={ariaLabel}
+        data-mode={mode}
+        data-testid="diff-overlay"
+        className={cn(
+          'relative h-full w-full overflow-hidden',
+          'rounded-[var(--amp-radius-md)]',
+          className,
+        )}
+      >
+        {/* Live screenshot — the base layer */}
+        <img
+          src={liveScreenshot}
+          alt=""
+          aria-hidden="true"
+          data-testid="diff-overlay-live"
+          className="absolute inset-0 h-full w-full object-cover"
+        />
+
+        {/* mode === 'highlight' — translucent red/green bands */}
+        {mode === 'highlight' && (
+          <div
+            data-testid="diff-overlay-highlight"
+            aria-hidden="true"
+            className={cn(
+              'pointer-events-none absolute inset-0',
+              'mix-blend-multiply',
+              'bg-[linear-gradient(180deg,var(--amp-semantic-color-success-soft)_0%,var(--amp-semantic-color-success-soft)_18%,transparent_18%,transparent_42%,var(--amp-semantic-color-danger-soft)_42%,var(--amp-semantic-color-danger-soft)_60%,transparent_60%)]',
+            )}
+          />
+        )}
+
+        {/* mode === 'swipe' — vertical curtain. The variant image is
+         * absolutely positioned at the wrapper's full size; the curtain
+         * div clips it via overflow + clip-path so the visible slice
+         * sits flush with the underlying live image. */}
+        {mode === 'swipe' && (
+          <>
+            <div
+              data-testid="diff-overlay-swipe"
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-0 overflow-hidden"
+              style={{
+                clipPath: `inset(0 ${100 - clampedSwipe}% 0 0)`,
+              }}
+            >
+              <img
+                src={variantScreenshot}
+                alt=""
+                aria-hidden="true"
+                className="absolute inset-0 h-full w-full object-cover"
+              />
+            </div>
+            <div
+              data-testid="diff-overlay-swipe-divider"
+              aria-hidden="true"
+              className={cn(
+                'pointer-events-none absolute inset-y-0',
+                'w-px bg-[var(--amp-studio-theme-color-fg)]',
+              )}
+              style={{ left: `${clampedSwipe}%` }}
+            />
+          </>
+        )}
+
+        {/* mode === 'side-by-side' — 1fr / 1fr grid above the base */}
+        {mode === 'side-by-side' && (
+          <div
+            data-testid="diff-overlay-side"
+            aria-hidden="true"
+            className={cn(
+              'absolute inset-0 grid grid-cols-2',
+              'gap-[var(--amp-spacing-2)]',
+              'bg-[var(--amp-studio-theme-color-bg-elev)]',
+            )}
+          >
+            <img
+              src={liveScreenshot}
+              alt=""
+              aria-hidden="true"
+              className="h-full w-full object-cover"
+            />
+            <img
+              src={variantScreenshot}
+              alt=""
+              aria-hidden="true"
+              className="h-full w-full object-cover"
+            />
+          </div>
+        )}
+
+        {legendVisible && (
+          <div
+            data-testid="diff-overlay-legend"
+            className={cn(
+              'absolute right-[var(--amp-spacing-4)] top-[var(--amp-spacing-4)]',
+              'flex flex-col gap-[var(--amp-spacing-1)]',
+              'rounded-[var(--amp-radius-md)] border',
+              'border-[var(--amp-studio-theme-color-border)]',
+              'bg-[var(--amp-studio-theme-color-bg-elev)]',
+              'px-[var(--amp-spacing-3)] py-[var(--amp-spacing-2)]',
+              'text-[var(--amp-font-size-xs)] text-[var(--amp-studio-theme-color-fg)]',
+              'shadow-[var(--amp-shadow-sm)]',
+            )}
+          >
+            <div className="flex items-center gap-[var(--amp-spacing-2)]">
+              <span
+                aria-hidden="true"
+                className="inline-block size-3 rounded-[var(--amp-radius-xs)] bg-[var(--amp-semantic-color-success-soft)]"
+              />
+              <span>Added</span>
+            </div>
+            <div className="flex items-center gap-[var(--amp-spacing-2)]">
+              <span
+                aria-hidden="true"
+                className="inline-block size-3 rounded-[var(--amp-radius-xs)] bg-[var(--amp-semantic-color-danger-soft)]"
+              />
+              <span>Removed</span>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+DiffOverlay.displayName = 'DiffOverlay';

--- a/packages/ui/src/components/DiffOverlay/index.ts
+++ b/packages/ui/src/components/DiffOverlay/index.ts
@@ -1,0 +1,2 @@
+export { DiffOverlay } from './DiffOverlay';
+export type { DiffOverlayProps, DiffOverlayMode } from './DiffOverlay';

--- a/packages/ui/src/components/FlowContextSidebar/FlowContextSidebar.stories.tsx
+++ b/packages/ui/src/components/FlowContextSidebar/FlowContextSidebar.stories.tsx
@@ -1,0 +1,209 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { FlowContextSidebar, type FlowStep } from './FlowContextSidebar';
+
+/**
+ * `FlowContextSidebar` is the left-rail multi-step navigator used in the
+ * Magic Studio Option-D cockpit
+ * (`magic-studio/docs/mockups/option-d.html`, region R5). Implements the
+ * `FlowSidebar` v0 contract from
+ * `packages/ui/src/components/FlowSidebar/SPEC.md` (PR #101).
+ *
+ * Mockup region:
+ *
+ * ```html
+ * <aside class="flow-side">
+ *   <div class="head">
+ *     <div class="title-block">
+ *       <div class="title">Brand Order</div>
+ *       <div class="sub">5 steps</div>
+ *     </div>
+ *     <button class="collapse">‹</button>
+ *   </div>
+ *   <div class="steps">
+ *     <div class="step-card active">…</div>
+ *     <div class="step-card">…</div>
+ *   </div>
+ *   <div class="foot">
+ *     <button class="apply-all">Apply brief to all 5 steps</button>
+ *   </div>
+ * </aside>
+ * ```
+ *
+ * Spec: `magic-studio/docs/mockups/OPTION_D_SPEC.md` §1 R5, §2 C4, §4 I13–I15.
+ */
+const meta = {
+  title: 'Studio v0/FlowContextSidebar',
+  component: FlowContextSidebar,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    status: { type: 'beta' },
+  },
+} satisfies Meta<typeof FlowContextSidebar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const Frame: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <div style={{ height: 600, display: 'flex' }}>{children}</div>
+);
+
+const fiveSteps: FlowStep[] = [
+  { id: 's1', label: 'Step 1 · Brief', status: 'complete' },
+  { id: 's2', label: 'Step 2 · Package', status: 'in-progress' },
+  { id: 's3', label: 'Step 3 · Visuals', status: 'default' },
+  { id: 's4', label: 'Step 4 · Review', status: 'default' },
+  { id: 's5', label: 'Step 5 · Ship', status: 'default' },
+];
+
+const fiveStepsMixed: FlowStep[] = [
+  { id: 's1', label: 'Step 1 · Brief', status: 'complete' },
+  {
+    id: 's2',
+    label: 'Step 2 · Package',
+    status: 'in-progress',
+    badge: { count: 3, tone: 'accent' },
+  },
+  { id: 's3', label: 'Step 3 · Visuals', status: 'default' },
+  { id: 's4', label: 'Step 4 · Review', status: 'skipped' },
+  { id: 's5', label: 'Step 5 · Ship', status: 'default' },
+];
+
+/** Default — 5 steps, step 2 active, no thumbnails. */
+export const Default: Story = {
+  render: () => {
+    const [active, setActive] = React.useState('s2');
+    return (
+      <Frame>
+        <FlowContextSidebar
+          flowName="Brand Order — 5 steps"
+          steps={fiveSteps}
+          activeStepId={active}
+          onStepClick={setActive}
+        />
+      </Frame>
+    );
+  },
+  args: {
+    flowName: 'Brand Order — 5 steps',
+    steps: fiveSteps,
+    activeStepId: 's2',
+  },
+};
+
+/** Mixed status — complete / in-progress / skipped + accent badge. */
+export const MixedStatus: Story = {
+  render: () => {
+    const [active, setActive] = React.useState('s2');
+    return (
+      <Frame>
+        <FlowContextSidebar
+          flowName="Brand Order — 5 steps"
+          steps={fiveStepsMixed}
+          activeStepId={active}
+          onStepClick={setActive}
+        />
+      </Frame>
+    );
+  },
+  args: {
+    flowName: 'Brand Order — 5 steps',
+    steps: fiveStepsMixed,
+    activeStepId: 's2',
+  },
+};
+
+/** Apply-to-all variant — bottom action button visible. */
+export const WithApplyToAll: Story = {
+  render: () => {
+    const [active, setActive] = React.useState('s2');
+    return (
+      <Frame>
+        <FlowContextSidebar
+          flowName="Brand Order — 5 steps"
+          steps={fiveSteps}
+          activeStepId={active}
+          onStepClick={setActive}
+          onApplyToAll={() => undefined}
+          applyToAllLabel="Apply brief to all 5 steps"
+        />
+      </Frame>
+    );
+  },
+  args: {
+    flowName: 'Brand Order — 5 steps',
+    steps: fiveSteps,
+    activeStepId: 's2',
+    onApplyToAll: () => undefined,
+  },
+};
+
+/** Collapsed — 44px rail of step pips. */
+export const Collapsed: Story = {
+  render: () => {
+    const [collapsed, setCollapsed] = React.useState(true);
+    const [active, setActive] = React.useState('s2');
+    return (
+      <Frame>
+        <FlowContextSidebar
+          flowName="Brand Order — 5 steps"
+          steps={fiveSteps}
+          activeStepId={active}
+          collapsed={collapsed}
+          onCollapse={setCollapsed}
+          onStepClick={setActive}
+        />
+      </Frame>
+    );
+  },
+  args: {
+    flowName: 'Brand Order — 5 steps',
+    steps: fiveSteps,
+    activeStepId: 's2',
+    collapsed: true,
+  },
+};
+
+/** Long list — 12 steps demonstrating sticky header + scrolling. */
+export const LongList: Story = {
+  render: () => {
+    const longSteps: FlowStep[] = Array.from({ length: 12 }, (_, i) => ({
+      id: `s${i + 1}`,
+      label: `Step ${i + 1} · Lorem ipsum`,
+      status: i < 4 ? 'complete' : i === 4 ? 'in-progress' : 'default',
+    }));
+    return (
+      <Frame>
+        <FlowContextSidebar
+          flowName="Brand Order — 12 steps"
+          steps={longSteps}
+          activeStepId="s5"
+          onApplyToAll={() => undefined}
+        />
+      </Frame>
+    );
+  },
+  args: {
+    flowName: 'Brand Order — 12 steps',
+    steps: [],
+    activeStepId: 's5',
+  },
+};
+
+/**
+ * Empty — `steps: []` returns null. Story documents that consumers must
+ * gate render on `steps.length > 0` (no skeleton).
+ */
+export const Empty: Story = {
+  render: () => (
+    <Frame>
+      <FlowContextSidebar flowName="No flow" steps={[]} activeStepId="" />
+    </Frame>
+  ),
+  args: {
+    flowName: 'No flow',
+    steps: [],
+    activeStepId: '',
+  },
+};

--- a/packages/ui/src/components/FlowContextSidebar/FlowContextSidebar.test.tsx
+++ b/packages/ui/src/components/FlowContextSidebar/FlowContextSidebar.test.tsx
@@ -1,0 +1,369 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import {
+  FlowContextSidebar,
+  type FlowStep,
+} from './FlowContextSidebar';
+
+afterEach(cleanup);
+
+const fiveSteps: FlowStep[] = [
+  { id: 's1', label: 'Step 1 · Brief', status: 'complete' },
+  { id: 's2', label: 'Step 2 · Package', status: 'in-progress' },
+  { id: 's3', label: 'Step 3 · Visuals', status: 'default' },
+  { id: 's4', label: 'Step 4 · Review', status: 'skipped' },
+  { id: 's5', label: 'Step 5 · Ship', status: 'default' },
+];
+
+describe('FlowContextSidebar', () => {
+  it('renders a navigation landmark with the configured aria-label', () => {
+    render(
+      <FlowContextSidebar
+        flowName="Brand Order — 5 steps"
+        steps={fiveSteps}
+        activeStepId="s2"
+      />,
+    );
+    expect(screen.getByRole('navigation', { name: 'Flow steps' })).toBeDefined();
+  });
+
+  it('renders all step labels', () => {
+    render(
+      <FlowContextSidebar
+        flowName="Brand Order"
+        steps={fiveSteps}
+        activeStepId="s1"
+      />,
+    );
+    fiveSteps.forEach((s) => {
+      expect(screen.getAllByText((text) => text.includes(s.label)).length).toBeGreaterThan(0);
+    });
+  });
+
+  it('renders the flow name in the sticky header', () => {
+    render(
+      <FlowContextSidebar
+        flowName="Brand Order — 5 steps"
+        steps={fiveSteps}
+        activeStepId="s1"
+      />,
+    );
+    expect(
+      screen.getByTestId('flow-context-sidebar-title').textContent,
+    ).toBe('Brand Order — 5 steps');
+  });
+
+  it('only the active step has aria-current="step"', () => {
+    render(
+      <FlowContextSidebar flowName="F" steps={fiveSteps} activeStepId="s2" />,
+    );
+    expect(
+      screen
+        .getByTestId('flow-context-sidebar-step-s2')
+        .getAttribute('aria-current'),
+    ).toBe('step');
+    expect(
+      screen
+        .getByTestId('flow-context-sidebar-step-s1')
+        .getAttribute('aria-current'),
+    ).toBeNull();
+  });
+
+  it('clicking a step fires onStepClick with the step id', () => {
+    const onStepClick = vi.fn();
+    render(
+      <FlowContextSidebar
+        flowName="F"
+        steps={fiveSteps}
+        activeStepId="s1"
+        onStepClick={onStepClick}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('flow-context-sidebar-step-s3'));
+    expect(onStepClick).toHaveBeenCalledWith('s3');
+  });
+
+  it('roving tabindex — only the active chip is in the tab order', () => {
+    render(
+      <FlowContextSidebar flowName="F" steps={fiveSteps} activeStepId="s2" />,
+    );
+    expect(
+      screen
+        .getByTestId('flow-context-sidebar-step-s2')
+        .getAttribute('tabindex'),
+    ).toBe('0');
+    expect(
+      screen
+        .getByTestId('flow-context-sidebar-step-s1')
+        .getAttribute('tabindex'),
+    ).toBe('-1');
+  });
+
+  it('ArrowDown moves focus to the next chip; ArrowUp to the previous (wraps)', () => {
+    render(
+      <FlowContextSidebar flowName="F" steps={fiveSteps} activeStepId="s2" />,
+    );
+    const chip2 = screen.getByTestId('flow-context-sidebar-step-s2');
+    chip2.focus();
+    fireEvent.keyDown(chip2, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(
+      screen.getByTestId('flow-context-sidebar-step-s3'),
+    );
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(
+      screen.getByTestId('flow-context-sidebar-step-s2'),
+    );
+  });
+
+  it('Home / End jump to first / last chip', () => {
+    render(
+      <FlowContextSidebar flowName="F" steps={fiveSteps} activeStepId="s3" />,
+    );
+    const chip3 = screen.getByTestId('flow-context-sidebar-step-s3');
+    chip3.focus();
+    fireEvent.keyDown(chip3, { key: 'Home' });
+    expect(document.activeElement).toBe(
+      screen.getByTestId('flow-context-sidebar-step-s1'),
+    );
+    fireEvent.keyDown(document.activeElement!, { key: 'End' });
+    expect(document.activeElement).toBe(
+      screen.getByTestId('flow-context-sidebar-step-s5'),
+    );
+  });
+
+  it('Enter / Space activate the focused chip', () => {
+    const onStepClick = vi.fn();
+    render(
+      <FlowContextSidebar
+        flowName="F"
+        steps={fiveSteps}
+        activeStepId="s1"
+        onStepClick={onStepClick}
+      />,
+    );
+    fireEvent.keyDown(screen.getByTestId('flow-context-sidebar-step-s2'), {
+      key: 'Enter',
+    });
+    expect(onStepClick).toHaveBeenLastCalledWith('s2');
+    fireEvent.keyDown(screen.getByTestId('flow-context-sidebar-step-s3'), {
+      key: ' ',
+    });
+    expect(onStepClick).toHaveBeenLastCalledWith('s3');
+  });
+
+  it('collapse toggle changes aria-expanded and emits onCollapse(!collapsed)', () => {
+    const onCollapse = vi.fn();
+    const { rerender } = render(
+      <FlowContextSidebar
+        flowName="F"
+        steps={fiveSteps}
+        activeStepId="s1"
+        collapsed={false}
+        onCollapse={onCollapse}
+      />,
+    );
+    const toggle = screen.getByTestId('flow-context-sidebar-collapse');
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    fireEvent.click(toggle);
+    expect(onCollapse).toHaveBeenCalledWith(true);
+
+    rerender(
+      <FlowContextSidebar
+        flowName="F"
+        steps={fiveSteps}
+        activeStepId="s1"
+        collapsed={true}
+        onCollapse={onCollapse}
+      />,
+    );
+    const toggle2 = screen.getByTestId('flow-context-sidebar-collapse');
+    expect(toggle2.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(toggle2);
+    expect(onCollapse).toHaveBeenLastCalledWith(false);
+  });
+
+  it('href chips render as <a> and still fire onStepClick on click', () => {
+    const onStepClick = vi.fn();
+    const linked: FlowStep[] = [
+      { id: 'a', label: 'A', href: '/a' },
+      { id: 'b', label: 'B', href: '/b' },
+    ];
+    render(
+      <FlowContextSidebar
+        flowName="F"
+        steps={linked}
+        activeStepId="a"
+        onStepClick={onStepClick}
+      />,
+    );
+    const chip = screen.getByTestId('flow-context-sidebar-step-b');
+    expect(chip.tagName).toBe('A');
+    expect(chip.getAttribute('href')).toBe('/b');
+    fireEvent.click(chip);
+    expect(onStepClick).toHaveBeenCalledWith('b');
+  });
+
+  it('skipped chip remains keyboard-focusable (skipped !== disabled)', () => {
+    render(
+      <FlowContextSidebar flowName="F" steps={fiveSteps} activeStepId="s4" />,
+    );
+    const skipped = screen.getByTestId('flow-context-sidebar-step-s4');
+    skipped.focus();
+    expect(document.activeElement).toBe(skipped);
+  });
+
+  it('apply-to-all button is hidden when onApplyToAll is not provided', () => {
+    render(
+      <FlowContextSidebar flowName="F" steps={fiveSteps} activeStepId="s1" />,
+    );
+    expect(
+      screen.queryByTestId('flow-context-sidebar-apply-to-all'),
+    ).toBeNull();
+  });
+
+  it('apply-to-all button renders and fires the callback when provided', () => {
+    const onApplyToAll = vi.fn();
+    render(
+      <FlowContextSidebar
+        flowName="F"
+        steps={fiveSteps}
+        activeStepId="s1"
+        onApplyToAll={onApplyToAll}
+      />,
+    );
+    const btn = screen.getByTestId('flow-context-sidebar-apply-to-all');
+    fireEvent.click(btn);
+    expect(onApplyToAll).toHaveBeenCalledOnce();
+  });
+
+  it('apply-to-all label honours the applyToAllLabel prop', () => {
+    render(
+      <FlowContextSidebar
+        flowName="F"
+        steps={fiveSteps}
+        activeStepId="s1"
+        onApplyToAll={() => undefined}
+        applyToAllLabel="Apply to all 5 steps"
+      />,
+    );
+    expect(
+      screen.getByTestId('flow-context-sidebar-apply-to-all').textContent,
+    ).toBe('Apply to all 5 steps');
+  });
+
+  it('empty steps renders nothing', () => {
+    const { container } = render(
+      <FlowContextSidebar flowName="F" steps={[]} activeStepId="any" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('status surfaces in aria-label', () => {
+    render(
+      <FlowContextSidebar flowName="F" steps={fiveSteps} activeStepId="s1" />,
+    );
+    expect(
+      screen
+        .getByTestId('flow-context-sidebar-step-s1')
+        .getAttribute('aria-label'),
+    ).toContain('complete');
+    expect(
+      screen
+        .getByTestId('flow-context-sidebar-step-s4')
+        .getAttribute('aria-label'),
+    ).toContain('skipped');
+    expect(
+      screen
+        .getByTestId('flow-context-sidebar-step-s2')
+        .getAttribute('aria-label'),
+    ).toContain('in progress');
+  });
+
+  it('thumbnail null/undefined renders the dashed placeholder block', () => {
+    render(
+      <FlowContextSidebar flowName="F" steps={fiveSteps} activeStepId="s1" />,
+    );
+    expect(
+      screen.getAllByTestId('flow-context-sidebar-thumb-placeholder').length,
+    ).toBe(fiveSteps.length);
+  });
+
+  it('thumbnail URL renders an <img>', () => {
+    const withThumb: FlowStep[] = [
+      { id: 'a', label: 'A', thumbnail: 'data:image/svg+xml,a' },
+      { id: 'b', label: 'B', thumbnail: null },
+    ];
+    const { container } = render(
+      <FlowContextSidebar
+        flowName="F"
+        steps={withThumb}
+        activeStepId="a"
+      />,
+    );
+    expect(container.querySelectorAll('img').length).toBe(1);
+  });
+
+  it('collapsed=true exposes data-collapsed="true" on the nav', () => {
+    render(
+      <FlowContextSidebar
+        flowName="F"
+        steps={fiveSteps}
+        activeStepId="s1"
+        collapsed
+      />,
+    );
+    expect(
+      screen
+        .getByTestId('flow-context-sidebar')
+        .getAttribute('data-collapsed'),
+    ).toBe('true');
+  });
+
+  it('collapsed=true hides the title and apply-to-all', () => {
+    render(
+      <FlowContextSidebar
+        flowName="F"
+        steps={fiveSteps}
+        activeStepId="s1"
+        collapsed
+        onApplyToAll={() => undefined}
+      />,
+    );
+    expect(screen.queryByTestId('flow-context-sidebar-title')).toBeNull();
+    expect(
+      screen.queryByTestId('flow-context-sidebar-apply-to-all'),
+    ).toBeNull();
+  });
+
+  it('badge renders with the count when provided', () => {
+    const withBadge: FlowStep[] = [
+      { id: 'a', label: 'A', badge: { count: 3, tone: 'accent' } },
+    ];
+    render(
+      <FlowContextSidebar
+        flowName="F"
+        steps={withBadge}
+        activeStepId="a"
+      />,
+    );
+    expect(
+      screen.getByTestId('flow-context-sidebar-badge').textContent,
+    ).toBe('3');
+  });
+
+  it('does NOT inject hardcoded hex colours into the rendered DOM', () => {
+    const { container } = render(
+      <FlowContextSidebar
+        flowName="F"
+        steps={fiveSteps}
+        activeStepId="s1"
+        onApplyToAll={() => undefined}
+      />,
+    );
+    expect(container.innerHTML).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+  });
+});

--- a/packages/ui/src/components/FlowContextSidebar/FlowContextSidebar.tsx
+++ b/packages/ui/src/components/FlowContextSidebar/FlowContextSidebar.tsx
@@ -1,0 +1,586 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+/**
+ * FlowContextSidebar — left-rail multi-step flow navigator for Magic
+ * Studio's Option-D cockpit (`magic-studio/docs/mockups/option-d.html`,
+ * region R5). Implements the `FlowSidebar` v0 contract from
+ * `packages/ui/src/components/FlowSidebar/SPEC.md` (PR #101).
+ *
+ * The component is purely presentational. `activeStepId`, `collapsed`,
+ * and `steps` are all controlled by the parent — matching `PhaseRibbon`
+ * and `HistoryStrip`. v0 supports navigation only; drag-reorder /
+ * insert-remove / conditional-flow are deferred to v0.2.
+ *
+ * Layout uses three Studio-scoped layout tokens:
+ *   --amp-studio-theme-layout-flow-sidebar-w           260px
+ *   --amp-studio-theme-layout-flow-sidebar-rail-w       44px
+ *   --amp-studio-theme-layout-flow-step-chip-h          64px
+ *
+ * Width transition is 180ms cubic-bezier(0.4,0,0.2,1) — disabled under
+ * `prefers-reduced-motion: reduce` via `motion-reduce:transition-none`.
+ */
+
+// ─── Types (mirror FlowSidebar/SPEC.md §2) ───────────────────────────────────
+
+export type FlowStepStatus = 'default' | 'in-progress' | 'complete' | 'skipped';
+
+export interface FlowStepBadge {
+  count: number;
+  tone?: 'default' | 'accent';
+}
+
+export interface FlowStep {
+  /** Stable id — used for `activeStepId` matching, React keys, and click events. */
+  id: string;
+  /** Visible label, e.g. "Step 2 · Package". */
+  label: string;
+  /**
+   * Optional href. When provided, the chip renders as `<a href>` instead
+   * of `<button>`. `onStepClick` still fires for analytics.
+   */
+  href?: string;
+  /**
+   * Image URL, or `null` / `undefined` for a token-driven placeholder
+   * block (1.6:1 aspect, dashed border).
+   */
+  thumbnail?: string | null;
+  /** Visual status. Defaults to `'default'`. */
+  status?: FlowStepStatus;
+  /** Optional badge, e.g. iteration count. */
+  badge?: FlowStepBadge;
+}
+
+export interface FlowContextSidebarProps {
+  /** Header label, e.g. "Brand Order — 7 steps". Hidden when collapsed. */
+  flowName: string;
+  /** Ordered list of steps. Empty array → component returns null. */
+  steps: FlowStep[];
+  /** Id of the currently active step. */
+  activeStepId: string;
+  /** Default `false`. When `true`, sidebar collapses to icon-only rail. */
+  collapsed?: boolean;
+  /** Fired on chip activation (click, Enter, Space). */
+  onStepClick?: (id: string) => void;
+  /** Fired when the collapse toggle is activated. */
+  onCollapse?: (collapsed: boolean) => void;
+  /** Optional bottom-of-rail action button. */
+  onApplyToAll?: () => void;
+  /** Default `"Apply brief to all steps"`. */
+  applyToAllLabel?: string;
+  /** Optional className passthrough on the outer `<nav>`. */
+  className?: string;
+}
+
+// ─── Pulse keyframes (id-guarded, injected once) ────────────────────────────
+
+const STYLE_ID = 'amp-flow-sidebar-keyframes';
+const styleSheet = `
+@keyframes amp-flow-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.55; transform: scale(0.85); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .amp-flow-pulse { animation: none !important; }
+}
+`;
+
+function useInjectedKeyframes() {
+  React.useEffect(() => {
+    if (typeof document === 'undefined') return;
+    if (document.getElementById(STYLE_ID)) return;
+    const el = document.createElement('style');
+    el.id = STYLE_ID;
+    el.textContent = styleSheet;
+    document.head.appendChild(el);
+  }, []);
+}
+
+// ─── Status helpers ─────────────────────────────────────────────────────────
+
+const statusToAriaSuffix = (status: FlowStepStatus): string => {
+  switch (status) {
+    case 'complete':
+      return ', complete';
+    case 'in-progress':
+      return ', in progress';
+    case 'skipped':
+      return ', skipped';
+    default:
+      return '';
+  }
+};
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function FlowContextSidebar({
+  flowName,
+  steps,
+  activeStepId,
+  collapsed = false,
+  onStepClick,
+  onCollapse,
+  onApplyToAll,
+  applyToAllLabel = 'Apply brief to all steps',
+  className,
+}: FlowContextSidebarProps) {
+  useInjectedKeyframes();
+
+  const listId = React.useId();
+  const stepRefs = React.useRef<Map<string, HTMLElement>>(new Map());
+
+  // Empty steps → render nothing. Hooks above this guard so call order
+  // stays stable across renders.
+  if (steps.length === 0) return null;
+
+  const setStepRef = (id: string) => (el: HTMLElement | null) => {
+    const map = stepRefs.current;
+    if (el) map.set(id, el);
+    else map.delete(id);
+  };
+
+  const focusStep = (id: string) => {
+    stepRefs.current.get(id)?.focus();
+  };
+
+  const handleKeyDown = (
+    e: React.KeyboardEvent<HTMLElement>,
+    stepId: string,
+  ) => {
+    const idx = steps.findIndex((s) => s.id === stepId);
+    if (idx === -1) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      focusStep(steps[(idx + 1) % steps.length].id);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      focusStep(steps[(idx - 1 + steps.length) % steps.length].id);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      focusStep(steps[0].id);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      focusStep(steps[steps.length - 1].id);
+    } else if (e.key === 'Enter' || e.key === ' ') {
+      // Native <button> already handles this; explicit handler keeps
+      // <a> chips consistent.
+      e.preventDefault();
+      onStepClick?.(stepId);
+    }
+  };
+
+  const handleCollapseToggle = () => {
+    onCollapse?.(!collapsed);
+  };
+
+  return (
+    <nav
+      role="navigation"
+      aria-label="Flow steps"
+      data-collapsed={collapsed}
+      data-testid="flow-context-sidebar"
+      className={cn(
+        'flex h-full flex-col overflow-hidden',
+        'border-r border-[var(--amp-studio-theme-color-border)]',
+        'bg-[var(--amp-studio-theme-color-bg-elev)]',
+        'transition-[width] duration-[180ms] ease-[cubic-bezier(0.4,0,0.2,1)]',
+        'motion-reduce:transition-none',
+        className,
+      )}
+      style={{
+        width: collapsed
+          ? 'var(--amp-studio-theme-layout-flow-sidebar-rail-w, 44px)'
+          : 'var(--amp-studio-theme-layout-flow-sidebar-w, 260px)',
+      }}
+    >
+      {/* Sticky header */}
+      <div
+        className={cn(
+          'sticky top-0 flex shrink-0 items-center justify-between gap-[var(--amp-spacing-2)]',
+          'border-b border-[var(--amp-studio-theme-color-border)]',
+          'bg-[var(--amp-studio-theme-color-bg-elev)]',
+          'px-[var(--amp-spacing-3)] py-[var(--amp-spacing-3)]',
+        )}
+      >
+        {!collapsed && (
+          <div className="min-w-0 flex-1">
+            <div
+              className={cn(
+                'truncate text-[var(--amp-font-size-md)]',
+                'font-[var(--amp-font-weight-semibold)]',
+                'leading-[var(--amp-line-height-tight)]',
+                'text-[var(--amp-studio-theme-color-fg)]',
+              )}
+              data-testid="flow-context-sidebar-title"
+            >
+              {flowName}
+            </div>
+          </div>
+        )}
+        <button
+          type="button"
+          aria-expanded={!collapsed}
+          aria-controls={listId}
+          aria-label={collapsed ? 'Expand flow steps' : 'Collapse flow steps'}
+          data-testid="flow-context-sidebar-collapse"
+          onClick={handleCollapseToggle}
+          className={cn(
+            'inline-flex h-7 w-7 shrink-0 items-center justify-center',
+            'rounded-[var(--amp-radius-sm)] border-0 bg-transparent',
+            'text-[var(--amp-studio-theme-color-muted)]',
+            'cursor-pointer',
+            'hover:bg-[var(--amp-studio-theme-color-bg-subtle)]',
+            'hover:text-[var(--amp-studio-theme-color-fg)]',
+            'focus-visible:outline-none focus-visible:ring-2',
+            'focus-visible:ring-[var(--amp-semantic-border-focus)]',
+            'focus-visible:ring-offset-1',
+          )}
+        >
+          <CollapseIcon collapsed={collapsed} />
+        </button>
+      </div>
+
+      {/* Step list */}
+      <ul
+        id={listId}
+        role="list"
+        data-testid="flow-context-sidebar-list"
+        className={cn(
+          'flex flex-1 flex-col gap-[var(--amp-spacing-2)] overflow-y-auto',
+          'p-[var(--amp-spacing-3)]',
+        )}
+      >
+        {steps.map((step, idx) => (
+          <li key={step.id} role="listitem">
+            <StepChip
+              step={step}
+              index={idx}
+              isActive={step.id === activeStepId}
+              collapsed={collapsed}
+              onClick={() => onStepClick?.(step.id)}
+              onKeyDown={(e) => handleKeyDown(e, step.id)}
+              setRef={setStepRef(step.id)}
+            />
+          </li>
+        ))}
+      </ul>
+
+      {/* Sticky bottom action */}
+      {onApplyToAll && !collapsed && (
+        <div
+          className={cn(
+            'sticky bottom-0 mt-auto shrink-0',
+            'border-t border-[var(--amp-studio-theme-color-border)]',
+            'bg-[var(--amp-studio-theme-color-bg-elev)]',
+            'px-[var(--amp-spacing-4)] py-[var(--amp-spacing-3)]',
+          )}
+        >
+          <button
+            type="button"
+            data-testid="flow-context-sidebar-apply-to-all"
+            aria-label={applyToAllLabel}
+            onClick={onApplyToAll}
+            className={cn(
+              'block w-full cursor-pointer',
+              'rounded-full border',
+              'border-[var(--amp-studio-theme-color-border-strong)]',
+              'bg-[var(--amp-studio-theme-color-bg)]',
+              'px-[var(--amp-spacing-3)] py-[var(--amp-spacing-2)]',
+              'text-[var(--amp-font-size-sm)]',
+              'font-[var(--amp-font-weight-medium)]',
+              'text-[var(--amp-studio-theme-color-fg)]',
+              'transition-colors duration-[var(--amp-motion-duration-fast)]',
+              'motion-reduce:transition-none',
+              'hover:bg-[var(--amp-studio-theme-color-bg-elev)]',
+              'hover:border-[var(--amp-semantic-border-accent)]',
+              'focus-visible:outline-none focus-visible:ring-2',
+              'focus-visible:ring-[var(--amp-semantic-border-focus)]',
+              'focus-visible:ring-offset-1',
+            )}
+          >
+            {applyToAllLabel}
+          </button>
+        </div>
+      )}
+    </nav>
+  );
+}
+
+FlowContextSidebar.displayName = 'FlowContextSidebar';
+
+// ─── StepChip sub-component ─────────────────────────────────────────────────
+
+interface StepChipProps {
+  step: FlowStep;
+  index: number;
+  isActive: boolean;
+  collapsed: boolean;
+  onClick: () => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => void;
+  setRef: (el: HTMLElement | null) => void;
+}
+
+const StepChip: React.FC<StepChipProps> = ({
+  step,
+  index,
+  isActive,
+  collapsed,
+  onClick,
+  onKeyDown,
+  setRef,
+}) => {
+  const status: FlowStepStatus = step.status ?? 'default';
+  const ariaLabel = `${step.label}${statusToAriaSuffix(status)}`;
+  const ariaCurrent = isActive ? 'step' : undefined;
+  // Roving tabindex — only the active chip is in the tab order.
+  const tabIndex = isActive ? 0 : -1;
+
+  const commonClasses = cn(
+    'group relative flex w-full cursor-pointer flex-col',
+    'gap-[var(--amp-spacing-2)] p-[var(--amp-spacing-2)]',
+    'rounded-[var(--amp-radius-md)] border text-left',
+    'transition-[border-color,background-color,box-shadow] duration-[var(--amp-motion-duration-fast)]',
+    'motion-reduce:transition-none',
+    // height token so click target ≥ 44px
+    'min-h-[var(--amp-studio-theme-layout-flow-step-chip-h,64px)]',
+    'focus-visible:outline-none focus-visible:ring-2',
+    'focus-visible:ring-offset-2',
+    'focus-visible:ring-[var(--amp-semantic-border-focus)]',
+    isActive
+      ? cn(
+          'bg-[var(--amp-studio-theme-color-bg-elev)]',
+          'border-[var(--amp-semantic-border-accent)]',
+          'shadow-[var(--amp-shadow-ring-accent)]',
+        )
+      : cn(
+          'bg-[var(--amp-studio-theme-color-bg-subtle)]',
+          'border-[var(--amp-studio-theme-color-border)]',
+          'hover:border-[var(--amp-studio-theme-color-border-strong)]',
+        ),
+    status === 'skipped' && 'opacity-50',
+    collapsed && 'min-h-[28px] flex-row items-center justify-center border-0 bg-transparent p-0 hover:bg-transparent',
+  );
+
+  const content = collapsed ? (
+    <CollapsedPip
+      index={index}
+      isActive={isActive}
+      status={status}
+      label={step.label}
+    />
+  ) : (
+    <>
+      {/* Thumbnail */}
+      <Thumbnail thumbnail={step.thumbnail} />
+      {/* Label row */}
+      <div
+        className={cn(
+          'flex items-center justify-between',
+          'text-[var(--amp-font-size-xs)]',
+          'font-[var(--amp-font-mono)] text-[var(--amp-studio-theme-color-muted)]',
+          isActive && 'text-[var(--amp-studio-theme-color-accent)]',
+        )}
+      >
+        <span className="truncate">
+          <span
+            className={cn(
+              'ml-1 font-[var(--amp-font-weight-medium)]',
+              'text-[var(--amp-studio-theme-color-fg)]',
+            )}
+          >
+            {step.label}
+          </span>
+        </span>
+        <StatusGlyph status={status} />
+      </div>
+      {step.badge && <BadgeDot badge={step.badge} />}
+    </>
+  );
+
+  if (step.href) {
+    return (
+      <a
+        ref={setRef as (el: HTMLAnchorElement | null) => void}
+        href={step.href}
+        aria-label={ariaLabel}
+        aria-current={ariaCurrent}
+        data-status={status}
+        data-active={isActive}
+        data-testid={`flow-context-sidebar-step-${step.id}`}
+        tabIndex={tabIndex}
+        onClick={onClick}
+        onKeyDown={onKeyDown}
+        className={commonClasses}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      ref={setRef as (el: HTMLButtonElement | null) => void}
+      type="button"
+      aria-label={ariaLabel}
+      aria-current={ariaCurrent}
+      data-status={status}
+      data-active={isActive}
+      data-testid={`flow-context-sidebar-step-${step.id}`}
+      tabIndex={tabIndex}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      className={commonClasses}
+    >
+      {content}
+    </button>
+  );
+};
+
+// ─── Sub-bits ────────────────────────────────────────────────────────────────
+
+const Thumbnail: React.FC<{ thumbnail?: string | null }> = ({ thumbnail }) => {
+  if (thumbnail) {
+    return (
+      <div
+        className={cn(
+          'relative w-full overflow-hidden',
+          'rounded-[var(--amp-radius-sm)]',
+          'border border-[var(--amp-studio-theme-color-border)]',
+          'bg-[var(--amp-studio-theme-color-bg-elev)]',
+          'aspect-[1.6/1]',
+        )}
+      >
+        <img
+          src={thumbnail}
+          alt=""
+          aria-hidden="true"
+          className="h-full w-full object-cover"
+        />
+      </div>
+    );
+  }
+  return (
+    <div
+      data-testid="flow-context-sidebar-thumb-placeholder"
+      className={cn(
+        'w-full',
+        'rounded-[var(--amp-radius-sm)]',
+        'border border-dashed border-[var(--amp-studio-theme-color-border)]',
+        'bg-[var(--amp-semantic-bg-subtle)]',
+        'aspect-[1.6/1]',
+      )}
+    />
+  );
+};
+
+const CollapsedPip: React.FC<{
+  index: number;
+  isActive: boolean;
+  status: FlowStepStatus;
+  label: string;
+}> = ({ index, isActive, status, label }) => (
+  <span
+    aria-hidden="true"
+    title={label}
+    data-status={status}
+    className={cn(
+      'inline-flex h-7 w-7 items-center justify-center',
+      'rounded-full',
+      'font-[var(--amp-font-mono)] text-[var(--amp-font-size-xs)]',
+      isActive
+        ? 'bg-[var(--amp-studio-theme-color-accent)] text-[var(--amp-studio-theme-color-fg-on-accent)]'
+        : 'bg-[var(--amp-studio-theme-color-bg-subtle)] text-[var(--amp-studio-theme-color-muted)]',
+    )}
+  >
+    {index + 1}
+  </span>
+);
+
+const StatusGlyph: React.FC<{ status: FlowStepStatus }> = ({ status }) => {
+  if (status === 'complete') {
+    return (
+      <span
+        aria-hidden="true"
+        data-testid="flow-context-sidebar-status-complete"
+        className={cn(
+          'inline-flex h-4 w-4 items-center justify-center',
+          'rounded-full',
+          'bg-[var(--amp-semantic-color-success)]',
+          'text-[var(--amp-studio-theme-color-fg-on-accent)]',
+          'text-[10px]',
+        )}
+      >
+        ✓
+      </span>
+    );
+  }
+  if (status === 'in-progress') {
+    return (
+      <span
+        aria-hidden="true"
+        data-testid="flow-context-sidebar-status-in-progress"
+        className={cn(
+          'amp-flow-pulse inline-block size-2 rounded-full',
+          'bg-[var(--amp-semantic-color-info,var(--amp-studio-theme-color-accent))]',
+        )}
+        style={{ animation: 'amp-flow-pulse 1.4s ease-in-out infinite' }}
+      />
+    );
+  }
+  if (status === 'skipped') {
+    return (
+      <span
+        aria-hidden="true"
+        data-testid="flow-context-sidebar-status-skipped"
+        className={cn(
+          'inline-block h-3 w-3 rounded-[var(--amp-radius-xs)]',
+          'bg-[linear-gradient(135deg,transparent_47%,var(--amp-studio-theme-color-border)_48%,var(--amp-studio-theme-color-border)_52%,transparent_53%)]',
+        )}
+      />
+    );
+  }
+  return null;
+};
+
+const BadgeDot: React.FC<{ badge: { count: number; tone?: 'default' | 'accent' } }> = ({
+  badge,
+}) => (
+  <span
+    data-testid="flow-context-sidebar-badge"
+    className={cn(
+      'absolute right-[var(--amp-spacing-2)] top-[var(--amp-spacing-2)]',
+      'inline-flex h-4 min-w-[16px] items-center justify-center',
+      'rounded-full px-1',
+      'text-[var(--amp-font-size-2xs)]',
+      'font-[var(--amp-font-weight-medium)]',
+      badge.tone === 'accent'
+        ? 'bg-[var(--amp-studio-theme-color-accent)] text-[var(--amp-studio-theme-color-fg-on-accent)]'
+        : 'bg-[var(--amp-studio-theme-color-bg-subtle)] text-[var(--amp-studio-theme-color-muted)]',
+    )}
+  >
+    {badge.count}
+  </span>
+);
+
+const CollapseIcon: React.FC<{ collapsed: boolean }> = ({ collapsed }) => (
+  <svg
+    width={14}
+    height={14}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    style={{
+      transform: collapsed ? 'rotate(180deg)' : 'rotate(0deg)',
+      transition: 'transform 180ms cubic-bezier(0.4,0,0.2,1)',
+    }}
+  >
+    <polyline points="15 18 9 12 15 6" />
+  </svg>
+);

--- a/packages/ui/src/components/FlowContextSidebar/index.ts
+++ b/packages/ui/src/components/FlowContextSidebar/index.ts
@@ -1,0 +1,7 @@
+export { FlowContextSidebar } from './FlowContextSidebar';
+export type {
+  FlowContextSidebarProps,
+  FlowStep,
+  FlowStepStatus,
+  FlowStepBadge,
+} from './FlowContextSidebar';

--- a/packages/ui/src/components/LivePaneToggle/LivePaneToggle.stories.tsx
+++ b/packages/ui/src/components/LivePaneToggle/LivePaneToggle.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { LivePaneToggle, type LivePaneMode } from './LivePaneToggle';
+
+/**
+ * `LivePaneToggle` is the 3-state pane-mode control in the Magic Studio
+ * cockpit (`magic-studio/docs/mockups/option-d.html`). Mockup region:
+ *
+ * ```html
+ * <div class="seg" role="group" aria-label="Pane mode">
+ *   <button>Live</button>
+ *   <button class="on">Variants</button>
+ *   <button>Split</button>
+ * </div>
+ * ```
+ *
+ * Spec: `magic-studio/docs/mockups/OPTION_D_SPEC.md` §1 R3, §2 C1.
+ */
+const meta = {
+  title: 'Studio v0/LivePaneToggle',
+  component: LivePaneToggle,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    status: { type: 'beta' },
+  },
+} satisfies Meta<typeof LivePaneToggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default state — `variants` selected. Matches the canonical cockpit's
+ * `#loaded` state where the user is reviewing AI-generated variants.
+ */
+export const Default: Story = {
+  render: () => {
+    const [value, setValue] = React.useState<LivePaneMode>('variants');
+    return (
+      <LivePaneToggle
+        value={value}
+        onChange={setValue}
+        liveUrl="https://app.example.com/order"
+      />
+    );
+  },
+  args: {
+    value: 'variants',
+    onChange: () => undefined,
+  },
+};
+
+/**
+ * `live` selected — matches `#live-split` state where the live iframe
+ * occupies the workspace (variants hidden).
+ */
+export const LiveActive: Story = {
+  render: () => {
+    const [value, setValue] = React.useState<LivePaneMode>('live');
+    return (
+      <LivePaneToggle
+        value={value}
+        onChange={setValue}
+        liveUrl="https://app.example.com/order"
+      />
+    );
+  },
+  args: {
+    value: 'live',
+    onChange: () => undefined,
+  },
+};
+
+/**
+ * `split` selected — matches `#live-split` state with side-by-side Live +
+ * Variants layout.
+ */
+export const SplitActive: Story = {
+  render: () => {
+    const [value, setValue] = React.useState<LivePaneMode>('split');
+    return (
+      <LivePaneToggle
+        value={value}
+        onChange={setValue}
+        liveUrl="https://app.example.com/order"
+      />
+    );
+  },
+  args: {
+    value: 'split',
+    onChange: () => undefined,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    value: 'variants',
+    onChange: () => undefined,
+    disabled: true,
+  },
+};

--- a/packages/ui/src/components/LivePaneToggle/LivePaneToggle.test.tsx
+++ b/packages/ui/src/components/LivePaneToggle/LivePaneToggle.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { LivePaneToggle, type LivePaneMode } from './LivePaneToggle';
+
+afterEach(cleanup);
+
+const renderToggle = (
+  initial: LivePaneMode = 'variants',
+  overrides: Partial<React.ComponentProps<typeof LivePaneToggle>> = {},
+) => {
+  const onChange = vi.fn();
+  const utils = render(
+    <LivePaneToggle value={initial} onChange={onChange} {...overrides} />,
+  );
+  return { onChange, ...utils };
+};
+
+describe('LivePaneToggle', () => {
+  it('renders three radio buttons (Live / Variants / Split)', () => {
+    renderToggle();
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+    expect(screen.getByRole('radio', { name: 'Live' })).toBeDefined();
+    expect(screen.getByRole('radio', { name: 'Variants' })).toBeDefined();
+    expect(screen.getByRole('radio', { name: 'Split' })).toBeDefined();
+  });
+
+  it('marks the active option with aria-checked=true and others false', () => {
+    renderToggle('split');
+    expect(
+      screen.getByRole('radio', { name: 'Split' }).getAttribute('aria-checked'),
+    ).toBe('true');
+    expect(
+      screen.getByRole('radio', { name: 'Live' }).getAttribute('aria-checked'),
+    ).toBe('false');
+    expect(
+      screen.getByRole('radio', { name: 'Variants' }).getAttribute('aria-checked'),
+    ).toBe('false');
+  });
+
+  it('clicking an option fires onChange with that value', () => {
+    const { onChange } = renderToggle('variants');
+    fireEvent.click(screen.getByRole('radio', { name: 'Live' }));
+    expect(onChange).toHaveBeenCalledWith('live');
+  });
+
+  it('roving tabindex — only the active option is tabbable', () => {
+    renderToggle('split');
+    expect(
+      screen.getByRole('radio', { name: 'Live' }).getAttribute('tabindex'),
+    ).toBe('-1');
+    expect(
+      screen.getByRole('radio', { name: 'Variants' }).getAttribute('tabindex'),
+    ).toBe('-1');
+    expect(
+      screen.getByRole('radio', { name: 'Split' }).getAttribute('tabindex'),
+    ).toBe('0');
+  });
+
+  it('ArrowRight cycles to next; ArrowLeft to previous (wraps)', () => {
+    const { onChange } = renderToggle('variants');
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'Variants' }), {
+      key: 'ArrowRight',
+    });
+    expect(onChange).toHaveBeenLastCalledWith('split');
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'Variants' }), {
+      key: 'ArrowLeft',
+    });
+    expect(onChange).toHaveBeenLastCalledWith('live');
+  });
+
+  it('Home / End jump to first / last', () => {
+    const { onChange } = renderToggle('variants');
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'Variants' }), {
+      key: 'Home',
+    });
+    expect(onChange).toHaveBeenLastCalledWith('live');
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'Variants' }), {
+      key: 'End',
+    });
+    expect(onChange).toHaveBeenLastCalledWith('split');
+  });
+
+  it('Enter / Space activate the focused option', () => {
+    const { onChange } = renderToggle('variants');
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'Live' }), { key: 'Enter' });
+    expect(onChange).toHaveBeenLastCalledWith('live');
+    fireEvent.keyDown(screen.getByRole('radio', { name: 'Split' }), { key: ' ' });
+    expect(onChange).toHaveBeenLastCalledWith('split');
+  });
+
+  it('renders with role=radiogroup and the configured ariaLabel', () => {
+    renderToggle('live', { ariaLabel: 'Studio pane mode' });
+    expect(
+      screen.getByRole('radiogroup', { name: 'Studio pane mode' }),
+    ).toBeDefined();
+  });
+
+  it('exposes liveUrl via data-live-url attribute when provided', () => {
+    const { container } = renderToggle('split', { liveUrl: 'https://app.example.com' });
+    const wrap = container.querySelector('[role="radiogroup"]') as HTMLElement;
+    expect(wrap.getAttribute('data-live-url')).toBe('https://app.example.com');
+  });
+
+  it('omits data-live-url when liveUrl is not provided', () => {
+    const { container } = renderToggle();
+    const wrap = container.querySelector('[role="radiogroup"]') as HTMLElement;
+    expect(wrap.hasAttribute('data-live-url')).toBe(false);
+  });
+
+  it('disabled — aria-disabled set, click does not fire onChange', () => {
+    const { onChange } = renderToggle('variants', { disabled: true });
+    expect(
+      screen.getByRole('radiogroup').getAttribute('aria-disabled'),
+    ).toBe('true');
+    fireEvent.click(screen.getByRole('radio', { name: 'Live' }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does NOT inject hardcoded hex colours into the rendered DOM', () => {
+    const { container } = renderToggle();
+    expect(container.innerHTML).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+  });
+
+  it('does NOT inject hardcoded px appearance values into the rendered DOM', () => {
+    const { container } = renderToggle();
+    // Allow tailwind utility tokens (`px-3`, `py-1`, `gap-0.5`) — block
+    // explicit `Npx` literals in the DOM (they only appear if a hex / px
+    // bypasses tokens). The DOM stringified by jsdom contains only
+    // class names, never the resolved CSS, so any literal like
+    // `style="padding: 12px"` would be a smoking gun.
+    expect(container.innerHTML).not.toMatch(/style="[^"]*\d+px/);
+  });
+});

--- a/packages/ui/src/components/LivePaneToggle/LivePaneToggle.tsx
+++ b/packages/ui/src/components/LivePaneToggle/LivePaneToggle.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+/**
+ * LivePaneToggle — 3-state pane-mode control for Magic Studio Option-D cockpit.
+ *
+ * Distinct from the generic `SegmentedControl` because it owns pane-state
+ * semantics: switching to `"live"` or `"split"` mounts a live iframe of
+ * `liveUrl`; switching to `"variants"` unmounts it. Consumers wire the
+ * iframe themselves; this primitive is the control surface only.
+ *
+ * Renders as a pill-shaped 3-button group matching the `.seg` block in
+ * `magic-studio/docs/mockups/option-d.html`. The active button uses an
+ * inverted fill (foreground bg, elevated-bg fg) to read as a "selected"
+ * state. Standard ARIA radiogroup semantics with roving tabindex and
+ * arrow-key navigation.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type LivePaneMode = 'live' | 'variants' | 'split';
+
+export interface LivePaneToggleProps {
+  /** Currently selected pane mode (controlled). */
+  value: LivePaneMode;
+  /** Fired on activation (click, Enter, Space, Arrow). */
+  onChange: (value: LivePaneMode) => void;
+  /**
+   * Live URL the consumer mounts in its iframe when value !== 'variants'.
+   * Stored on a `data-live-url` attribute on the wrapper for analytics /
+   * dev-tools introspection. The toggle itself does NOT render the iframe.
+   */
+  liveUrl?: string;
+  /** Optional label for the radiogroup. Defaults to `"Pane mode"`. */
+  ariaLabel?: string;
+  /** Disable the entire control. */
+  disabled?: boolean;
+  className?: string;
+}
+
+interface ModeOption {
+  value: LivePaneMode;
+  label: string;
+}
+
+const MODES: readonly ModeOption[] = Object.freeze([
+  { value: 'live', label: 'Live' },
+  { value: 'variants', label: 'Variants' },
+  { value: 'split', label: 'Split' },
+]);
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export const LivePaneToggle = React.forwardRef<HTMLDivElement, LivePaneToggleProps>(
+  function LivePaneToggle(
+    { value, onChange, liveUrl, ariaLabel = 'Pane mode', disabled = false, className },
+    ref,
+  ) {
+    const buttonRefs = React.useRef<Map<LivePaneMode, HTMLButtonElement>>(new Map());
+
+    const setRef = (mode: LivePaneMode) => (el: HTMLButtonElement | null) => {
+      const map = buttonRefs.current;
+      if (el) map.set(mode, el);
+      else map.delete(mode);
+    };
+
+    const focusByOffset = (current: LivePaneMode, offset: number) => {
+      if (disabled) return;
+      const idx = MODES.findIndex((m) => m.value === current);
+      if (idx === -1) return;
+      const next = MODES[(idx + offset + MODES.length) % MODES.length];
+      buttonRefs.current.get(next.value)?.focus();
+      onChange(next.value);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>, mode: LivePaneMode) => {
+      if (disabled) return;
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        focusByOffset(mode, 1);
+      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        focusByOffset(mode, -1);
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        const first = MODES[0];
+        buttonRefs.current.get(first.value)?.focus();
+        onChange(first.value);
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        const last = MODES[MODES.length - 1];
+        buttonRefs.current.get(last.value)?.focus();
+        onChange(last.value);
+      } else if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault();
+        onChange(mode);
+      }
+    };
+
+    return (
+      <div
+        ref={ref}
+        role="radiogroup"
+        aria-label={ariaLabel}
+        aria-disabled={disabled || undefined}
+        data-live-url={liveUrl || undefined}
+        data-value={value}
+        className={cn(
+          'inline-flex items-center gap-0.5 p-0.5',
+          'rounded-full border',
+          'border-[var(--amp-studio-theme-color-border)]',
+          'bg-[var(--amp-studio-theme-color-bg)]',
+          disabled && 'opacity-50',
+          className,
+        )}
+      >
+        {MODES.map((mode) => {
+          const isActive = mode.value === value;
+          return (
+            <button
+              key={mode.value}
+              ref={setRef(mode.value)}
+              type="button"
+              role="radio"
+              aria-checked={isActive}
+              aria-label={mode.label}
+              data-value={mode.value}
+              data-active={isActive}
+              data-testid={`live-pane-toggle-${mode.value}`}
+              disabled={disabled}
+              tabIndex={isActive ? 0 : -1}
+              onClick={() => {
+                if (!disabled) onChange(mode.value);
+              }}
+              onKeyDown={(e) => handleKeyDown(e, mode.value)}
+              className={cn(
+                'inline-flex items-center justify-center',
+                'rounded-full border-0',
+                'px-3 py-1 text-[var(--amp-font-size-sm)] font-[var(--amp-font-weight-medium)]',
+                'transition-colors duration-[var(--amp-motion-duration-fast)]',
+                'motion-reduce:transition-none',
+                'focus-visible:outline-none focus-visible:ring-2',
+                'focus-visible:ring-[var(--amp-semantic-border-focus)]',
+                'focus-visible:ring-offset-1',
+                'cursor-pointer',
+                disabled && 'cursor-not-allowed',
+                isActive
+                  ? 'bg-[var(--amp-studio-theme-color-fg)] text-[var(--amp-studio-theme-color-bg-elev)]'
+                  : 'bg-transparent text-[var(--amp-studio-theme-color-muted)] hover:text-[var(--amp-studio-theme-color-fg)]',
+              )}
+            >
+              {mode.label}
+            </button>
+          );
+        })}
+      </div>
+    );
+  },
+);
+
+LivePaneToggle.displayName = 'LivePaneToggle';

--- a/packages/ui/src/components/LivePaneToggle/index.ts
+++ b/packages/ui/src/components/LivePaneToggle/index.ts
@@ -1,0 +1,2 @@
+export { LivePaneToggle } from './LivePaneToggle';
+export type { LivePaneToggleProps, LivePaneMode } from './LivePaneToggle';

--- a/packages/ui/src/components/RecentChangesPanel/RecentChangesPanel.stories.tsx
+++ b/packages/ui/src/components/RecentChangesPanel/RecentChangesPanel.stories.tsx
@@ -1,0 +1,127 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import {
+  RecentChangesPanel,
+  type GitCommit,
+} from './RecentChangesPanel';
+
+/**
+ * `RecentChangesPanel` is the right-side slide-in panel listing the last
+ * N git commits touching the target file. Used in Magic Studio's
+ * Option-D cockpit (`magic-studio/docs/mockups/option-d.html`, region R4
+ * + state `#changes`).
+ *
+ * Mockup region:
+ *
+ * ```html
+ * <aside class="changes-panel">
+ *   <div class="panel-head">
+ *     <h3>Recent changes</h3>
+ *     <button>×</button>
+ *   </div>
+ *   <div class="commit">
+ *     <div class="msg">…</div>
+ *     <div class="meta-row">
+ *       <span>Apaksh Gupta</span> · <span>3h ago</span>
+ *       · <span class="added">+38</span> <span class="removed">−12</span>
+ *     </div>
+ *   </div>
+ * </aside>
+ * ```
+ *
+ * Spec: `magic-studio/docs/mockups/OPTION_D_SPEC.md` §1 R4, §2 C5, §4 I10.
+ */
+const meta = {
+  title: 'Studio v0/RecentChangesPanel',
+  component: RecentChangesPanel,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    status: { type: 'beta' },
+  },
+} satisfies Meta<typeof RecentChangesPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const Frame: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <div style={{ height: 600, display: 'flex', justifyContent: 'flex-end' }}>
+    {children}
+  </div>
+);
+
+const baseCommit = (i: number): GitCommit => ({
+  sha: `${'a'.repeat(7 - i.toString().length)}${i}sha`,
+  message: [
+    'Add live-page diff overlay over fullscreen viewer',
+    'Lift CTA pills above sticky header on small viewports',
+    'Wire @-reference reply syntax into composer',
+    'Switch composer to /api/v1/design/generate-async',
+    'Inline reference-snapshot pill in top bar',
+    'Resolve hover-toolbar z-index regression',
+    'Rebuild thread auto-scroll on new turn',
+  ][i % 7],
+  author: ['Apaksh Gupta', 'Claude Opus 4.7', 'Pixel Agent'][i % 3],
+  timestamp: new Date(Date.now() - (i + 1) * 3600_000),
+  added: 38 - i * 4,
+  removed: 12 - i,
+  url: i === 0 ? 'https://github.com/One-Impression/magic-studio/commit/abc1234' : undefined,
+});
+
+const sevenCommits: GitCommit[] = Array.from({ length: 7 }, (_, i) => baseCommit(i));
+
+/** Default — 7 commits for `src/components/Order.tsx`. */
+export const Default: Story = {
+  render: () => (
+    <Frame>
+      <RecentChangesPanel
+        filePath="src/components/Order.tsx"
+        commits={sevenCommits}
+        onClose={() => undefined}
+        formatTime={() => '3h ago'}
+      />
+    </Frame>
+  ),
+  args: {
+    filePath: 'src/components/Order.tsx',
+    commits: sevenCommits,
+    onClose: () => undefined,
+  },
+};
+
+/** Empty — no commits yet. Renders the empty-state message. */
+export const Empty: Story = {
+  render: () => (
+    <Frame>
+      <RecentChangesPanel
+        filePath="src/components/UnchangedFile.tsx"
+        commits={[]}
+        onClose={() => undefined}
+      />
+    </Frame>
+  ),
+  args: {
+    filePath: 'src/components/UnchangedFile.tsx',
+    commits: [],
+    onClose: () => undefined,
+  },
+};
+
+/** Single commit — verifies row sizing on a sparse panel. */
+export const SingleCommit: Story = {
+  render: () => (
+    <Frame>
+      <RecentChangesPanel
+        filePath="src/components/Order.tsx"
+        commits={[sevenCommits[0]]}
+        onClose={() => undefined}
+        formatTime={() => '12m ago'}
+      />
+    </Frame>
+  ),
+  args: {
+    filePath: 'src/components/Order.tsx',
+    commits: [sevenCommits[0]],
+    onClose: () => undefined,
+  },
+};

--- a/packages/ui/src/components/RecentChangesPanel/RecentChangesPanel.test.tsx
+++ b/packages/ui/src/components/RecentChangesPanel/RecentChangesPanel.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import {
+  RecentChangesPanel,
+  type GitCommit,
+} from './RecentChangesPanel';
+
+afterEach(cleanup);
+
+const sevenCommits: GitCommit[] = Array.from({ length: 7 }, (_, i) => ({
+  sha: `sha${i}abcd`,
+  message: `Commit message ${i}`,
+  author: `Author ${i}`,
+  timestamp: new Date(Date.now() - (i + 1) * 3600_000),
+  added: 10 * (i + 1),
+  removed: 2 * (i + 1),
+  url: i === 0 ? 'https://github.com/example/repo/commit/sha0abcd' : undefined,
+}));
+
+describe('RecentChangesPanel', () => {
+  it('renders as a complementary landmark with the heading id linked', () => {
+    render(
+      <RecentChangesPanel
+        filePath="src/components/Order.tsx"
+        commits={sevenCommits}
+        onClose={() => undefined}
+      />,
+    );
+    const aside = screen.getByRole('complementary');
+    const heading = screen.getByTestId('recent-changes-panel-heading');
+    expect(aside.getAttribute('aria-labelledby')).toBe(heading.id);
+  });
+
+  it('renders the heading "Recent changes" and the file path', () => {
+    render(
+      <RecentChangesPanel
+        filePath="src/components/Order.tsx"
+        commits={sevenCommits}
+        onClose={() => undefined}
+      />,
+    );
+    expect(screen.getByTestId('recent-changes-panel-heading').textContent).toBe(
+      'Recent changes',
+    );
+    expect(
+      screen.getByTestId('recent-changes-panel-filepath').textContent,
+    ).toBe('src/components/Order.tsx');
+  });
+
+  it('renders one list item per commit', () => {
+    render(
+      <RecentChangesPanel
+        filePath="x"
+        commits={sevenCommits}
+        onClose={() => undefined}
+      />,
+    );
+    sevenCommits.forEach((c) => {
+      expect(screen.getByTestId(`recent-changes-panel-commit-${c.sha}`)).toBeDefined();
+    });
+  });
+
+  it('renders the commit message, author, +added, -removed, short SHA per row', () => {
+    render(
+      <RecentChangesPanel
+        filePath="x"
+        commits={[sevenCommits[1]]}
+        onClose={() => undefined}
+      />,
+    );
+    const c = sevenCommits[1];
+    expect(
+      screen.getByTestId(`recent-changes-panel-commit-${c.sha}`).textContent,
+    ).toContain(c.message);
+    expect(
+      screen.getByTestId(`recent-changes-panel-commit-author-${c.sha}`).textContent,
+    ).toBe(c.author);
+    expect(
+      screen.getByTestId(`recent-changes-panel-commit-added-${c.sha}`).textContent,
+    ).toBe(`+${c.added}`);
+    expect(
+      screen.getByTestId(`recent-changes-panel-commit-removed-${c.sha}`).textContent,
+    ).toBe(`−${c.removed}`);
+  });
+
+  it('renders the message as <a> when commit.url is provided', () => {
+    render(
+      <RecentChangesPanel
+        filePath="x"
+        commits={[sevenCommits[0]]}
+        onClose={() => undefined}
+      />,
+    );
+    const link = screen.getByTestId(
+      `recent-changes-panel-commit-link-${sevenCommits[0].sha}`,
+    ) as HTMLAnchorElement;
+    expect(link.tagName).toBe('A');
+    expect(link.href).toContain('github.com/example/repo/commit/sha0abcd');
+    expect(link.target).toBe('_blank');
+    expect(link.rel).toContain('noopener');
+  });
+
+  it('renders the message as plain text when commit.url is not provided', () => {
+    const noUrl: GitCommit = { ...sevenCommits[1], url: undefined };
+    render(
+      <RecentChangesPanel
+        filePath="x"
+        commits={[noUrl]}
+        onClose={() => undefined}
+      />,
+    );
+    expect(
+      screen.queryByTestId(`recent-changes-panel-commit-link-${noUrl.sha}`),
+    ).toBeNull();
+  });
+
+  it('close button fires onClose when clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <RecentChangesPanel
+        filePath="x"
+        commits={sevenCommits}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('recent-changes-panel-close'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('Escape on the window fires onClose', () => {
+    const onClose = vi.fn();
+    render(
+      <RecentChangesPanel
+        filePath="x"
+        commits={sevenCommits}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('renders an empty-state message when commits is empty', () => {
+    render(
+      <RecentChangesPanel filePath="x" commits={[]} onClose={() => undefined} />,
+    );
+    expect(screen.getByTestId('recent-changes-panel-empty')).toBeDefined();
+    expect(screen.queryByTestId('recent-changes-panel-list')).toBeNull();
+  });
+
+  it('honours custom formatTime', () => {
+    render(
+      <RecentChangesPanel
+        filePath="x"
+        commits={[sevenCommits[0]]}
+        onClose={() => undefined}
+        formatTime={() => 'NOW-NOW'}
+      />,
+    );
+    expect(
+      screen.getByTestId(`recent-changes-panel-commit-time-${sevenCommits[0].sha}`)
+        .textContent,
+    ).toBe('NOW-NOW');
+  });
+
+  it('does NOT inject hardcoded hex colours into the rendered DOM', () => {
+    const { container } = render(
+      <RecentChangesPanel
+        filePath="x"
+        commits={sevenCommits}
+        onClose={() => undefined}
+      />,
+    );
+    expect(container.innerHTML).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+  });
+});

--- a/packages/ui/src/components/RecentChangesPanel/RecentChangesPanel.tsx
+++ b/packages/ui/src/components/RecentChangesPanel/RecentChangesPanel.tsx
@@ -1,0 +1,308 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+/**
+ * RecentChangesPanel — right-side slide-in panel listing the last N git
+ * commits touching a file. Used by Magic Studio's Option-D cockpit
+ * (`magic-studio/docs/mockups/option-d.html`, region R4 + state
+ * `#changes`).
+ *
+ * Width is driven by the existing
+ * `--amp-studio-theme-layout-history-panel-w` token (default 360px). The
+ * panel is purely presentational — the consumer fetches commits from
+ * `/api/files/{path}/commits?limit=N` and feeds them in.
+ *
+ * Renders as `<aside aria-label>` with role="complementary" so screen
+ * readers announce it as a side region. The close button sits in the
+ * sticky top-right of the panel head.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface GitCommit {
+  /** Short SHA, e.g. "920696b". */
+  sha: string;
+  /** First-line commit message. */
+  message: string;
+  /** Author display name. */
+  author: string;
+  /** Commit timestamp. Rendered with `formatTime` (default `Intl.RelativeTimeFormat`). */
+  timestamp: Date;
+  /** Lines added in this commit. */
+  added: number;
+  /** Lines removed in this commit. */
+  removed: number;
+  /** Optional URL to the commit page (GitHub etc.). When set, the message is rendered as `<a>`. */
+  url?: string;
+}
+
+export interface RecentChangesPanelProps {
+  /** Path of the file the commits are filtered to, e.g. "src/components/Order.tsx". */
+  filePath: string;
+  /** Ordered commits — most recent first. */
+  commits: GitCommit[];
+  /** Fired when the user closes the panel (× button or Esc). */
+  onClose: () => void;
+  /** Custom timestamp formatter. Defaults to relative ("3h ago"). */
+  formatTime?: (date: Date) => string;
+  /** Optional className passthrough on the outer `<aside>`. */
+  className?: string;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const RTF =
+  typeof Intl !== 'undefined' && 'RelativeTimeFormat' in Intl
+    ? new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+    : null;
+
+const defaultFormatTime = (d: Date): string => {
+  if (!RTF) return d.toLocaleString();
+  const diffMs = d.getTime() - Date.now();
+  const sec = Math.round(diffMs / 1000);
+  const abs = Math.abs(sec);
+  if (abs < 60) return RTF.format(sec, 'second');
+  if (abs < 3600) return RTF.format(Math.round(sec / 60), 'minute');
+  if (abs < 86400) return RTF.format(Math.round(sec / 3600), 'hour');
+  if (abs < 86400 * 30) return RTF.format(Math.round(sec / 86400), 'day');
+  if (abs < 86400 * 365) return RTF.format(Math.round(sec / (86400 * 30)), 'month');
+  return RTF.format(Math.round(sec / (86400 * 365)), 'year');
+};
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function RecentChangesPanel({
+  filePath,
+  commits,
+  onClose,
+  formatTime = defaultFormatTime,
+  className,
+}: RecentChangesPanelProps) {
+  const headingId = React.useId();
+
+  // Esc closes — only when the panel is in the DOM. Listener is on the
+  // window; we attach/detach in an effect.
+  React.useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  return (
+    <aside
+      role="complementary"
+      aria-labelledby={headingId}
+      data-testid="recent-changes-panel"
+      className={cn(
+        'flex h-full flex-col overflow-hidden',
+        'border-l border-[var(--amp-studio-theme-color-border)]',
+        'bg-[var(--amp-studio-theme-color-bg-elev)]',
+        className,
+      )}
+      style={{
+        width:
+          'var(--amp-studio-theme-layout-history-panel-w, 360px)',
+      }}
+    >
+      <header
+        className={cn(
+          'sticky top-0 flex shrink-0 items-center justify-between',
+          'gap-[var(--amp-spacing-2)]',
+          'border-b border-[var(--amp-studio-theme-color-border)]',
+          'bg-[var(--amp-studio-theme-color-bg-elev)]',
+          'px-[var(--amp-spacing-4)] py-[var(--amp-spacing-3)]',
+        )}
+      >
+        <div className="min-w-0 flex-1">
+          <h3
+            id={headingId}
+            data-testid="recent-changes-panel-heading"
+            className={cn(
+              'truncate',
+              'text-[var(--amp-font-size-md)]',
+              'font-[var(--amp-font-weight-semibold)]',
+              'leading-[var(--amp-line-height-tight)]',
+              'text-[var(--amp-studio-theme-color-fg)]',
+            )}
+          >
+            Recent changes
+          </h3>
+          <div
+            className={cn(
+              'truncate font-[var(--amp-font-mono)]',
+              'text-[var(--amp-font-size-xs)]',
+              'text-[var(--amp-studio-theme-color-muted)]',
+            )}
+            data-testid="recent-changes-panel-filepath"
+          >
+            {filePath}
+          </div>
+        </div>
+        <button
+          type="button"
+          aria-label="Close recent changes"
+          data-testid="recent-changes-panel-close"
+          onClick={onClose}
+          className={cn(
+            'inline-flex h-7 w-7 shrink-0 items-center justify-center',
+            'rounded-[var(--amp-radius-sm)] border-0 bg-transparent',
+            'cursor-pointer',
+            'text-[var(--amp-studio-theme-color-muted)]',
+            'hover:bg-[var(--amp-studio-theme-color-bg-subtle)]',
+            'hover:text-[var(--amp-studio-theme-color-fg)]',
+            'focus-visible:outline-none focus-visible:ring-2',
+            'focus-visible:ring-[var(--amp-semantic-border-focus)]',
+            'focus-visible:ring-offset-1',
+          )}
+        >
+          <CloseIcon />
+        </button>
+      </header>
+
+      <div
+        className={cn(
+          'flex-1 overflow-y-auto',
+          'px-[var(--amp-spacing-4)] py-[var(--amp-spacing-3)]',
+        )}
+      >
+        {commits.length === 0 ? (
+          <div
+            data-testid="recent-changes-panel-empty"
+            className={cn(
+              'py-[var(--amp-spacing-6)] text-center',
+              'text-[var(--amp-font-size-sm)]',
+              'text-[var(--amp-studio-theme-color-muted)]',
+            )}
+          >
+            No recent changes for this file.
+          </div>
+        ) : (
+          <ol
+            role="list"
+            data-testid="recent-changes-panel-list"
+            className="m-0 flex list-none flex-col p-0"
+          >
+            {commits.map((commit) => (
+              <li
+                key={commit.sha}
+                data-testid={`recent-changes-panel-commit-${commit.sha}`}
+                className={cn(
+                  'border-b border-[var(--amp-studio-theme-color-border)]',
+                  'py-[var(--amp-spacing-3)]',
+                  'last:border-b-0',
+                )}
+              >
+                <Commit commit={commit} formatTime={formatTime} />
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+RecentChangesPanel.displayName = 'RecentChangesPanel';
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+const Commit: React.FC<{ commit: GitCommit; formatTime: (d: Date) => string }> = ({
+  commit,
+  formatTime,
+}) => {
+  const Wrapper: React.FC<React.PropsWithChildren<{ className: string }>> = ({
+    children,
+    className,
+  }) =>
+    commit.url ? (
+      <a
+        href={commit.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={className}
+        data-testid={`recent-changes-panel-commit-link-${commit.sha}`}
+      >
+        {children}
+      </a>
+    ) : (
+      <span className={className}>{children}</span>
+    );
+
+  return (
+    <div className="flex flex-col gap-[var(--amp-spacing-1)]">
+      <Wrapper
+        className={cn(
+          'block truncate',
+          'text-[var(--amp-font-size-sm)]',
+          'text-[var(--amp-studio-theme-color-fg)]',
+          commit.url && cn(
+            'hover:underline focus-visible:outline-none',
+            'focus-visible:ring-2 focus-visible:ring-offset-1',
+            'focus-visible:ring-[var(--amp-semantic-border-focus)]',
+            'rounded-[var(--amp-radius-xs)]',
+          ),
+        )}
+      >
+        {commit.message}
+      </Wrapper>
+      <div
+        className={cn(
+          'flex items-center gap-[var(--amp-spacing-2)]',
+          'text-[var(--amp-font-size-xs)]',
+          'text-[var(--amp-studio-theme-color-muted)]',
+        )}
+      >
+        <span data-testid={`recent-changes-panel-commit-author-${commit.sha}`}>
+          {commit.author}
+        </span>
+        <span aria-hidden="true">·</span>
+        <span data-testid={`recent-changes-panel-commit-time-${commit.sha}`}>
+          {formatTime(commit.timestamp)}
+        </span>
+        <span aria-hidden="true">·</span>
+        <span
+          className="text-[var(--amp-semantic-color-success)]"
+          data-testid={`recent-changes-panel-commit-added-${commit.sha}`}
+        >
+          +{commit.added}
+        </span>
+        <span
+          className="text-[var(--amp-semantic-color-danger)]"
+          data-testid={`recent-changes-panel-commit-removed-${commit.sha}`}
+        >
+          −{commit.removed}
+        </span>
+        <span
+          aria-hidden="true"
+          className={cn(
+            'ml-auto font-[var(--amp-font-mono)]',
+            'text-[var(--amp-studio-theme-color-muted)]',
+          )}
+        >
+          {commit.sha.slice(0, 7)}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+const CloseIcon: React.FC = () => (
+  <svg
+    width={14}
+    height={14}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <line x1="18" y1="6" x2="6" y2="18" />
+    <line x1="6" y1="6" x2="18" y2="18" />
+  </svg>
+);

--- a/packages/ui/src/components/RecentChangesPanel/index.ts
+++ b/packages/ui/src/components/RecentChangesPanel/index.ts
@@ -1,0 +1,2 @@
+export { RecentChangesPanel } from './RecentChangesPanel';
+export type { RecentChangesPanelProps, GitCommit } from './RecentChangesPanel';

--- a/packages/ui/src/components/ReferenceSnapshotPill/ReferenceSnapshotPill.stories.tsx
+++ b/packages/ui/src/components/ReferenceSnapshotPill/ReferenceSnapshotPill.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { ReferenceSnapshotPill } from './ReferenceSnapshotPill';
+
+/**
+ * `ReferenceSnapshotPill` is the time-stamped pill in the Magic Studio
+ * top-bar that announces when the original page screenshot was captured
+ * (`magic-studio/docs/mockups/option-d.html`, region R2).
+ *
+ * Mockup region:
+ *
+ * ```html
+ * <button class="pill-snapshot" title="Click to view the original screenshot">
+ *   Reference snapshot · 3:42 PM
+ * </button>
+ * ```
+ *
+ * Spec: `magic-studio/docs/mockups/OPTION_D_SPEC.md` §1 R2.
+ */
+const meta = {
+  title: 'Studio v0/ReferenceSnapshotPill',
+  component: ReferenceSnapshotPill,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    status: { type: 'beta' },
+  },
+} satisfies Meta<typeof ReferenceSnapshotPill>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const capturedAt = new Date('2026-05-08T15:42:00');
+
+export const Default: Story = {
+  args: {
+    capturedAt,
+    screenshotUrl: 'https://snapshots.example.com/order-page-3-42pm.png',
+    onClick: () => undefined,
+  },
+};
+
+/** Custom label — used when the snapshot is of something other than a page. */
+export const CustomLabel: Story = {
+  args: {
+    capturedAt,
+    screenshotUrl: 'https://snapshots.example.com/order-page-3-42pm.png',
+    label: 'Original design',
+    onClick: () => undefined,
+  },
+};
+
+/** Pinned formatTime so the rendered label is locale-independent for VR. */
+export const PinnedTimeFormat: Story = {
+  args: {
+    capturedAt,
+    screenshotUrl: 'https://snapshots.example.com/order-page-3-42pm.png',
+    formatTime: () => '3:42 PM',
+    onClick: () => undefined,
+  },
+};

--- a/packages/ui/src/components/ReferenceSnapshotPill/ReferenceSnapshotPill.test.tsx
+++ b/packages/ui/src/components/ReferenceSnapshotPill/ReferenceSnapshotPill.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ReferenceSnapshotPill } from './ReferenceSnapshotPill';
+
+afterEach(cleanup);
+
+const FIXED_DATE = new Date('2026-05-08T15:42:00');
+const SCREENSHOT = 'https://snapshots.example.com/abc.png';
+
+describe('ReferenceSnapshotPill', () => {
+  it('renders as a button (keyboard-activatable)', () => {
+    render(<ReferenceSnapshotPill capturedAt={FIXED_DATE} screenshotUrl={SCREENSHOT} />);
+    const btn = screen.getByTestId('reference-snapshot-pill');
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn.getAttribute('type')).toBe('button');
+  });
+
+  it('renders the label and formatted time text', () => {
+    render(<ReferenceSnapshotPill capturedAt={FIXED_DATE} screenshotUrl={SCREENSHOT} />);
+    const btn = screen.getByTestId('reference-snapshot-pill');
+    // Default label
+    expect(btn.textContent).toMatch(/Reference snapshot/);
+    // Default formatter — locale-dependent but should at minimum contain digits
+    expect(btn.textContent).toMatch(/\d/);
+  });
+
+  it('honours a custom formatTime', () => {
+    render(
+      <ReferenceSnapshotPill
+        capturedAt={FIXED_DATE}
+        screenshotUrl={SCREENSHOT}
+        formatTime={() => 'EXACTLY-NOW'}
+      />,
+    );
+    expect(screen.getByTestId('reference-snapshot-pill').textContent).toContain(
+      'EXACTLY-NOW',
+    );
+  });
+
+  it('honours a custom label prefix', () => {
+    render(
+      <ReferenceSnapshotPill
+        capturedAt={FIXED_DATE}
+        screenshotUrl={SCREENSHOT}
+        label="Original page"
+      />,
+    );
+    expect(screen.getByTestId('reference-snapshot-pill').textContent).toContain(
+      'Original page',
+    );
+  });
+
+  it('exposes the screenshot URL via data-screenshot-url', () => {
+    render(<ReferenceSnapshotPill capturedAt={FIXED_DATE} screenshotUrl={SCREENSHOT} />);
+    expect(
+      screen
+        .getByTestId('reference-snapshot-pill')
+        .getAttribute('data-screenshot-url'),
+    ).toBe(SCREENSHOT);
+  });
+
+  it('exposes the ISO capturedAt via data-captured-at', () => {
+    render(<ReferenceSnapshotPill capturedAt={FIXED_DATE} screenshotUrl={SCREENSHOT} />);
+    expect(
+      screen
+        .getByTestId('reference-snapshot-pill')
+        .getAttribute('data-captured-at'),
+    ).toBe(FIXED_DATE.toISOString());
+  });
+
+  it('fires onClick when clicked', () => {
+    const onClick = vi.fn();
+    render(
+      <ReferenceSnapshotPill
+        capturedAt={FIXED_DATE}
+        screenshotUrl={SCREENSHOT}
+        onClick={onClick}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('reference-snapshot-pill'));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('has a descriptive aria-label naming the action', () => {
+    render(
+      <ReferenceSnapshotPill
+        capturedAt={FIXED_DATE}
+        screenshotUrl={SCREENSHOT}
+        formatTime={() => '3:42 PM'}
+      />,
+    );
+    const btn = screen.getByTestId('reference-snapshot-pill');
+    expect(btn.getAttribute('aria-label')).toMatch(
+      /Reference snapshot taken at 3:42 PM — click to view the original screenshot/,
+    );
+  });
+
+  it('does NOT inject hardcoded hex colours into the rendered DOM', () => {
+    const { container } = render(
+      <ReferenceSnapshotPill capturedAt={FIXED_DATE} screenshotUrl={SCREENSHOT} />,
+    );
+    expect(container.innerHTML).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+  });
+
+  it('does NOT inject inline px appearance values', () => {
+    const { container } = render(
+      <ReferenceSnapshotPill capturedAt={FIXED_DATE} screenshotUrl={SCREENSHOT} />,
+    );
+    expect(container.innerHTML).not.toMatch(/style="[^"]*\d+px/);
+  });
+});

--- a/packages/ui/src/components/ReferenceSnapshotPill/ReferenceSnapshotPill.tsx
+++ b/packages/ui/src/components/ReferenceSnapshotPill/ReferenceSnapshotPill.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+/**
+ * ReferenceSnapshotPill — "Reference snapshot taken at 3:42 PM" pill from
+ * the Magic Studio Option-D cockpit (`magic-studio/docs/mockups/option-d.html`,
+ * region R2). Click opens a modal of the original screenshot.
+ *
+ * Renders as a `<button>` so it is naturally keyboard-activatable. The
+ * component formats `capturedAt` with `Intl.DateTimeFormat` using the
+ * consumer's locale; consumers can override via `formatTime` if a
+ * non-default time format is required.
+ *
+ * The pill stores `screenshotUrl` on `data-screenshot-url` for analytics /
+ * dev-tools introspection, but rendering the modal itself is the
+ * consumer's responsibility (Studio mounts a `<Dialog>` on click). This
+ * primitive is the affordance only.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface ReferenceSnapshotPillProps {
+  /** Timestamp the reference screenshot was captured. */
+  capturedAt: Date;
+  /** URL of the captured screenshot — passed through as `data-screenshot-url`. */
+  screenshotUrl: string;
+  /** Click handler — typically opens a modal previewing `screenshotUrl`. */
+  onClick?: () => void;
+  /**
+   * Optional time formatter. Defaults to `h:mm a` style via
+   * `Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' })`.
+   */
+  formatTime?: (date: Date) => string;
+  /** Optional label prefix. Defaults to `"Reference snapshot"`. */
+  label?: string;
+  /** Optional className passthrough. */
+  className?: string;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const defaultFormatTime = (d: Date): string =>
+  new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(d);
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export const ReferenceSnapshotPill = React.forwardRef<
+  HTMLButtonElement,
+  ReferenceSnapshotPillProps
+>(function ReferenceSnapshotPill(
+  {
+    capturedAt,
+    screenshotUrl,
+    onClick,
+    formatTime = defaultFormatTime,
+    label = 'Reference snapshot',
+    className,
+  },
+  ref,
+) {
+  const timeText = formatTime(capturedAt);
+  const fullText = `${label} · ${timeText}`;
+  const ariaLabel = `${label} taken at ${timeText} — click to view the original screenshot`;
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      data-screenshot-url={screenshotUrl}
+      data-captured-at={capturedAt.toISOString()}
+      data-testid="reference-snapshot-pill"
+      aria-label={ariaLabel}
+      title="Click to view the original screenshot"
+      onClick={onClick}
+      className={cn(
+        'inline-flex items-center gap-1',
+        'rounded-full border-0 cursor-pointer',
+        'px-3 py-1',
+        'text-[var(--amp-font-size-xs)]',
+        'bg-[var(--amp-semantic-color-info-soft)]',
+        'text-[var(--amp-studio-theme-color-fg)]',
+        'transition-shadow duration-[var(--amp-motion-duration-fast)]',
+        'motion-reduce:transition-none',
+        'hover:shadow-[var(--amp-shadow-xs)]',
+        'focus-visible:outline-none focus-visible:ring-2',
+        'focus-visible:ring-[var(--amp-semantic-border-focus)]',
+        'focus-visible:ring-offset-1',
+        className,
+      )}
+    >
+      {fullText}
+    </button>
+  );
+});
+
+ReferenceSnapshotPill.displayName = 'ReferenceSnapshotPill';

--- a/packages/ui/src/components/ReferenceSnapshotPill/index.ts
+++ b/packages/ui/src/components/ReferenceSnapshotPill/index.ts
@@ -1,0 +1,2 @@
+export { ReferenceSnapshotPill } from './ReferenceSnapshotPill';
+export type { ReferenceSnapshotPillProps } from './ReferenceSnapshotPill';

--- a/packages/ui/src/components/ReplyAffordance/ReplyAffordance.stories.tsx
+++ b/packages/ui/src/components/ReplyAffordance/ReplyAffordance.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { ReplyAffordance } from './ReplyAffordance';
+
+/**
+ * `ReplyAffordance` is the hover-revealed pill on a `VariantCard` in the
+ * Magic Studio Option-D cockpit
+ * (`magic-studio/docs/mockups/option-d.html`, region R9). Click pre-fills
+ * the composer with `@V<n> (Gen <m>):`.
+ *
+ * Mockup region:
+ *
+ * ```html
+ * <div class="variant show-reply">
+ *   <button class="reply" title="Reply to this variant — pre-fills composer with @V2 (Gen 3):">↩ Reply</button>
+ * </div>
+ * ```
+ *
+ * Spec: `magic-studio/docs/mockups/OPTION_D_SPEC.md` §1 R9, §2 C6, §4 I3–I4.
+ */
+const meta = {
+  title: 'Studio v0/ReplyAffordance',
+  component: ReplyAffordance,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    status: { type: 'beta' },
+  },
+} satisfies Meta<typeof ReplyAffordance>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    variantRef: { gen: 2, variant: 3 },
+    onClick: () => undefined,
+  },
+};
+
+/**
+ * Letter-keyed variant — when consumers use V<A>, V<B> conventions.
+ */
+export const LetterKey: Story = {
+  args: {
+    variantRef: { gen: 4, variant: 'B' },
+    onClick: () => undefined,
+  },
+};
+
+/**
+ * Custom label — when a denser UI needs a shorter affordance.
+ */
+export const CustomLabel: Story = {
+  args: {
+    variantRef: { gen: 2, variant: 3 },
+    onClick: () => undefined,
+    label: '↩',
+  },
+};
+
+/**
+ * In-context — pinned top-right of a fake variant card to mimic the
+ * mockup's hover-revealed positioning.
+ */
+export const InVariantCardContext: Story = {
+  render: () => (
+    <div
+      style={{
+        position: 'relative',
+        width: 268,
+        height: 320,
+        borderRadius: 12,
+        background: 'var(--amp-studio-theme-color-bg-elev)',
+        border: '1px solid var(--amp-studio-theme-color-border)',
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          top: 'var(--amp-spacing-3)',
+          right: 'var(--amp-spacing-3)',
+        }}
+      >
+        <ReplyAffordance
+          variantRef={{ gen: 3, variant: 2 }}
+          onClick={() => undefined}
+        />
+      </div>
+    </div>
+  ),
+  args: {
+    variantRef: { gen: 3, variant: 2 },
+    onClick: () => undefined,
+  },
+};

--- a/packages/ui/src/components/ReplyAffordance/ReplyAffordance.test.tsx
+++ b/packages/ui/src/components/ReplyAffordance/ReplyAffordance.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ReplyAffordance } from './ReplyAffordance';
+
+afterEach(cleanup);
+
+describe('ReplyAffordance', () => {
+  it('renders as a button (keyboard-activatable)', () => {
+    render(
+      <ReplyAffordance
+        variantRef={{ gen: 2, variant: 3 }}
+        onClick={() => undefined}
+      />,
+    );
+    const btn = screen.getByTestId('reply-affordance');
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn.getAttribute('type')).toBe('button');
+  });
+
+  it('renders the default label "↩ Reply"', () => {
+    render(
+      <ReplyAffordance
+        variantRef={{ gen: 2, variant: 3 }}
+        onClick={() => undefined}
+      />,
+    );
+    expect(screen.getByTestId('reply-affordance').textContent).toBe('↩ Reply');
+  });
+
+  it('honours a custom label', () => {
+    render(
+      <ReplyAffordance
+        variantRef={{ gen: 2, variant: 3 }}
+        onClick={() => undefined}
+        label="Reply to this variant"
+      />,
+    );
+    expect(screen.getByTestId('reply-affordance').textContent).toBe(
+      'Reply to this variant',
+    );
+  });
+
+  it('exposes the reference syntax via data-ref-syntax', () => {
+    render(
+      <ReplyAffordance
+        variantRef={{ gen: 2, variant: 3 }}
+        onClick={() => undefined}
+      />,
+    );
+    expect(
+      screen.getByTestId('reply-affordance').getAttribute('data-ref-syntax'),
+    ).toBe('@V3 (Gen 2):');
+  });
+
+  it('exposes gen / variant attributes for analytics introspection', () => {
+    render(
+      <ReplyAffordance
+        variantRef={{ gen: 4, variant: 'B' }}
+        onClick={() => undefined}
+      />,
+    );
+    const btn = screen.getByTestId('reply-affordance');
+    expect(btn.getAttribute('data-variant-gen')).toBe('4');
+    expect(btn.getAttribute('data-variant')).toBe('B');
+    expect(btn.getAttribute('data-ref-syntax')).toBe('@VB (Gen 4):');
+  });
+
+  it('clicking fires onClick with the same variantRef object', () => {
+    const onClick = vi.fn();
+    const ref = { gen: 2, variant: 3 };
+    render(<ReplyAffordance variantRef={ref} onClick={onClick} />);
+    fireEvent.click(screen.getByTestId('reply-affordance'));
+    expect(onClick).toHaveBeenCalledWith(ref);
+  });
+
+  it('Enter / Space activate the button (native semantics)', () => {
+    const onClick = vi.fn();
+    render(
+      <ReplyAffordance
+        variantRef={{ gen: 1, variant: 1 }}
+        onClick={onClick}
+      />,
+    );
+    const btn = screen.getByTestId('reply-affordance');
+    btn.focus();
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('aria-label describes the action and references the syntax inserted', () => {
+    render(
+      <ReplyAffordance
+        variantRef={{ gen: 2, variant: 3 }}
+        onClick={() => undefined}
+      />,
+    );
+    expect(
+      screen.getByTestId('reply-affordance').getAttribute('aria-label'),
+    ).toBe(
+      'Reply to V3 (Gen 2) — pre-fills composer with @V3 (Gen 2):',
+    );
+  });
+
+  it('does NOT inject hardcoded hex colours into the rendered DOM', () => {
+    const { container } = render(
+      <ReplyAffordance
+        variantRef={{ gen: 2, variant: 3 }}
+        onClick={() => undefined}
+      />,
+    );
+    expect(container.innerHTML).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+  });
+
+  it('does NOT inject inline px appearance values', () => {
+    const { container } = render(
+      <ReplyAffordance
+        variantRef={{ gen: 2, variant: 3 }}
+        onClick={() => undefined}
+      />,
+    );
+    expect(container.innerHTML).not.toMatch(/style="[^"]*\d+px/);
+  });
+});

--- a/packages/ui/src/components/ReplyAffordance/ReplyAffordance.tsx
+++ b/packages/ui/src/components/ReplyAffordance/ReplyAffordance.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+/**
+ * ReplyAffordance — hover-revealed pill that appears on a `VariantCard`
+ * in the Magic Studio Option-D cockpit
+ * (`magic-studio/docs/mockups/option-d.html`, region R9). Click pre-fills
+ * the composer with `@V<n> (Gen <m>):` so users can chain a follow-up
+ * brief tied to a specific variant.
+ *
+ * Visibility is owned by the parent `VariantCard`'s hover state — this
+ * component only renders the pill itself; the parent wires `display:
+ * none` / `display: inline-flex` based on hover. We keep that contract
+ * intact: this primitive renders unconditionally and the parent shows /
+ * hides it via `data-hovered`-driven CSS or by mounting only on hover.
+ *
+ * Note from the SPEC (§4 I3–I4): the affordance opens the composer with
+ * `@V<n> (Gen <m>):` inserted. The reference syntax is `@V` + variant
+ * number + ` (Gen ` + generation number + `):`. Consumers handle that
+ * prefill themselves via `onClick(variantRef)`.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface VariantRef {
+  /** Generation number, 1-indexed. e.g. `2` → "Gen 2". */
+  gen: number;
+  /**
+   * Variant identifier — typically a 1-indexed slot number ("3" → "V3").
+   * Accepts string for letter-keyed variants ("A" / "B") if the consumer
+   * uses that convention.
+   */
+  variant: number | string;
+}
+
+export interface ReplyAffordanceProps {
+  /** The variant being replied to. */
+  variantRef: VariantRef;
+  /** Fired on click — receives the same `variantRef`. */
+  onClick: (variantRef: VariantRef) => void;
+  /** Optional label override. Defaults to `"↩ Reply"`. */
+  label?: string;
+  /** Optional className passthrough. */
+  className?: string;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const formatRefSyntax = (ref: VariantRef): string =>
+  `@V${ref.variant} (Gen ${ref.gen}):`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export const ReplyAffordance = React.forwardRef<
+  HTMLButtonElement,
+  ReplyAffordanceProps
+>(function ReplyAffordance(
+  { variantRef, onClick, label = '↩ Reply', className },
+  ref,
+) {
+  const refSyntax = formatRefSyntax(variantRef);
+  const ariaLabel = `Reply to V${variantRef.variant} (Gen ${variantRef.gen}) — pre-fills composer with ${refSyntax}`;
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      data-variant-gen={variantRef.gen}
+      data-variant={String(variantRef.variant)}
+      data-ref-syntax={refSyntax}
+      data-testid="reply-affordance"
+      aria-label={ariaLabel}
+      title={`Reply to this variant — pre-fills composer with ${refSyntax}`}
+      onClick={() => onClick(variantRef)}
+      className={cn(
+        'inline-flex items-center gap-[var(--amp-spacing-1)]',
+        'rounded-full border cursor-pointer',
+        'border-[var(--amp-studio-theme-color-border)]',
+        'bg-[var(--amp-studio-theme-color-bg-elev)]',
+        'text-[var(--amp-studio-theme-color-fg)]',
+        'px-[var(--amp-spacing-2)] py-[3px]',
+        'text-[var(--amp-font-size-xs)]',
+        'transition-[background-color,border-color,box-shadow] duration-[var(--amp-motion-duration-fast)]',
+        'motion-reduce:transition-none',
+        'hover:border-[var(--amp-semantic-border-accent)]',
+        'hover:bg-[var(--amp-studio-theme-color-bg-subtle)]',
+        'focus-visible:outline-none focus-visible:ring-2',
+        'focus-visible:ring-[var(--amp-semantic-border-focus)]',
+        'focus-visible:ring-offset-1',
+        className,
+      )}
+    >
+      {label}
+    </button>
+  );
+});
+
+ReplyAffordance.displayName = 'ReplyAffordance';

--- a/packages/ui/src/components/ReplyAffordance/index.ts
+++ b/packages/ui/src/components/ReplyAffordance/index.ts
@@ -1,0 +1,2 @@
+export { ReplyAffordance } from './ReplyAffordance';
+export type { ReplyAffordanceProps, VariantRef } from './ReplyAffordance';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -602,3 +602,55 @@ export type {
 // StatusBar
 export { StatusBar } from './components/StatusBar';
 export type { StatusBarProps, StatusBarItem } from './components/StatusBar';
+
+// ─── Studio v0 primitives (Wave 4 — 2.13.0) ──────────────────────────
+// Six new primitives that ship the Magic Studio Option-D cockpit shell.
+// All consume the `--amp-studio-theme-*` token surface; the matching
+// `tokens-studio` bump lands in a sibling PR (see PR body).
+//
+// Source-of-truth contracts:
+//   - magic-studio/docs/mockups/option-d.html
+//   - magic-studio/docs/mockups/OPTION_D_SPEC.md
+//   - packages/ui/src/components/FlowSidebar/SPEC.md (PR #101)
+
+// LivePaneToggle — 3-state Live / Variants / Split control
+export { LivePaneToggle } from './components/LivePaneToggle';
+export type {
+  LivePaneToggleProps,
+  LivePaneMode,
+} from './components/LivePaneToggle';
+
+// ReferenceSnapshotPill — "Reference snapshot · 3:42 PM" pill
+export { ReferenceSnapshotPill } from './components/ReferenceSnapshotPill';
+export type { ReferenceSnapshotPillProps } from './components/ReferenceSnapshotPill';
+
+// DiffOverlay — red/green pixel diff layer (highlight / swipe / side-by-side)
+export { DiffOverlay } from './components/DiffOverlay';
+export type {
+  DiffOverlayProps,
+  DiffOverlayMode,
+} from './components/DiffOverlay';
+
+// FlowContextSidebar — left rail multi-step flow navigator (FlowSidebar
+// SPEC v0 implementation, scoped to the Studio cockpit)
+export { FlowContextSidebar } from './components/FlowContextSidebar';
+export type {
+  FlowContextSidebarProps,
+  FlowStep,
+  FlowStepStatus,
+  FlowStepBadge,
+} from './components/FlowContextSidebar';
+
+// RecentChangesPanel — right side-panel of last N git commits
+export { RecentChangesPanel } from './components/RecentChangesPanel';
+export type {
+  RecentChangesPanelProps,
+  GitCommit,
+} from './components/RecentChangesPanel';
+
+// ReplyAffordance — hover-revealed pill that pre-fills @V<n> (Gen <m>):
+export { ReplyAffordance } from './components/ReplyAffordance';
+export type {
+  ReplyAffordanceProps,
+  VariantRef,
+} from './components/ReplyAffordance';


### PR DESCRIPTION
## Summary

Studio v0 Wave 4 — six new Canvas primitives that ship the Magic Studio Option-D cockpit shell. All ship as `lifecycle.status=beta`, `since=2.13.0`. Pure additive — no breaking changes.

**Source-of-truth contracts:**
- [`magic-studio/docs/mockups/option-d.html`](https://github.com/One-Impression/magic-studio/blob/main/docs/mockups/option-d.html) — canonical mockup (PR #85, just merged)
- [`magic-studio/docs/mockups/OPTION_D_SPEC.md`](https://github.com/One-Impression/magic-studio/blob/main/docs/mockups/OPTION_D_SPEC.md) — binding spec
- [`packages/ui/src/components/FlowSidebar/SPEC.md`](packages/ui/src/components/FlowSidebar/SPEC.md) — FlowSidebar v0 contract (PR #101, just merged); implemented here as `FlowContextSidebar`

## Per-primitive

### 1. `LivePaneToggle` (Studio v0 / R3)

3-state segmented control (`live` / `variants` / `split`) for the Studio top bar. Distinct from the generic `SegmentedControl` because it owns pane-state semantics: switching to `live` or `split` is the consumer's signal to mount a live iframe of `liveUrl`. W3C radiogroup keyboard pattern with roving tabindex; honours `prefers-reduced-motion`.

**Main props:** `value`, `onChange`, `liveUrl?`, `ariaLabel?`, `disabled?`
**Stories:** `Default` · `LiveActive` · `SplitActive` · `Disabled`

### 2. `ReferenceSnapshotPill` (Studio v0 / R2)

"Reference snapshot · 3:42 PM" pill rendered in the top bar after the first generate. Click opens the original-screenshot modal (consumer-rendered).

**Main props:** `capturedAt`, `screenshotUrl`, `onClick?`, `formatTime?`, `label?`
**Stories:** `Default` · `CustomLabel` · `PinnedTimeFormat`

### 3. `DiffOverlay` (Studio v0 / R15)

Red/green pixel-diff layer over the Live pane. Three modes: `highlight` (translucent multiply bands + legend pill), `swipe` (vertical curtain at `swipePercent` 0–100, `clip-path` for clean reveal), `side-by-side` (1fr / 1fr grid). `role="img"` with descriptive aria-label.

**Main props:** `liveScreenshot`, `variantScreenshot`, `mode`, `swipePercent?`, `showLegend?`, `ariaLabel?`
**Stories:** `Highlight` · `Swipe` · `SwipeAt70` · `SideBySide`

### 4. `FlowContextSidebar` (Studio v0 / R5)

Left-rail multi-step flow navigator implementing the FlowSidebar v0 contract from PR #101. 260 px expanded / 44 px rail; per-step status (`default` / `in-progress` / `complete` / `skipped`); roving tabindex; `Enter`/`Space` activate; `Home`/`End` jump first/last; `<a href>` chips render as anchors but still emit `onStepClick`; sticky bottom Apply-to-all action; collapse toggle with `aria-expanded` + `aria-controls`. Empty `steps: []` returns `null`.

**Main props:** `flowName`, `steps`, `activeStepId`, `collapsed?`, `onStepClick?`, `onCollapse?`, `onApplyToAll?`, `applyToAllLabel?`
**Stories:** `Default` · `MixedStatus` · `WithApplyToAll` · `Collapsed` · `LongList` · `Empty`

### 5. `RecentChangesPanel` (Studio v0 / R4)

Right side-panel listing the last N git commits touching a file. 360 px width via `--amp-studio-theme-layout-history-panel-w`; `role="complementary"` with `aria-labelledby`; `Esc` closes; commits with `url` render as `<a target="_blank" rel="noopener>`. `Intl.RelativeTimeFormat` default; overridable.

**Main props:** `filePath`, `commits`, `onClose`, `formatTime?`
**Stories:** `Default` · `Empty` · `SingleCommit`

### 6. `ReplyAffordance` (Studio v0 / R9)

Hover-revealed pill on a `VariantCard` that pre-fills the composer with `@V<n> (Gen <m>):`. Reference syntax exposed via `data-ref-syntax`; gen / variant via dedicated data attributes. Native `<button>` semantics.

**Main props:** `variantRef`, `onClick`, `label?`
**Stories:** `Default` · `LetterKey` · `CustomLabel` · `InVariantCardContext`

## Tokens

All six primitives consume the existing `--amp-studio-theme-*` and `--amp-semantic-*` token surface that ships from `@amplify-ai/tokens-studio` 1.0.2 plus the alias block landed in 2.11.2 / 2.12.0.

**Four token references propose new layout tokens (each with `var(--name, fallback)` defaults so components render correctly even before the token-bump publishes):**

| Token | Default | Used by |
|---|---|---|
| `--amp-studio-theme-layout-flow-sidebar-w` | 260 px | `FlowContextSidebar` (already in OPTION_D_SPEC §7) |
| `--amp-studio-theme-layout-flow-sidebar-rail-w` | 44 px | `FlowContextSidebar` (already in OPTION_D_SPEC §7) |
| `--amp-studio-theme-layout-flow-step-chip-h` | 64 px | `FlowContextSidebar` (already in FlowSidebar SPEC §3) |
| `--amp-studio-theme-layout-history-panel-w` | 360 px | `RecentChangesPanel` (already in OPTION_D_SPEC §6) |

These are all referenced in the source-of-truth specs above and ship via the matching `tokens-studio` sibling PR (token-bump sub-agent). No new colour primitives — semantic colours reuse the existing surface entirely.

## Build / verify

| Check | Status |
|---|---|
| `npm install --cache /tmp/npm-cache-canvas-v2-13` | green |
| `npm run validate` | 0 errors / 0 warnings |
| `npm run build` (all packages) | green |
| `npm run test -w packages/ui` | 343 pass (263 baseline + 80 new) |
| `npx tsc --noEmit -w packages/ui` (the 6 new primitives) | clean |
| Storybook build | green (38 stories across 6 primitives) |
| `dist/contracts.json` (committed) | regenerated, 120 components |

> `tsc --noEmit` reports pre-existing type drift in unrelated `*.stories.tsx` files (React 19 `bigint`-in-`ReactNode` × Storybook 8 types) across the whole repo on `main`. Those are unchanged by this PR. The library output (`tsup` / `dts`) compiles cleanly.

## Versioning

- `@amplify-ai/ui`: `2.12.0` → `2.13.0`
- `component-status.json` extended with the 6 new beta entries (each `since: "2.13.0"`)
- Root `CHANGELOG.md` + new `packages/ui/CHANGELOG.md` updated

## Publish gating

This PR does NOT publish `@amplify-ai/ui@2.13.0` to npm. Publish is gated on the matching `tokens-studio` sibling PR merging first so consumers picking up `@amplify-ai/ui` 2.13.0 alongside `@amplify-ai/tokens-studio` get a consistent token surface. The orchestrating coordinator handles the sequence.

## Test plan

- [ ] `npm install --cache /tmp/npm-cache-canvas-v2-13`
- [ ] `npm run validate`
- [ ] `npm run build`
- [ ] `npm run test -w packages/ui`
- [ ] Pull up Storybook and verify the new stories under `Studio v0/`
  - `LivePaneToggle/Default`, `LiveActive`, `SplitActive`, `Disabled`
  - `ReferenceSnapshotPill/Default`, `CustomLabel`, `PinnedTimeFormat`
  - `DiffOverlay/Highlight`, `Swipe`, `SwipeAt70`, `SideBySide`
  - `FlowContextSidebar/Default`, `MixedStatus`, `WithApplyToAll`, `Collapsed`, `LongList`, `Empty`
  - `RecentChangesPanel/Default`, `Empty`, `SingleCommit`
  - `ReplyAffordance/Default`, `LetterKey`, `CustomLabel`, `InVariantCardContext`
- [ ] Confirm `dist/contracts.json` lists 120 components (Pixel registry consumes this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)