### PR TITLE
feat(tokens-studio): add bg-elev token (1.0.4) for LivePaneToggle active state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10885,7 +10885,7 @@
     },
     "packages/tokens-foundation": {
       "name": "@amplify-ai/tokens-foundation",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
@@ -10899,7 +10899,7 @@
     },
     "packages/tokens-studio": {
       "name": "@amplify-ai/tokens-studio",
-      "version": "1.0.2",
+      "version": "1.0.4",
       "dependencies": {
         "@amplify-ai/tokens-foundation": "^2.1.0"
       },
@@ -10909,7 +10909,7 @@
     },
     "packages/ui": {
       "name": "@amplify-ai/ui",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "dependencies": {
         "clsx": "^2.1.0",
         "tailwind-merge": "^2.3.0"

--- a/packages/tokens-studio/package.json
+++ b/packages/tokens-studio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amplify-ai/tokens-studio",
-  "version": "1.0.3",
-  "description": "Amplify Magic Studio design tokens — Studio cockpit chrome, mirror/Map-mode voices, status scale; consumed only by studio.amplify.club",
+  "version": "1.0.4",
+  "description": "Amplify Magic Studio design tokens \u2014 Studio cockpit chrome, mirror/Map-mode voices, status scale; consumed only by studio.amplify.club",
   "main": "dist/tokens.js",
   "exports": {
     "./css": "./dist/variables.css",

--- a/packages/tokens-studio/tokens/theme-dark.json
+++ b/packages/tokens-studio/tokens/theme-dark.json
@@ -6,6 +6,7 @@
     "color": {
       "$type": "color",
       "bg":             { "$value": "{semantic.bg-surface}",   "$description": "Studio surface background (dark)" },
+      "bg-elev":        { "$value": "{semantic.bg-surface}",   "$description": "Studio elevated surface (dark) — same alias as bg so an inverted-fill chip's text reads as the surface beneath fg. See light-theme description for full context." },
       "fg":             { "$value": "{semantic.text-primary}", "$description": "Studio default foreground (dark)" },
       "muted":          { "$value": "{semantic.text-secondary}", "$description": "Studio muted text (dark)" },
       "border":         { "$value": "{semantic.border-default}", "$description": "Studio default border (dark)" },

--- a/packages/tokens-studio/tokens/theme-light.json
+++ b/packages/tokens-studio/tokens/theme-light.json
@@ -6,6 +6,7 @@
     "color": {
       "$type": "color",
       "bg":             { "$value": "{semantic.bg-surface}",   "$description": "Studio surface background — paired with --studio-bg consumer alias" },
+      "bg-elev":        { "$value": "{semantic.bg-surface}",   "$description": "Studio elevated surface — used as the foreground colour for filled chips/pills whose background is the page bg/fg pair (LivePaneToggle active state). Aliases bg in the default scheme so an inverted-fill button's text reads as the surface beneath fg." },
       "fg":             { "$value": "{semantic.text-primary}", "$description": "Studio default foreground — paired with --studio-fg" },
       "muted":          { "$value": "{semantic.text-secondary}", "$description": "Studio muted text — paired with --studio-muted" },
       "border":         { "$value": "{semantic.border-default}", "$description": "Studio default border — paired with --studio-border" },


### PR DESCRIPTION
## Summary

Closes the missing-token gap that produced the unreadable black-blob bug on the v0 LivePaneToggle in production (`studio.amplify.club`).

`@amplify-ai/ui@2.13.0`'s LivePaneToggle uses
`text-[var(--amp-studio-theme-color-bg-elev)]` for the active-pill
text — but `tokens-studio@1.0.3` doesn't define that variable. CSS
resolves the missing var to `currentColor`, painting dark text on
the dark active background.

## What this changes

- Add `theme.color.bg-elev` to both `theme-light.json` and `theme-dark.json`, aliasing `{semantic.bg-surface}` (= `bg`).
- Bump `@amplify-ai/tokens-studio` 1.0.3 → 1.0.4.

## Why alias `bg-surface`?

For an inverted-fill chip (background = page fg, text = ?), the text
needs to read as the surface beneath fg. That's exactly `bg-surface`
in both schemes:

| theme | `fg`     | `bg-elev` (= `bg-surface`) | contrast    |
|-------|----------|----------------------------|-------------|
| light | `#1C1917` | `#FFFFFF`                  | high (light text on dark) |
| dark  | `#E7E5E4` | `#292524`                  | high (dark text on light) |

## Downstream

The `magic-studio` round-1 defect-fix PR ([#92](https://github.com/One-Impression/magic-studio/pull/92)) currently bridges the missing token in `globals.css`. Once this PR merges + a tokens-studio@1.0.4 publish lands, that bridge can be removed in a one-line follow-up commit on PR #92.

## Test plan

- [x] `npm run build:studio` — built 5 artifacts
- [x] Verified `--amp-studio-theme-color-bg-elev: #FFFFFF;` in `dist/variables.css` (light), `#292524;` (dark)
- [ ] (Reviewer) confirm token name + alias choice match the LivePaneToggle contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)