### PR TITLE
feat(ui-native): add @amplify-ai/ui-native@1.0.0 — 18 React Native primitives

### DIFF
--- a/.changeset/ui-native-v1.md
+++ b/.changeset/ui-native-v1.md
@@ -1,0 +1,13 @@
+---
+"@amplify-ai/ui-native": major
+---
+
+feat(ui-native): initial release — 18 React Native primitives for Creator App SDUI
+
+Token-resolved components consuming @amplify-ai/tokens-creator/react-native:
+- Layout: Box, Stack
+- Foundation: Text, Icon, Image, Separator
+- Interactive: Button, Card, Input, Chip, Checkbox, Radio, Tag, Tab
+- Composite: ProgressIndicator, SearchBar, SelectableItem, ImageStack, Section, ScrollView
+
+Plus ThemeProvider, token type unions, and resolver utilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,10 @@
       "resolved": "packages/ui",
       "link": true
     },
+    "node_modules/@amplify-ai/ui-native": {
+      "resolved": "packages/ui-native",
+      "link": true
+    },
     "node_modules/@amplify/tokens-marketing": {
       "resolved": "packages/tokens-marketing",
       "link": true
@@ -87,7 +91,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -102,7 +105,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -112,7 +114,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -143,7 +144,6 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -160,7 +160,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -177,7 +176,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -187,7 +185,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -197,7 +194,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -211,7 +207,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -229,7 +224,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -239,7 +233,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -249,7 +242,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -259,7 +251,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
       "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -273,7 +264,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -289,7 +279,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -299,7 +288,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -314,7 +302,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -333,7 +320,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -515,6 +501,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -532,6 +519,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -549,6 +537,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -566,6 +555,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -583,6 +573,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -600,6 +591,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -617,6 +609,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -634,6 +627,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -651,6 +645,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -668,6 +663,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -685,6 +681,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -702,6 +699,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -719,6 +717,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -736,6 +735,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -753,6 +753,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -770,6 +771,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -787,6 +789,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -804,6 +807,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -821,6 +825,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -838,6 +843,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -855,6 +861,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -872,6 +879,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -889,6 +897,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -906,6 +915,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -923,6 +933,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -940,6 +951,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1208,6 +1220,44 @@
         "node": ">=12"
       }
     },
+    "node_modules/@isaacs/ttlcache": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+      "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "peer": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "peer": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.5.0.tgz",
@@ -1246,7 +1296,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1257,7 +1306,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1268,24 +1316,31 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1791,6 +1846,271 @@
         "node": ">=14"
       }
     },
+    "node_modules/@react-native/assets-registry": {
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.85.3.tgz",
+      "integrity": "sha512-u9ZiYP23vA2IFtdFQFmetzSmk6SM0xgKIoiOsr1hXNHjHaLhOm+/Ph1ud57wX6+Dbwdzx8coJgnzSKL3W21PCg==",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/codegen": {
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.85.3.tgz",
+      "integrity": "sha512-/JkS1lGLyzBWP1FbgDwaqEf7qShIC6pUC1M0a/YMAd/v4iqR24MRkQWe7jkYvcBQ2LpEhs5NGE9InhxSv21zCA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/parser": "^7.29.0",
+        "hermes-parser": "0.33.3",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "tinyglobby": "^0.2.15",
+        "yargs": "^17.6.2"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin": {
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.85.3.tgz",
+      "integrity": "sha512-fs85dmbIqNmtzEixDb0g+q6R3Vt4H9eAt8/inIZdDKfjN76+sUJA2r1nxODQ76bU23MrIbz8sI7KFBPaWk/zQw==",
+      "peer": true,
+      "dependencies": {
+        "@react-native/dev-middleware": "0.85.3",
+        "debug": "^4.4.0",
+        "invariant": "^2.2.4",
+        "metro": "^0.84.3",
+        "metro-config": "^0.84.3",
+        "metro-core": "^0.84.3",
+        "semver": "^7.1.3"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@react-native-community/cli": "*",
+        "@react-native/metro-config": "0.85.3"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-community/cli": {
+          "optional": true
+        },
+        "@react-native/metro-config": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@react-native/debugger-frontend": {
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.85.3.tgz",
+      "integrity": "sha512-uAu7rM5o/Np1zgp6fi5zM1sP1aB8DcS7DdOLcj/TkSutOAjkMqqd2lWt1/+3S7qXexRHVK5XcP+o3VXo4L/V0A==",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/debugger-shell": {
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.85.3.tgz",
+      "integrity": "sha512-/jRAaT9boiCttIcEwS02WPwYkUihqsjSaK/TMtHz05vT6uMgac9PaQt5kzBQLIABv5aEIa5gtrMmKVz49MjkjQ==",
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.4.0",
+        "fb-dotslash": "0.5.8"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/dev-middleware": {
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.85.3.tgz",
+      "integrity": "sha512-JYzBiT4A8w+KQt+dOD5v+ti+tDrGoPnsSTuApq3Ls4RB5sfWbDlYMyz3dbc8qBIHz9tv0sQ5+eOu6Xwqzr5AQA==",
+      "peer": true,
+      "dependencies": {
+        "@isaacs/ttlcache": "^1.4.1",
+        "@react-native/debugger-frontend": "0.85.3",
+        "@react-native/debugger-shell": "0.85.3",
+        "chrome-launcher": "^0.15.2",
+        "chromium-edge-launcher": "^0.3.0",
+        "connect": "^3.6.5",
+        "debug": "^4.4.0",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "open": "^7.0.3",
+        "serve-static": "^1.16.2",
+        "ws": "^7.5.10"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "peer": true,
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "peer": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "peer": true
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "peer": true,
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-native/gradle-plugin": {
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.85.3.tgz",
+      "integrity": "sha512-39dY2j50Q1pntejzwt3XL7vwXtrj8jcIfHq6E+gyu3jzYxZJVvMkMutQ39vSg6zinIQOX36oQDhidXUbCXzgoA==",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/js-polyfills": {
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.85.3.tgz",
+      "integrity": "sha512-U2+aMshIXf1uFn77tpBb/xhHWB9vkVrMpt7kkucAugF8hJKYTDGB587X7WwelHduK2KBfhl4giSv0rzZGoef9A==",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/normalize-colors": {
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.85.3.tgz",
+      "integrity": "sha512-hj0PScZEhIbcOvQV5yMKX3ha4XEIOy/SVE1Rrpp0beW0dpNLOgSC7KDxGewmDnIHK9YdQUXGY9eMEfShUMIaZw==",
+      "peer": true
+    },
+    "node_modules/@react-native/virtualized-lists": {
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.85.3.tgz",
+      "integrity": "sha512-dsCjI//OIPEUJMyNHp4l7zNLVjCx7bcaRUceOCkU+IB17hkbtbGWvi7HjGFSzy7FJGmS/MOlcfpb72xXiy1Oig==",
+      "peer": true,
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^19.2.0",
+        "react": "*",
+        "react-native": "0.85.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -1906,9 +2226,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1923,9 +2240,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1940,9 +2254,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1957,9 +2268,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1974,9 +2282,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1991,9 +2296,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2008,9 +2310,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2025,9 +2324,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2042,9 +2338,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2059,9 +2352,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2076,9 +2366,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2093,9 +2380,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2110,9 +2394,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2202,6 +2483,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "peer": true
     },
     "node_modules/@storybook/addon-a11y": {
       "version": "8.6.18",
@@ -3001,6 +3288,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "peer": true
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "peer": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "peer": true,
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3019,7 +3330,6 @@
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3029,17 +3339,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
-      "license": "MIT",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "devOptional": true,
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
@@ -3066,6 +3373,21 @@
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "peer": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "peer": true
     },
     "node_modules/@vitest/expect": {
       "version": "2.0.5",
@@ -3225,6 +3547,18 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "peer": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -3242,7 +3576,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3265,7 +3598,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -3304,11 +3636,16 @@
         }
       }
     },
+    "node_modules/anser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
+      "integrity": "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==",
+      "peer": true
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3318,7 +3655,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3353,6 +3689,12 @@
       "dependencies": {
         "dequal": "^2.0.3"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "peer": true
     },
     "node_modules/assert": {
       "version": "2.1.0",
@@ -3424,6 +3766,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/babel-plugin-syntax-hermes-parser": {
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.33.3.tgz",
+      "integrity": "sha512-/Z9xYdaJ1lC0pT9do6TqCqhOSLfZ5Ot8D5za1p+feEfWYupCOfGbhhEXN9r2ZgJtDNUNRw/Z+T2CvAGKBqtqWA==",
+      "peer": true,
+      "dependencies": {
+        "hermes-parser": "0.33.3"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3435,7 +3786,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3456,7 +3806,6 @@
       "version": "2.10.24",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
       "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -3517,7 +3866,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -3536,7 +3884,6 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3566,6 +3913,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "peer": true,
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -3590,6 +3946,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "peer": true
     },
     "node_modules/bundle-require": {
       "version": "5.1.0",
@@ -3684,11 +4046,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001791",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
       "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3726,7 +4099,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -3796,11 +4168,41 @@
         }
       }
     },
+    "node_modules/chrome-launcher": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
+      "integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.js"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/chromium-edge-launcher": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.3.0.tgz",
+      "integrity": "sha512-p03azHlGjtyRvFEee3cyvtsRYdniSkwjkzmM/KmVnqT5d7QkkwpJBhis/zCLMYdQMVJ5tt140TBNqqrZPaWeFA==",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "^1.0.4"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3810,6 +4212,69 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "peer": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "peer": true
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clsx": {
@@ -3825,7 +4290,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3838,7 +4302,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -3858,7 +4321,6 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3890,6 +4352,84 @@
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/connect": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+      "peer": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.2",
+        "parseurl": "~1.3.3",
+        "utils-merge": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/connect/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/connect/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "peer": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "peer": true
+    },
+    "node_modules/connect/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/consola": {
       "version": "3.4.2",
@@ -3927,7 +4467,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -4011,7 +4550,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -4154,6 +4693,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -4205,7 +4754,6 @@
       "version": "1.5.344",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
       "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -4235,6 +4783,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "peer": true,
+      "dependencies": {
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-define-property": {
@@ -4349,7 +4906,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4365,7 +4921,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4582,6 +5137,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -4622,6 +5186,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "peer": true
     },
     "node_modules/express": {
       "version": "5.2.1",
@@ -4720,11 +5290,31 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fb-dotslash": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/fb-dotslash/-/fb-dotslash-0.5.8.tgz",
+      "integrity": "sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==",
+      "peer": true,
+      "bin": {
+        "dotslash": "bin/dotslash"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "peer": true,
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -4755,7 +5345,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4844,6 +5433,12 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/flow-enums-runtime": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz",
+      "integrity": "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==",
+      "peer": true
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -4989,10 +5584,18 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "peer": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -5152,14 +5755,12 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5216,6 +5817,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-compiler": {
+      "version": "250829098.0.10",
+      "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.10.tgz",
+      "integrity": "sha512-TcRlZ0/TlyfJqquRFAWoyElVNnkdYRi/sEp4/Qy8/GYxjg8j2cS9D4MjuaQ+qimkmLN7AmO+44IznRf06mAr0w==",
+      "peer": true
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.33.3.tgz",
+      "integrity": "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==",
+      "peer": true
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.33.3.tgz",
+      "integrity": "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==",
+      "peer": true,
+      "dependencies": {
+        "hermes-estree": "0.33.3"
       }
     },
     "node_modules/hono": {
@@ -5278,7 +5900,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -5345,6 +5966,21 @@
         "node": ">= 4"
       }
     },
+    "node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "peer": true,
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5387,6 +6023,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -5456,7 +6101,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -5482,7 +6126,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5542,7 +6185,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -5613,7 +6255,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0"
@@ -5651,6 +6292,123 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "peer": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "peer": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "peer": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-validate/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "peer": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "peer": true
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/jose": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
@@ -5674,7 +6432,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5689,6 +6446,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsc-safe-url": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/jsc-safe-url/-/jsc-safe-url-0.2.4.tgz",
+      "integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
+      "peer": true
     },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "4.8.0",
@@ -5745,7 +6508,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -5804,7 +6566,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -5856,6 +6617,15 @@
         "graceful-fs": "^4.1.11"
       }
     },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -5869,6 +6639,31 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lighthouse-logger": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
+      "integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
+      "peer": true,
+      "dependencies": {
+        "debug": "^2.6.9",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "peer": true
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -5930,6 +6725,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "peer": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -5964,12 +6777,27 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "peer": true,
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
     "node_modules/map-or-similar": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
       "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/marky": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "peer": true
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -6019,6 +6847,12 @@
         "tslib": "2"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "peer": true
+    },
     "node_modules/memoizerific": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
@@ -6041,11 +6875,368 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "peer": true
+    },
+    "node_modules/metro": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.4.tgz",
+      "integrity": "sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "accepts": "^2.0.0",
+        "ci-info": "^2.0.0",
+        "connect": "^3.6.5",
+        "debug": "^4.4.0",
+        "error-stack-parser": "^2.0.6",
+        "flow-enums-runtime": "^0.0.6",
+        "graceful-fs": "^4.2.4",
+        "hermes-parser": "0.35.0",
+        "image-size": "^1.0.2",
+        "invariant": "^2.2.4",
+        "jest-worker": "^29.7.0",
+        "jsc-safe-url": "^0.2.2",
+        "lodash.throttle": "^4.1.1",
+        "metro-babel-transformer": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-cache-key": "0.84.4",
+        "metro-config": "0.84.4",
+        "metro-core": "0.84.4",
+        "metro-file-map": "0.84.4",
+        "metro-resolver": "0.84.4",
+        "metro-runtime": "0.84.4",
+        "metro-source-map": "0.84.4",
+        "metro-symbolicate": "0.84.4",
+        "metro-transform-plugins": "0.84.4",
+        "metro-transform-worker": "0.84.4",
+        "mime-types": "^3.0.1",
+        "nullthrows": "^1.1.1",
+        "serialize-error": "^2.1.0",
+        "source-map": "^0.5.6",
+        "throat": "^5.0.0",
+        "ws": "^7.5.10",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "metro": "src/cli.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-babel-transformer": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.4.tgz",
+      "integrity": "sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "flow-enums-runtime": "^0.0.6",
+        "hermes-parser": "0.35.0",
+        "metro-cache-key": "0.84.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+      "peer": true
+    },
+    "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+      "peer": true,
+      "dependencies": {
+        "hermes-estree": "0.35.0"
+      }
+    },
+    "node_modules/metro-cache": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.4.tgz",
+      "integrity": "sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==",
+      "peer": true,
+      "dependencies": {
+        "exponential-backoff": "^3.1.1",
+        "flow-enums-runtime": "^0.0.6",
+        "https-proxy-agent": "^7.0.5",
+        "metro-core": "0.84.4"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-cache-key": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.4.tgz",
+      "integrity": "sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-config": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.4.tgz",
+      "integrity": "sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==",
+      "peer": true,
+      "dependencies": {
+        "connect": "^3.6.5",
+        "flow-enums-runtime": "^0.0.6",
+        "jest-validate": "^29.7.0",
+        "metro": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-core": "0.84.4",
+        "metro-runtime": "0.84.4",
+        "yaml": "^2.6.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-core": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.4.tgz",
+      "integrity": "sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "lodash.throttle": "^4.1.1",
+        "metro-resolver": "0.84.4"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-file-map": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.4.tgz",
+      "integrity": "sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "fb-watchman": "^2.0.0",
+        "flow-enums-runtime": "^0.0.6",
+        "graceful-fs": "^4.2.4",
+        "invariant": "^2.2.4",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "nullthrows": "^1.1.1",
+        "walker": "^1.0.7"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-minify-terser": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.4.tgz",
+      "integrity": "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "terser": "^5.15.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-resolver": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.4.tgz",
+      "integrity": "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-runtime": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
+      "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-source-map": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
+      "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-symbolicate": "0.84.4",
+        "nullthrows": "^1.1.1",
+        "ob1": "0.84.4",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-source-map/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/metro-symbolicate": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.4.tgz",
+      "integrity": "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-source-map": "0.84.4",
+        "nullthrows": "^1.1.1",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "bin": {
+        "metro-symbolicate": "src/index.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-symbolicate/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/metro-transform-plugins": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.4.tgz",
+      "integrity": "sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro-transform-worker": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.4.tgz",
+      "integrity": "sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "metro": "0.84.4",
+        "metro-babel-transformer": "0.84.4",
+        "metro-cache": "0.84.4",
+        "metro-cache-key": "0.84.4",
+        "metro-minify-terser": "0.84.4",
+        "metro-source-map": "0.84.4",
+        "metro-transform-plugins": "0.84.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/metro/node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "peer": true
+    },
+    "node_modules/metro/node_modules/hermes-estree": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+      "peer": true
+    },
+    "node_modules/metro/node_modules/hermes-parser": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+      "peer": true,
+      "dependencies": {
+        "hermes-estree": "0.35.0"
+      }
+    },
+    "node_modules/metro/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/metro/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -6059,13 +7250,24 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "peer": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mime-db": {
@@ -6136,6 +7338,18 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "peer": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -6202,12 +7416,23 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "peer": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nullthrows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "peer": true
     },
     "node_modules/nwsapi": {
       "version": "2.2.23",
@@ -6215,6 +7440,18 @@
       "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ob1": {
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.4.tgz",
+      "integrity": "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==",
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -6585,14 +7822,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6791,6 +8026,15 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/promise": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
+      "peer": true,
+      "dependencies": {
+        "asap": "~2.0.6"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -6826,6 +8070,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "peer": true,
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6857,6 +8110,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-devtools-core": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.5.tgz",
+      "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
+      "peer": true,
+      "dependencies": {
+        "shell-quote": "^1.6.1",
+        "ws": "^7"
+      }
+    },
+    "node_modules/react-devtools-core/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-docgen": {
@@ -6910,6 +8194,139 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-native": {
+      "version": "0.85.3",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.85.3.tgz",
+      "integrity": "sha512-HN/fGC+3nZVcDNcw7gfbM/DuqZAvI9Mz+/SxuhODaua4JY0BPzhfTzWXRyTR4mRgMHmShTPpH2PYMTxvZrsdZA==",
+      "peer": true,
+      "dependencies": {
+        "@react-native/assets-registry": "0.85.3",
+        "@react-native/codegen": "0.85.3",
+        "@react-native/community-cli-plugin": "0.85.3",
+        "@react-native/gradle-plugin": "0.85.3",
+        "@react-native/js-polyfills": "0.85.3",
+        "@react-native/normalize-colors": "0.85.3",
+        "@react-native/virtualized-lists": "0.85.3",
+        "abort-controller": "^3.0.0",
+        "anser": "^1.4.9",
+        "ansi-regex": "^5.0.0",
+        "babel-plugin-syntax-hermes-parser": "0.33.3",
+        "base64-js": "^1.5.1",
+        "commander": "^12.0.0",
+        "flow-enums-runtime": "^0.0.6",
+        "hermes-compiler": "250829098.0.10",
+        "invariant": "^2.2.4",
+        "memoize-one": "^5.0.0",
+        "metro-runtime": "^0.84.3",
+        "metro-source-map": "^0.84.3",
+        "nullthrows": "^1.1.1",
+        "pretty-format": "^29.7.0",
+        "promise": "^8.3.0",
+        "react-devtools-core": "^6.1.5",
+        "react-refresh": "^0.14.0",
+        "regenerator-runtime": "^0.13.2",
+        "scheduler": "0.27.0",
+        "semver": "^7.1.3",
+        "stacktrace-parser": "^0.1.10",
+        "tinyglobby": "^0.2.15",
+        "whatwg-fetch": "^3.0.0",
+        "ws": "^7.5.10",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "react-native": "cli.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@react-native/jest-preset": "0.85.3",
+        "@types/react": "^19.1.1",
+        "react": "^19.2.3"
+      },
+      "peerDependenciesMeta": {
+        "@react-native/jest-preset": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/react-native/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "peer": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-native/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "peer": true
+    },
+    "node_modules/react-native/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/react-native/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -6967,6 +8384,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "peer": true
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -7150,14 +8582,12 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7187,6 +8617,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/serve-static": {
@@ -7251,6 +8690,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -7359,7 +8810,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7375,12 +8825,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "peer": true
+    },
+    "node_modules/stacktrace-parser": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+      "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
+      "peer": true,
+      "dependencies": {
+        "type-fest": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -7657,7 +9135,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -7703,6 +9180,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/terser": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "peer": true
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -7743,6 +9244,12 @@
         "tslib": "^2"
       }
     },
+    "node_modules/throat": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+      "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+      "peer": true
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -7775,7 +9282,6 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -7848,11 +9354,16 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "peer": true
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -8562,6 +10073,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8579,6 +10091,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8596,6 +10109,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8613,6 +10127,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8630,6 +10145,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8647,6 +10163,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8664,6 +10181,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8681,6 +10199,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8698,6 +10217,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8715,6 +10235,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8732,6 +10253,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8749,6 +10271,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8766,6 +10289,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8783,6 +10307,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8800,6 +10325,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8817,6 +10343,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8834,6 +10361,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8851,6 +10379,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8868,6 +10397,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8885,6 +10415,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8902,6 +10433,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8919,6 +10451,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8936,6 +10469,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8953,6 +10487,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8970,6 +10505,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8987,6 +10523,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9046,6 +10583,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+      "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -9085,7 +10631,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -9125,7 +10670,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9198,6 +10742,15 @@
         "is-generator-function": "^1.0.7",
         "is-typed-array": "^1.1.3",
         "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/uuid": {
@@ -10447,6 +12000,12 @@
         }
       }
     },
+    "node_modules/vlq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
+      "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
+      "peer": true
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -10458,6 +12017,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "peer": true,
+      "dependencies": {
+        "makeerror": "1.0.12"
       }
     },
     "node_modules/webidl-conversions": {
@@ -10503,6 +12071,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "peer": true
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
@@ -10722,18 +12296,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -10743,6 +12324,65 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "peer": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "peer": true
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {
@@ -10853,6 +12493,16 @@
         "react-dom": ">=18.0.0"
       }
     },
+    "packages/templates/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
     "packages/tokens-atmosphere": {
       "name": "@amplify-ai/tokens-atmosphere",
       "version": "2.0.3",
@@ -10865,7 +12515,7 @@
     },
     "packages/tokens-brand": {
       "name": "@amplify-ai/tokens-brand",
-      "version": "3.0.2",
+      "version": "3.1.0",
       "dependencies": {
         "@amplify-ai/tokens-foundation": "^2.0.1"
       },
@@ -10931,13 +12581,26 @@
         "react-dom": ">=18.0.0"
       }
     },
-    "packages/ui/node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+    "packages/ui-native": {
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/react": "^18.2.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.5.0"
+      },
+      "peerDependencies": {
+        "@amplify-ai/tokens-creator": ">=2.0.3",
+        "react": ">=18.0.0",
+        "react-native": ">=0.72.0"
+      }
+    },
+    "packages/ui-native/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
+        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },

--- a/packages/ui-native/CLAUDE.md
+++ b/packages/ui-native/CLAUDE.md
@@ -1,0 +1,78 @@
+# @amplify-ai/ui-native — Package Context
+
+React Native primitives for the Amplify Creator App. Every component resolves SDUI tokens from `@amplify-ai/tokens-creator/react-native` — no hardcoded colors, spacing, or sizing.
+
+## Architecture
+
+```
+packages/ui-native/
+  src/
+    tokens.ts          — ColorToken, SpacingToken, etc. type unions
+    theme/
+      resolvers.ts     — resolveColor(), resolveSpacing(), etc.
+      ThemeProvider.tsx — React Context wrapping tokens-creator
+    layout/
+      Box.tsx          — flex View with token props
+      Stack.tsx        — vertical/horizontal stack (Box wrapper)
+    primitives/
+      <Name>/          — 5-file pattern per component
+        <Name>.types.ts
+        <Name>.styles.ts
+        <Name>.tsx
+        <Name>.test.tsx
+        index.ts
+```
+
+## Boundaries
+
+- **NO Zod schemas** — those live in `@one-impression/sdk-native-sdui`
+- **NO SDUI renderers** — those live in `@amplify-ai/sdui-runtime`
+- **NO BFF logic, action engine, or creator business logic**
+- **NO `react-dom` imports** — this is React Native only
+- **NO `@one-impression/*` imports** — this package is in the `@amplify-ai` namespace
+
+## Primitives (18)
+
+| Category | Components |
+|----------|-----------|
+| Layout | Box, Stack |
+| Foundation | Text, Icon, Image, Separator |
+| Interactive | Button, Card, Input, Chip, Checkbox, Radio, Tag, Tab |
+| Composite | ProgressIndicator, SearchBar, SelectableItem, ImageStack, Section, ScrollView |
+
+## Token Resolution
+
+All components accept token names as props and resolve them via `theme/resolvers.ts`:
+
+```tsx
+<Box bg="primary" p="lg" rounded="md">
+  <Text color="neutralInverse" size="xl" weight="bold">
+    Hello
+  </Text>
+</Box>
+```
+
+Resolvers accept either a token name OR a raw value, enabling both SDUI-driven and one-off usage.
+
+## Adding a New Primitive
+
+1. Create `src/primitives/<Name>/` with the 5-file pattern
+2. Use token types from `../../tokens` for props
+3. Use resolvers from `../../theme/resolvers` for style computation
+4. Export from the component's `index.ts`
+5. Add exports to `src/index.ts` barrel
+6. Write tests with `@testing-library/react-native`
+
+## Commands
+
+```bash
+npm run build -w packages/ui-native   # tsup ESM + types
+npm run test -w packages/ui-native    # jest + react-native preset
+npm run lint -w packages/ui-native    # eslint
+```
+
+## Peer Dependencies
+
+- `react` >= 18.0.0
+- `react-native` >= 0.72.0
+- `@amplify-ai/tokens-creator` >= 2.1.0

--- a/packages/ui-native/__mocks__/tokens-creator.ts
+++ b/packages/ui-native/__mocks__/tokens-creator.ts
@@ -1,0 +1,46 @@
+/** Mock tokens for testing — mirrors @amplify-ai/tokens-creator/react-native */
+export const sdui = {
+  color: {
+    neutralStrong: '#1C1917',
+    neutralMedium: '#78716C',
+    neutralWeak: '#D6D3D1',
+    neutralSubtle: '#E7E5E4',
+    neutralInverse: '#FFFFFF',
+    primary: '#7C3AED',
+    primaryWeak: '#EDE9FE',
+    positive: '#16A34A',
+    positiveWeak: '#E3F6EC',
+    notice: '#D97706',
+    noticeWeak: '#FFF3E1',
+    negative: '#DC2626',
+    negativeWeak: '#FFEBEF',
+    offsetStrong: '#E7E5E4',
+    offsetMedium: '#F1F6FE',
+    offsetWeak: '#F6FAFF',
+    transparent: 'transparent',
+  },
+  spacing: { xs: 4, sm: 8, md: 12, lg: 16, xl: 24, xxl: 32, xxxl: 48 },
+  fontSize: { xs: 10, sm: 12, md: 14, lg: 16, xl: 20, xxl: 24, xxxl: 32 },
+  fontWeight: { regular: 400, medium: 500, semibold: 600, bold: 700 },
+  iconSize: { sm: 16, md: 20, lg: 24, xl: 32 },
+  radius: { none: 0, xs: 2, sm: 4, md: 8, lg: 12, xl: 16, full: 9999 },
+  borderWidth: { none: 0, thin: 1, medium: 2, thick: 4 },
+  component: {
+    button: {
+      heightSm: 32,
+      heightMd: 40,
+      heightLg: 48,
+      paddingXSm: 12,
+      paddingXMd: 16,
+      paddingXLg: 20,
+      radius: 8,
+      fontSizeSm: 12,
+      fontSizeMd: 14,
+      fontSizeLg: 16,
+    },
+  },
+};
+
+export const colors = { ...sdui.color };
+export const fontSize = { ...sdui.fontSize };
+export const spacing = { ...sdui.spacing };

--- a/packages/ui-native/jest.config.js
+++ b/packages/ui-native/jest.config.js
@@ -1,0 +1,13 @@
+/** @type {import('@jest/types').Config.InitialOptions} */
+export default {
+  preset: 'react-native',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  transform: {
+    '^.+\\.(ts|tsx)$': ['babel-jest', { presets: ['module:@react-native/babel-preset'] }],
+  },
+  testMatch: ['**/*.test.ts', '**/*.test.tsx'],
+  setupFilesAfterSetup: [],
+  moduleNameMapper: {
+    '^@amplify-ai/tokens-creator/react-native$': '<rootDir>/__mocks__/tokens-creator.ts',
+  },
+};

--- a/packages/ui-native/package.json
+++ b/packages/ui-native/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@amplify-ai/ui-native",
+  "version": "1.0.0",
+  "description": "React Native primitives for Amplify Creator App — SDUI-driven, token-resolved components",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup && tsc --emitDeclarationOnly --noCheck",
+    "dev": "tsup --watch",
+    "lint": "eslint src/",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-native": ">=0.72.0",
+    "@amplify-ai/tokens-creator": ">=2.0.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/packages/ui-native/src/index.ts
+++ b/packages/ui-native/src/index.ts
@@ -1,0 +1,103 @@
+// ── Token types ──
+export type {
+  ColorToken,
+  SpacingToken,
+  FontSizeToken,
+  FontWeightToken,
+  IconSizeToken,
+  RadiusToken,
+  BorderWidthToken,
+} from './tokens';
+
+// ── Theme ──
+export { ThemeProvider, useTheme } from './theme';
+export type { ThemeProviderProps } from './theme';
+export {
+  resolveColor,
+  resolveSpacing,
+  resolveFontSize,
+  resolveFontWeight,
+  resolveIconSize,
+  resolveRadius,
+  resolveBorderWidth,
+} from './theme';
+
+// ── Layout ──
+export { Box } from './layout';
+export type { BoxProps } from './layout';
+export { Stack } from './layout';
+export type { StackProps } from './layout';
+
+// ── Primitives ──
+
+// Text
+export { Text } from './primitives/Text';
+export type { TextProps, TextVariant } from './primitives/Text';
+
+// Icon
+export { Icon } from './primitives/Icon';
+export type { IconProps } from './primitives/Icon';
+
+// Image
+export { Image } from './primitives/Image';
+export type { ImageProps, ImageResizeMode } from './primitives/Image';
+
+// Separator
+export { Separator } from './primitives/Separator';
+export type { SeparatorProps } from './primitives/Separator';
+
+// Button
+export { Button } from './primitives/Button';
+export type { ButtonProps, ButtonVariant, ButtonSize } from './primitives/Button';
+
+// Card
+export { Card } from './primitives/Card';
+export type { CardProps } from './primitives/Card';
+
+// Input
+export { Input } from './primitives/Input';
+export type { InputProps } from './primitives/Input';
+
+// Chip
+export { Chip } from './primitives/Chip';
+export type { ChipProps } from './primitives/Chip';
+
+// Checkbox
+export { Checkbox } from './primitives/Checkbox';
+export type { CheckboxProps } from './primitives/Checkbox';
+
+// Radio
+export { Radio } from './primitives/Radio';
+export type { RadioProps } from './primitives/Radio';
+
+// Tag
+export { Tag } from './primitives/Tag';
+export type { TagProps, TagVariant } from './primitives/Tag';
+
+// Tab
+export { Tab } from './primitives/Tab';
+export type { TabProps } from './primitives/Tab';
+
+// ProgressIndicator
+export { ProgressIndicator } from './primitives/ProgressIndicator';
+export type { ProgressIndicatorProps } from './primitives/ProgressIndicator';
+
+// SearchBar
+export { SearchBar } from './primitives/SearchBar';
+export type { SearchBarProps } from './primitives/SearchBar';
+
+// SelectableItem
+export { SelectableItem } from './primitives/SelectableItem';
+export type { SelectableItemProps } from './primitives/SelectableItem';
+
+// ImageStack
+export { ImageStack } from './primitives/ImageStack';
+export type { ImageStackProps } from './primitives/ImageStack';
+
+// Section
+export { Section } from './primitives/Section';
+export type { SectionProps } from './primitives/Section';
+
+// ScrollView
+export { ScrollView } from './primitives/ScrollView';
+export type { ScrollViewProps } from './primitives/ScrollView';

--- a/packages/ui-native/src/layout/Box.tsx
+++ b/packages/ui-native/src/layout/Box.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { View, type ViewProps, type StyleProp, type ViewStyle } from 'react-native';
+import { resolveColor, resolveSpacing, resolveRadius, resolveBorderWidth } from '../theme/resolvers';
+import type { ColorToken, SpacingToken, RadiusToken, BorderWidthToken } from '../tokens';
+
+export interface BoxProps extends ViewProps {
+  /** Background color token or raw color string. */
+  bg?: ColorToken | string;
+  /** Padding — all sides. */
+  p?: SpacingToken | number;
+  /** Horizontal padding. */
+  px?: SpacingToken | number;
+  /** Vertical padding. */
+  py?: SpacingToken | number;
+  /** Padding top. */
+  pt?: SpacingToken | number;
+  /** Padding bottom. */
+  pb?: SpacingToken | number;
+  /** Padding left. */
+  pl?: SpacingToken | number;
+  /** Padding right. */
+  pr?: SpacingToken | number;
+  /** Margin — all sides. */
+  m?: SpacingToken | number;
+  /** Horizontal margin. */
+  mx?: SpacingToken | number;
+  /** Vertical margin. */
+  my?: SpacingToken | number;
+  /** Margin top. */
+  mt?: SpacingToken | number;
+  /** Margin bottom. */
+  mb?: SpacingToken | number;
+  /** Border radius token or raw number. */
+  rounded?: RadiusToken | number;
+  /** Border width token or raw number. */
+  borderWidth?: BorderWidthToken | number;
+  /** Border color token or raw color string. */
+  borderColor?: ColorToken | string;
+  /** Flex value. */
+  flex?: number;
+  /** Flex direction. */
+  direction?: ViewStyle['flexDirection'];
+  /** Align items. */
+  align?: ViewStyle['alignItems'];
+  /** Justify content. */
+  justify?: ViewStyle['justifyContent'];
+  /** Gap between children. */
+  gap?: SpacingToken | number;
+  /** Width. */
+  width?: number | string;
+  /** Height. */
+  height?: number | string;
+}
+
+/**
+ * Box — the fundamental layout primitive. A flex View with token-resolved
+ * spacing, color, and border props.
+ */
+export const Box = React.forwardRef<View, BoxProps>(
+  (
+    {
+      bg,
+      p,
+      px,
+      py,
+      pt,
+      pb,
+      pl,
+      pr,
+      m,
+      mx,
+      my,
+      mt,
+      mb,
+      rounded,
+      borderWidth: bw,
+      borderColor,
+      flex,
+      direction,
+      align,
+      justify,
+      gap,
+      width,
+      height,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const resolvedStyle: ViewStyle = {
+      backgroundColor: resolveColor(bg),
+      padding: resolveSpacing(p),
+      paddingHorizontal: resolveSpacing(px),
+      paddingVertical: resolveSpacing(py),
+      paddingTop: resolveSpacing(pt),
+      paddingBottom: resolveSpacing(pb),
+      paddingLeft: resolveSpacing(pl),
+      paddingRight: resolveSpacing(pr),
+      margin: resolveSpacing(m),
+      marginHorizontal: resolveSpacing(mx),
+      marginVertical: resolveSpacing(my),
+      marginTop: resolveSpacing(mt),
+      marginBottom: resolveSpacing(mb),
+      borderRadius: resolveRadius(rounded),
+      borderWidth: resolveBorderWidth(bw),
+      borderColor: resolveColor(borderColor),
+      flex,
+      flexDirection: direction,
+      alignItems: align,
+      justifyContent: justify,
+      gap: resolveSpacing(gap),
+      width: width as ViewStyle['width'],
+      height: height as ViewStyle['height'],
+    };
+
+    // Strip undefined values to avoid overriding defaults
+    const cleaned = Object.fromEntries(
+      Object.entries(resolvedStyle).filter(([, v]) => v !== undefined),
+    ) as ViewStyle;
+
+    return <View ref={ref} style={[cleaned, style as StyleProp<ViewStyle>]} {...props} />;
+  },
+);
+
+Box.displayName = 'Box';

--- a/packages/ui-native/src/layout/Stack.tsx
+++ b/packages/ui-native/src/layout/Stack.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Box, type BoxProps } from './Box';
+import type { SpacingToken } from '../tokens';
+
+export interface StackProps extends Omit<BoxProps, 'direction'> {
+  /** Gap between children. Defaults to 'sm' (8px). */
+  spacing?: SpacingToken | number;
+  /** Stack direction. Defaults to 'column'. */
+  horizontal?: boolean;
+}
+
+/**
+ * Stack — a thin wrapper around Box that sets flex direction and gap.
+ * Vertical by default; set `horizontal` for a row.
+ */
+export const Stack = React.forwardRef<View, StackProps>(
+  ({ spacing = 'sm', horizontal = false, ...props }, ref) => {
+    return (
+      <Box
+        ref={ref}
+        direction={horizontal ? 'row' : 'column'}
+        gap={spacing}
+        {...props}
+      />
+    );
+  },
+);
+
+Stack.displayName = 'Stack';

--- a/packages/ui-native/src/layout/index.ts
+++ b/packages/ui-native/src/layout/index.ts
@@ -1,0 +1,4 @@
+export { Box } from './Box';
+export type { BoxProps } from './Box';
+export { Stack } from './Stack';
+export type { StackProps } from './Stack';

--- a/packages/ui-native/src/primitives/Button/Button.styles.ts
+++ b/packages/ui-native/src/primitives/Button/Button.styles.ts
@@ -1,0 +1,47 @@
+import { StyleSheet } from 'react-native';
+import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import type { ButtonVariant, ButtonSize } from './Button.types';
+
+type VariantColors = { bg: string; text: string; border?: string };
+
+export const variantColors: Record<ButtonVariant, VariantColors> = {
+  primary: { bg: sdui.color.primary, text: sdui.color.neutralInverse },
+  secondary: { bg: sdui.color.primaryWeak, text: sdui.color.primary },
+  ghost: { bg: 'transparent', text: sdui.color.neutralStrong },
+  outline: { bg: 'transparent', text: sdui.color.neutralStrong, border: sdui.color.neutralSubtle },
+  destructive: { bg: sdui.color.negative, text: sdui.color.neutralInverse },
+};
+
+export const sizeStyles: Record<ButtonSize, { height: number; paddingHorizontal: number; fontSize: number }> = {
+  sm: {
+    height: sdui.component.button.heightSm,
+    paddingHorizontal: sdui.component.button.paddingXSm,
+    fontSize: sdui.component.button.fontSizeSm,
+  },
+  md: {
+    height: sdui.component.button.heightMd,
+    paddingHorizontal: sdui.component.button.paddingXMd,
+    fontSize: sdui.component.button.fontSizeMd,
+  },
+  lg: {
+    height: sdui.component.button.heightLg,
+    paddingHorizontal: sdui.component.button.paddingXLg,
+    fontSize: sdui.component.button.fontSizeLg,
+  },
+};
+
+export const styles = StyleSheet.create({
+  base: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: sdui.component.button.radius,
+    gap: sdui.spacing.sm,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+  label: {
+    fontWeight: '600',
+  },
+});

--- a/packages/ui-native/src/primitives/Button/Button.test.tsx
+++ b/packages/ui-native/src/primitives/Button/Button.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { Button } from './Button';
+
+describe('Button', () => {
+  it('renders label text', () => {
+    render(<Button>Press me</Button>);
+    expect(screen.getByText('Press me')).toBeTruthy();
+  });
+
+  it('has button accessibility role', () => {
+    render(<Button testID="btn">OK</Button>);
+    expect(screen.getByTestId('btn').props.accessibilityRole).toBe('button');
+  });
+
+  it('is disabled when loading', () => {
+    render(<Button testID="btn" loading>OK</Button>);
+    const el = screen.getByTestId('btn');
+    expect(el.props.accessibilityState.busy).toBe(true);
+    expect(el.props.accessibilityState.disabled).toBe(true);
+  });
+
+  it('is disabled when disabled prop is set', () => {
+    render(<Button testID="btn" disabled>OK</Button>);
+    const el = screen.getByTestId('btn');
+    expect(el.props.accessibilityState.disabled).toBe(true);
+  });
+
+  it('fires onPress when not disabled', () => {
+    const onPress = jest.fn();
+    render(<Button testID="btn" onPress={onPress}>OK</Button>);
+    fireEvent.press(screen.getByTestId('btn'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui-native/src/primitives/Button/Button.tsx
+++ b/packages/ui-native/src/primitives/Button/Button.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Pressable, ActivityIndicator, View } from 'react-native';
+import { Text } from '../Text/Text';
+import type { ButtonProps } from './Button.types';
+import { styles, variantColors, sizeStyles } from './Button.styles';
+
+/**
+ * Button — token-driven pressable with variant, size, loading, and icon support.
+ * Uses SDUI component.button tokens for sizing.
+ */
+export const Button = React.forwardRef<View, ButtonProps>(
+  (
+    {
+      variant = 'primary',
+      size = 'md',
+      loading = false,
+      disabled = false,
+      icon,
+      iconPosition = 'left',
+      children,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const colors = variantColors[variant];
+    const sizing = sizeStyles[size];
+    const isDisabled = disabled || loading;
+
+    return (
+      <Pressable
+        ref={ref}
+        disabled={isDisabled}
+        accessibilityRole="button"
+        accessibilityState={{ disabled: isDisabled, busy: loading }}
+        style={[
+          styles.base,
+          {
+            backgroundColor: colors.bg,
+            height: sizing.height,
+            paddingHorizontal: sizing.paddingHorizontal,
+            borderWidth: colors.border ? 1 : 0,
+            borderColor: colors.border,
+          },
+          isDisabled && styles.disabled,
+          style,
+        ]}
+        {...props}
+      >
+        {loading ? (
+          <ActivityIndicator size="small" color={colors.text} />
+        ) : (
+          <>
+            {icon && iconPosition === 'left' && icon}
+            {typeof children === 'string' ? (
+              <Text
+                style={[styles.label, { color: colors.text, fontSize: sizing.fontSize }]}
+              >
+                {children}
+              </Text>
+            ) : (
+              children
+            )}
+            {icon && iconPosition === 'right' && icon}
+          </>
+        )}
+      </Pressable>
+    );
+  },
+);
+
+Button.displayName = 'Button';

--- a/packages/ui-native/src/primitives/Button/Button.types.ts
+++ b/packages/ui-native/src/primitives/Button/Button.types.ts
@@ -1,0 +1,24 @@
+import type { PressableProps, ViewProps } from 'react-native';
+import type { ColorToken } from '../../tokens';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'outline' | 'destructive';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+export interface ButtonProps extends Omit<PressableProps, 'style'> {
+  /** Visual variant. Defaults to 'primary'. */
+  variant?: ButtonVariant;
+  /** Size. Defaults to 'md'. */
+  size?: ButtonSize;
+  /** Loading state — disables press and shows spinner. */
+  loading?: boolean;
+  /** Disabled state. */
+  disabled?: boolean;
+  /** Icon element rendered before the label. */
+  icon?: React.ReactNode;
+  /** Icon position. Defaults to 'left'. */
+  iconPosition?: 'left' | 'right';
+  /** Button label text. */
+  children?: React.ReactNode;
+  /** Additional style overrides. */
+  style?: ViewProps['style'];
+}

--- a/packages/ui-native/src/primitives/Button/index.ts
+++ b/packages/ui-native/src/primitives/Button/index.ts
@@ -1,0 +1,2 @@
+export { Button } from './Button';
+export type { ButtonProps, ButtonVariant, ButtonSize } from './Button.types';

--- a/packages/ui-native/src/primitives/Card/Card.styles.ts
+++ b/packages/ui-native/src/primitives/Card/Card.styles.ts
@@ -1,0 +1,8 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  base: {
+    borderWidth: 1,
+    overflow: 'hidden',
+  },
+});

--- a/packages/ui-native/src/primitives/Card/Card.test.tsx
+++ b/packages/ui-native/src/primitives/Card/Card.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { Text as RNText } from 'react-native';
+import { Card } from './Card';
+
+describe('Card', () => {
+  it('renders children', () => {
+    render(
+      <Card testID="card">
+        <RNText>Content</RNText>
+      </Card>,
+    );
+    expect(screen.getByTestId('card')).toBeTruthy();
+    expect(screen.getByText('Content')).toBeTruthy();
+  });
+
+  it('applies default padding and radius', () => {
+    render(<Card testID="card"><RNText>X</RNText></Card>);
+    const el = screen.getByTestId('card');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.padding).toBe(16); // lg
+    expect(flatStyle.borderRadius).toBe(8); // md
+  });
+});

--- a/packages/ui-native/src/primitives/Card/Card.tsx
+++ b/packages/ui-native/src/primitives/Card/Card.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { View } from 'react-native';
+import type { CardProps } from './Card.types';
+import { styles } from './Card.styles';
+import { resolveColor, resolveSpacing, resolveRadius } from '../../theme/resolvers';
+
+/**
+ * Card — a bordered, padded container for grouped content.
+ */
+export const Card = React.forwardRef<View, CardProps>(
+  (
+    {
+      bg = 'neutralInverse',
+      padding = 'lg',
+      rounded = 'md',
+      borderColor = 'neutralSubtle',
+      mb,
+      style,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <View
+        ref={ref}
+        style={[
+          styles.base,
+          {
+            backgroundColor: resolveColor(bg),
+            padding: resolveSpacing(padding),
+            borderRadius: resolveRadius(rounded),
+            borderColor: resolveColor(borderColor),
+            marginBottom: resolveSpacing(mb),
+          },
+          style,
+        ]}
+        {...props}
+      >
+        {children}
+      </View>
+    );
+  },
+);
+
+Card.displayName = 'Card';

--- a/packages/ui-native/src/primitives/Card/Card.types.ts
+++ b/packages/ui-native/src/primitives/Card/Card.types.ts
@@ -1,0 +1,17 @@
+import type { ViewProps } from 'react-native';
+import type { ColorToken, SpacingToken, RadiusToken } from '../../tokens';
+
+export interface CardProps extends Omit<ViewProps, 'style'> {
+  /** Background color. Defaults to 'neutralInverse' (white). */
+  bg?: ColorToken | string;
+  /** Inner padding. Defaults to 'lg'. */
+  padding?: SpacingToken | number;
+  /** Border radius. Defaults to 'md'. */
+  rounded?: RadiusToken | number;
+  /** Border color. Defaults to 'neutralSubtle'. */
+  borderColor?: ColorToken | string;
+  /** Margin bottom. */
+  mb?: SpacingToken | number;
+  /** Additional style overrides. */
+  style?: ViewProps['style'];
+}

--- a/packages/ui-native/src/primitives/Card/index.ts
+++ b/packages/ui-native/src/primitives/Card/index.ts
@@ -1,0 +1,2 @@
+export { Card } from './Card';
+export type { CardProps } from './Card.types';

--- a/packages/ui-native/src/primitives/Checkbox/Checkbox.styles.ts
+++ b/packages/ui-native/src/primitives/Checkbox/Checkbox.styles.ts
@@ -1,0 +1,35 @@
+import { StyleSheet } from 'react-native';
+import { sdui } from '@amplify-ai/tokens-creator/react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: sdui.spacing.sm,
+  },
+  box: {
+    width: 20,
+    height: 20,
+    borderRadius: sdui.radius.xs,
+    borderWidth: sdui.borderWidth.medium,
+    borderColor: sdui.color.neutralWeak,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  boxChecked: {
+    backgroundColor: sdui.color.primary,
+    borderColor: sdui.color.primary,
+  },
+  checkmark: {
+    color: sdui.color.neutralInverse,
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  label: {
+    fontSize: sdui.fontSize.md,
+    color: sdui.color.neutralStrong,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+});

--- a/packages/ui-native/src/primitives/Checkbox/Checkbox.test.tsx
+++ b/packages/ui-native/src/primitives/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { Checkbox } from './Checkbox';
+
+describe('Checkbox', () => {
+  it('renders unchecked by default', () => {
+    render(<Checkbox testID="cb" />);
+    const el = screen.getByTestId('cb');
+    expect(el.props.accessibilityState.checked).toBe(false);
+  });
+
+  it('renders checked state', () => {
+    render(<Checkbox testID="cb" checked />);
+    const el = screen.getByTestId('cb');
+    expect(el.props.accessibilityState.checked).toBe(true);
+  });
+
+  it('renders label', () => {
+    render(<Checkbox label="Accept terms" />);
+    expect(screen.getByText('Accept terms')).toBeTruthy();
+  });
+
+  it('has checkbox role', () => {
+    render(<Checkbox testID="cb" />);
+    expect(screen.getByTestId('cb').props.accessibilityRole).toBe('checkbox');
+  });
+
+  it('fires onPress', () => {
+    const onPress = jest.fn();
+    render(<Checkbox testID="cb" onPress={onPress} />);
+    fireEvent.press(screen.getByTestId('cb'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui-native/src/primitives/Checkbox/Checkbox.tsx
+++ b/packages/ui-native/src/primitives/Checkbox/Checkbox.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Pressable, View, Text as RNText } from 'react-native';
+import type { CheckboxProps } from './Checkbox.types';
+import { styles } from './Checkbox.styles';
+
+/**
+ * Checkbox — a toggleable check control with optional label.
+ */
+export const Checkbox = React.forwardRef<View, CheckboxProps>(
+  ({ checked = false, label, disabled = false, style, ...props }, ref) => {
+    return (
+      <Pressable
+        ref={ref}
+        disabled={disabled}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked, disabled }}
+        style={[styles.container, disabled && styles.disabled, style]}
+        {...props}
+      >
+        <View style={[styles.box, checked && styles.boxChecked]}>
+          {checked && <RNText style={styles.checkmark}>✓</RNText>}
+        </View>
+        {label && <RNText style={styles.label}>{label}</RNText>}
+      </Pressable>
+    );
+  },
+);
+
+Checkbox.displayName = 'Checkbox';

--- a/packages/ui-native/src/primitives/Checkbox/Checkbox.types.ts
+++ b/packages/ui-native/src/primitives/Checkbox/Checkbox.types.ts
@@ -1,0 +1,12 @@
+import type { PressableProps, ViewProps } from 'react-native';
+
+export interface CheckboxProps extends Omit<PressableProps, 'style'> {
+  /** Whether the checkbox is checked. */
+  checked?: boolean;
+  /** Label text. */
+  label?: string;
+  /** Disabled state. */
+  disabled?: boolean;
+  /** Additional style overrides. */
+  style?: ViewProps['style'];
+}

--- a/packages/ui-native/src/primitives/Checkbox/index.ts
+++ b/packages/ui-native/src/primitives/Checkbox/index.ts
@@ -1,0 +1,2 @@
+export { Checkbox } from './Checkbox';
+export type { CheckboxProps } from './Checkbox.types';

--- a/packages/ui-native/src/primitives/Chip/Chip.styles.ts
+++ b/packages/ui-native/src/primitives/Chip/Chip.styles.ts
@@ -1,0 +1,31 @@
+import { StyleSheet } from 'react-native';
+import { sdui } from '@amplify-ai/tokens-creator/react-native';
+
+export const styles = StyleSheet.create({
+  base: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: sdui.spacing.md,
+    paddingVertical: sdui.spacing.xs,
+    borderRadius: sdui.radius.full,
+    borderWidth: sdui.borderWidth.thin,
+    borderColor: sdui.color.neutralSubtle,
+    backgroundColor: sdui.color.neutralInverse,
+    gap: sdui.spacing.xs,
+  },
+  selected: {
+    backgroundColor: sdui.color.primaryWeak,
+    borderColor: sdui.color.primary,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+  label: {
+    fontSize: sdui.fontSize.sm,
+    fontWeight: '500',
+    color: sdui.color.neutralStrong,
+  },
+  labelSelected: {
+    color: sdui.color.primary,
+  },
+});

--- a/packages/ui-native/src/primitives/Chip/Chip.test.tsx
+++ b/packages/ui-native/src/primitives/Chip/Chip.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { Chip } from './Chip';
+
+describe('Chip', () => {
+  it('renders label', () => {
+    render(<Chip label="Filter" />);
+    expect(screen.getByText('Filter')).toBeTruthy();
+  });
+
+  it('marks selected state in accessibility', () => {
+    render(<Chip testID="chip" label="A" selected />);
+    const el = screen.getByTestId('chip');
+    expect(el.props.accessibilityState.selected).toBe(true);
+  });
+
+  it('fires onPress', () => {
+    const onPress = jest.fn();
+    render(<Chip testID="chip" label="A" onPress={onPress} />);
+    fireEvent.press(screen.getByTestId('chip'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui-native/src/primitives/Chip/Chip.tsx
+++ b/packages/ui-native/src/primitives/Chip/Chip.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Pressable, View } from 'react-native';
+import { Text } from '../Text/Text';
+import type { ChipProps } from './Chip.types';
+import { styles } from './Chip.styles';
+
+/**
+ * Chip — a compact, selectable element for filters and multi-select.
+ */
+export const Chip = React.forwardRef<View, ChipProps>(
+  ({ label, selected = false, disabled = false, icon, style, ...props }, ref) => {
+    return (
+      <Pressable
+        ref={ref}
+        disabled={disabled}
+        accessibilityRole="button"
+        accessibilityState={{ selected, disabled }}
+        style={[
+          styles.base,
+          selected && styles.selected,
+          disabled && styles.disabled,
+          style,
+        ]}
+        {...props}
+      >
+        {icon}
+        <Text style={[styles.label, selected && styles.labelSelected]}>{label}</Text>
+      </Pressable>
+    );
+  },
+);
+
+Chip.displayName = 'Chip';

--- a/packages/ui-native/src/primitives/Chip/Chip.types.ts
+++ b/packages/ui-native/src/primitives/Chip/Chip.types.ts
@@ -1,0 +1,15 @@
+import type { PressableProps, ViewProps } from 'react-native';
+import type { ColorToken } from '../../tokens';
+
+export interface ChipProps extends Omit<PressableProps, 'style'> {
+  /** Label text. */
+  label: string;
+  /** Whether the chip is selected. */
+  selected?: boolean;
+  /** Disabled state. */
+  disabled?: boolean;
+  /** Icon element. */
+  icon?: React.ReactNode;
+  /** Additional style overrides. */
+  style?: ViewProps['style'];
+}

--- a/packages/ui-native/src/primitives/Chip/index.ts
+++ b/packages/ui-native/src/primitives/Chip/index.ts
@@ -1,0 +1,2 @@
+export { Chip } from './Chip';
+export type { ChipProps } from './Chip.types';

--- a/packages/ui-native/src/primitives/Icon/Icon.styles.ts
+++ b/packages/ui-native/src/primitives/Icon/Icon.styles.ts
@@ -1,0 +1,8 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/packages/ui-native/src/primitives/Icon/Icon.test.tsx
+++ b/packages/ui-native/src/primitives/Icon/Icon.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { Icon } from './Icon';
+
+describe('Icon', () => {
+  it('renders with default size', () => {
+    render(<Icon testID="icon" name="star" />);
+    const el = screen.getByTestId('icon');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.width).toBe(20);
+    expect(flatStyle.height).toBe(20);
+  });
+
+  it('resolves size token', () => {
+    render(<Icon testID="icon" name="star" size="lg" />);
+    const el = screen.getByTestId('icon');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.width).toBe(24);
+    expect(flatStyle.height).toBe(24);
+  });
+
+  it('resolves color token', () => {
+    render(<Icon testID="icon" name="star" color="primary" />);
+    const el = screen.getByTestId('icon');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.tintColor).toBe('#7C3AED');
+  });
+
+  it('has image accessibility role', () => {
+    render(<Icon testID="icon" name="star" />);
+    const el = screen.getByTestId('icon');
+    expect(el.props.accessibilityRole).toBe('image');
+  });
+});

--- a/packages/ui-native/src/primitives/Icon/Icon.tsx
+++ b/packages/ui-native/src/primitives/Icon/Icon.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { View } from 'react-native';
+import type { IconProps } from './Icon.types';
+import { styles } from './Icon.styles';
+import { resolveColor, resolveIconSize } from '../../theme/resolvers';
+
+/**
+ * Icon — a sized, colored container for icon content. Renders children
+ * (typically an SVG icon component) inside a constrained box. The
+ * consumer app provides the actual icon library; this primitive only
+ * handles sizing and color resolution.
+ *
+ * Usage:
+ *   <Icon name="heart" size="lg" color="primary">
+ *     <HeartSvg />
+ *   </Icon>
+ *
+ * The `name` prop is available for icon-lookup logic in the consumer
+ * but is not rendered by this component — it exists for SDUI mapping.
+ */
+export const Icon = React.forwardRef<View, IconProps>(
+  ({ name: _name, size = 'md', color = 'neutralStrong', style, children, ...props }, ref) => {
+    const resolvedSize = resolveIconSize(size) ?? 20;
+    const resolvedColor = resolveColor(color);
+
+    return (
+      <View
+        ref={ref}
+        accessibilityRole="image"
+        style={[
+          styles.container,
+          { width: resolvedSize, height: resolvedSize },
+          style,
+        ]}
+        {...props}
+      >
+        {children}
+      </View>
+    );
+  },
+);
+
+Icon.displayName = 'Icon';

--- a/packages/ui-native/src/primitives/Icon/Icon.types.ts
+++ b/packages/ui-native/src/primitives/Icon/Icon.types.ts
@@ -1,0 +1,13 @@
+import type { ViewProps } from 'react-native';
+import type { ColorToken, IconSizeToken } from '../../tokens';
+
+export interface IconProps extends Omit<ViewProps, 'style'> {
+  /** Icon name — passed to the render function. */
+  name: string;
+  /** Size token or raw number. Defaults to 'md' (20). */
+  size?: IconSizeToken | number;
+  /** Color token or raw color string. Defaults to 'neutralStrong'. */
+  color?: ColorToken | string;
+  /** Additional style overrides. */
+  style?: ViewProps['style'];
+}

--- a/packages/ui-native/src/primitives/Icon/index.ts
+++ b/packages/ui-native/src/primitives/Icon/index.ts
@@ -1,0 +1,2 @@
+export { Icon } from './Icon';
+export type { IconProps } from './Icon.types';

--- a/packages/ui-native/src/primitives/Image/Image.styles.ts
+++ b/packages/ui-native/src/primitives/Image/Image.styles.ts
@@ -1,0 +1,7 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  base: {
+    resizeMode: 'cover',
+  },
+});

--- a/packages/ui-native/src/primitives/Image/Image.test.tsx
+++ b/packages/ui-native/src/primitives/Image/Image.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { Image } from './Image';
+
+describe('Image', () => {
+  it('renders with source', () => {
+    render(<Image testID="img" source={{ uri: 'https://example.com/img.jpg' }} />);
+    expect(screen.getByTestId('img')).toBeTruthy();
+  });
+
+  it('applies width and height', () => {
+    render(
+      <Image testID="img" source={{ uri: 'https://example.com/img.jpg' }} width={100} height={100} />,
+    );
+    const el = screen.getByTestId('img');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.width).toBe(100);
+    expect(flatStyle.height).toBe(100);
+  });
+
+  it('resolves border radius token', () => {
+    render(
+      <Image testID="img" source={{ uri: 'https://example.com/img.jpg' }} rounded="full" />,
+    );
+    const el = screen.getByTestId('img');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.borderRadius).toBe(9999);
+  });
+});

--- a/packages/ui-native/src/primitives/Image/Image.tsx
+++ b/packages/ui-native/src/primitives/Image/Image.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Image as RNImage, type ImageStyle } from 'react-native';
+import type { ImageProps } from './Image.types';
+import { styles } from './Image.styles';
+import { resolveRadius, resolveSpacing } from '../../theme/resolvers';
+
+/**
+ * Image — token-resolved image primitive with border radius and spacing support.
+ */
+export const Image = React.forwardRef<RNImage, ImageProps>(
+  (
+    {
+      width,
+      height,
+      aspectRatio,
+      rounded,
+      resizeMode = 'cover',
+      mb,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const imageStyle: ImageStyle = {
+      width: width as ImageStyle['width'],
+      height: height as ImageStyle['height'],
+      aspectRatio,
+      borderRadius: resolveRadius(rounded),
+      resizeMode,
+      marginBottom: resolveSpacing(mb),
+    };
+
+    const cleaned = Object.fromEntries(
+      Object.entries(imageStyle).filter(([, v]) => v !== undefined),
+    ) as ImageStyle;
+
+    return <RNImage ref={ref} style={[styles.base, cleaned, style]} {...props} />;
+  },
+);
+
+Image.displayName = 'Image';

--- a/packages/ui-native/src/primitives/Image/Image.types.ts
+++ b/packages/ui-native/src/primitives/Image/Image.types.ts
@@ -1,0 +1,21 @@
+import type { ImageProps as RNImageProps } from 'react-native';
+import type { RadiusToken, SpacingToken } from '../../tokens';
+
+export type ImageResizeMode = 'cover' | 'contain' | 'stretch' | 'center';
+
+export interface ImageProps extends Omit<RNImageProps, 'style'> {
+  /** Image width. */
+  width?: number | string;
+  /** Image height. */
+  height?: number | string;
+  /** Aspect ratio (e.g. 1 for square, 16/9 for wide). */
+  aspectRatio?: number;
+  /** Border radius token or raw number. */
+  rounded?: RadiusToken | number;
+  /** Resize mode. Defaults to 'cover'. */
+  resizeMode?: ImageResizeMode;
+  /** Margin bottom. */
+  mb?: SpacingToken | number;
+  /** Additional style overrides. */
+  style?: RNImageProps['style'];
+}

--- a/packages/ui-native/src/primitives/Image/index.ts
+++ b/packages/ui-native/src/primitives/Image/index.ts
@@ -1,0 +1,2 @@
+export { Image } from './Image';
+export type { ImageProps, ImageResizeMode } from './Image.types';

--- a/packages/ui-native/src/primitives/ImageStack/ImageStack.styles.ts
+++ b/packages/ui-native/src/primitives/ImageStack/ImageStack.styles.ts
@@ -1,0 +1,25 @@
+import { StyleSheet } from 'react-native';
+import { sdui } from '@amplify-ai/tokens-creator/react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  image: {
+    borderWidth: 2,
+    borderColor: sdui.color.neutralInverse,
+  },
+  overflow: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: sdui.color.neutralSubtle,
+    borderWidth: 2,
+    borderColor: sdui.color.neutralInverse,
+  },
+  overflowText: {
+    fontSize: sdui.fontSize.xs,
+    fontWeight: '600',
+    color: sdui.color.neutralMedium,
+  },
+});

--- a/packages/ui-native/src/primitives/ImageStack/ImageStack.test.tsx
+++ b/packages/ui-native/src/primitives/ImageStack/ImageStack.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { ImageStack } from './ImageStack';
+
+describe('ImageStack', () => {
+  const images = [
+    { uri: 'https://example.com/1.jpg' },
+    { uri: 'https://example.com/2.jpg' },
+    { uri: 'https://example.com/3.jpg' },
+    { uri: 'https://example.com/4.jpg' },
+    { uri: 'https://example.com/5.jpg' },
+  ];
+
+  it('renders max images and overflow count', () => {
+    render(<ImageStack testID="stack" images={images} max={3} />);
+    expect(screen.getByText('+2')).toBeTruthy();
+  });
+
+  it('does not show overflow when images fit within max', () => {
+    render(<ImageStack testID="stack" images={images.slice(0, 2)} max={3} />);
+    expect(screen.queryByText(/\+/)).toBeNull();
+  });
+});

--- a/packages/ui-native/src/primitives/ImageStack/ImageStack.tsx
+++ b/packages/ui-native/src/primitives/ImageStack/ImageStack.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { View, Image as RNImage, Text as RNText } from 'react-native';
+import type { ImageStackProps } from './ImageStack.types';
+import { styles } from './ImageStack.styles';
+import { resolveRadius } from '../../theme/resolvers';
+
+/**
+ * ImageStack — overlapping circular images with overflow count.
+ * Common in creator lists showing multiple profile pictures.
+ */
+export const ImageStack = React.forwardRef<View, ImageStackProps>(
+  ({ images, size = 32, overlap = 8, max = 3, rounded = 'full', style, ...props }, ref) => {
+    const borderRadius = resolveRadius(rounded) ?? 9999;
+    const visible = images.slice(0, max);
+    const overflowCount = images.length - max;
+
+    return (
+      <View ref={ref} style={[styles.container, style]} {...props}>
+        {visible.map((source, i) => (
+          <RNImage
+            key={i}
+            source={source}
+            style={[
+              styles.image,
+              {
+                width: size,
+                height: size,
+                borderRadius,
+                marginLeft: i > 0 ? -overlap : 0,
+                zIndex: visible.length - i,
+              },
+            ]}
+          />
+        ))}
+        {overflowCount > 0 && (
+          <View
+            style={[
+              styles.overflow,
+              {
+                width: size,
+                height: size,
+                borderRadius,
+                marginLeft: -overlap,
+              },
+            ]}
+          >
+            <RNText style={styles.overflowText}>+{overflowCount}</RNText>
+          </View>
+        )}
+      </View>
+    );
+  },
+);
+
+ImageStack.displayName = 'ImageStack';

--- a/packages/ui-native/src/primitives/ImageStack/ImageStack.types.ts
+++ b/packages/ui-native/src/primitives/ImageStack/ImageStack.types.ts
@@ -1,0 +1,17 @@
+import type { ViewProps, ImageSourcePropType } from 'react-native';
+import type { RadiusToken } from '../../tokens';
+
+export interface ImageStackProps extends Omit<ViewProps, 'style'> {
+  /** Array of image sources to stack. */
+  images: ImageSourcePropType[];
+  /** Size of each image circle. Defaults to 32. */
+  size?: number;
+  /** Overlap between images in pixels. Defaults to 8. */
+  overlap?: number;
+  /** Max images to show before "+N" overflow. Defaults to 3. */
+  max?: number;
+  /** Border radius. Defaults to 'full'. */
+  rounded?: RadiusToken | number;
+  /** Additional style overrides. */
+  style?: ViewProps['style'];
+}

--- a/packages/ui-native/src/primitives/ImageStack/index.ts
+++ b/packages/ui-native/src/primitives/ImageStack/index.ts
@@ -1,0 +1,2 @@
+export { ImageStack } from './ImageStack';
+export type { ImageStackProps } from './ImageStack.types';

--- a/packages/ui-native/src/primitives/Input/Input.styles.ts
+++ b/packages/ui-native/src/primitives/Input/Input.styles.ts
@@ -1,0 +1,36 @@
+import { StyleSheet } from 'react-native';
+import { sdui } from '@amplify-ai/tokens-creator/react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    gap: sdui.spacing.xs,
+  },
+  input: {
+    borderWidth: sdui.borderWidth.thin,
+    borderColor: sdui.color.neutralSubtle,
+    borderRadius: sdui.radius.sm,
+    paddingHorizontal: sdui.spacing.md,
+    paddingVertical: sdui.spacing.sm,
+    fontSize: sdui.fontSize.md,
+    color: sdui.color.neutralStrong,
+    backgroundColor: sdui.color.neutralInverse,
+  },
+  inputError: {
+    borderColor: sdui.color.negative,
+  },
+  inputDisabled: {
+    opacity: 0.5,
+  },
+  label: {
+    fontSize: sdui.fontSize.sm,
+    fontWeight: '500',
+    color: sdui.color.neutralStrong,
+  },
+  helperText: {
+    fontSize: sdui.fontSize.xs,
+    color: sdui.color.neutralMedium,
+  },
+  helperError: {
+    color: sdui.color.negative,
+  },
+});

--- a/packages/ui-native/src/primitives/Input/Input.test.tsx
+++ b/packages/ui-native/src/primitives/Input/Input.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { Input } from './Input';
+
+describe('Input', () => {
+  it('renders with placeholder', () => {
+    render(<Input testID="input" placeholder="Enter text" />);
+    expect(screen.getByTestId('input')).toBeTruthy();
+    expect(screen.getByPlaceholderText('Enter text')).toBeTruthy();
+  });
+
+  it('renders label', () => {
+    render(<Input label="Email" testID="input" />);
+    expect(screen.getByText('Email')).toBeTruthy();
+  });
+
+  it('renders helper text', () => {
+    render(<Input helperText="Required field" testID="input" />);
+    expect(screen.getByText('Required field')).toBeTruthy();
+  });
+
+  it('is not editable when disabled', () => {
+    render(<Input testID="input" disabled />);
+    const el = screen.getByTestId('input');
+    expect(el.props.editable).toBe(false);
+  });
+});

--- a/packages/ui-native/src/primitives/Input/Input.tsx
+++ b/packages/ui-native/src/primitives/Input/Input.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { View, TextInput, Text as RNText } from 'react-native';
+import type { InputProps } from './Input.types';
+import { styles } from './Input.styles';
+import { resolveRadius, resolveFontSize } from '../../theme/resolvers';
+
+/**
+ * Input — a text input with label and helper text support.
+ */
+export const Input = React.forwardRef<TextInput, InputProps>(
+  (
+    {
+      label,
+      helperText,
+      error = false,
+      disabled = false,
+      size = 'md',
+      rounded = 'sm',
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <View style={styles.container}>
+        {label && <RNText style={styles.label}>{label}</RNText>}
+        <TextInput
+          ref={ref}
+          editable={!disabled}
+          accessibilityLabel={label}
+          style={[
+            styles.input,
+            {
+              fontSize: resolveFontSize(size) ?? 14,
+              borderRadius: resolveRadius(rounded),
+            },
+            error && styles.inputError,
+            disabled && styles.inputDisabled,
+            style,
+          ]}
+          placeholderTextColor="#78716C"
+          {...props}
+        />
+        {helperText && (
+          <RNText style={[styles.helperText, error && styles.helperError]}>
+            {helperText}
+          </RNText>
+        )}
+      </View>
+    );
+  },
+);
+
+Input.displayName = 'Input';

--- a/packages/ui-native/src/primitives/Input/Input.types.ts
+++ b/packages/ui-native/src/primitives/Input/Input.types.ts
@@ -1,0 +1,19 @@
+import type { TextInputProps as RNTextInputProps } from 'react-native';
+import type { ColorToken, SpacingToken, RadiusToken, FontSizeToken } from '../../tokens';
+
+export interface InputProps extends Omit<RNTextInputProps, 'style'> {
+  /** Label shown above the input. */
+  label?: string;
+  /** Helper or error text below the input. */
+  helperText?: string;
+  /** Error state. */
+  error?: boolean;
+  /** Disabled state. */
+  disabled?: boolean;
+  /** Font size token. Defaults to 'md'. */
+  size?: FontSizeToken | number;
+  /** Border radius. Defaults to 'sm'. */
+  rounded?: RadiusToken | number;
+  /** Additional style overrides for the input container. */
+  style?: RNTextInputProps['style'];
+}

--- a/packages/ui-native/src/primitives/Input/index.ts
+++ b/packages/ui-native/src/primitives/Input/index.ts
@@ -1,0 +1,2 @@
+export { Input } from './Input';
+export type { InputProps } from './Input.types';

--- a/packages/ui-native/src/primitives/ProgressIndicator/ProgressIndicator.styles.ts
+++ b/packages/ui-native/src/primitives/ProgressIndicator/ProgressIndicator.styles.ts
@@ -1,0 +1,11 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  track: {
+    width: '100%',
+    overflow: 'hidden',
+  },
+  fill: {
+    height: '100%',
+  },
+});

--- a/packages/ui-native/src/primitives/ProgressIndicator/ProgressIndicator.test.tsx
+++ b/packages/ui-native/src/primitives/ProgressIndicator/ProgressIndicator.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { ProgressIndicator } from './ProgressIndicator';
+
+describe('ProgressIndicator', () => {
+  it('renders with progressbar role', () => {
+    render(<ProgressIndicator testID="prog" value={0.5} />);
+    const el = screen.getByTestId('prog');
+    expect(el.props.accessibilityRole).toBe('progressbar');
+  });
+
+  it('clamps value to 0-1 range', () => {
+    render(<ProgressIndicator testID="prog" value={1.5} />);
+    const el = screen.getByTestId('prog');
+    expect(el.props.accessibilityValue.now).toBe(100);
+  });
+
+  it('reports percentage in accessibility value', () => {
+    render(<ProgressIndicator testID="prog" value={0.75} />);
+    const el = screen.getByTestId('prog');
+    expect(el.props.accessibilityValue.now).toBe(75);
+  });
+});

--- a/packages/ui-native/src/primitives/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/ui-native/src/primitives/ProgressIndicator/ProgressIndicator.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { View } from 'react-native';
+import type { ProgressIndicatorProps } from './ProgressIndicator.types';
+import { styles } from './ProgressIndicator.styles';
+import { resolveColor, resolveRadius } from '../../theme/resolvers';
+
+/**
+ * ProgressIndicator — a horizontal bar showing completion progress.
+ */
+export const ProgressIndicator = React.forwardRef<View, ProgressIndicatorProps>(
+  (
+    {
+      value,
+      trackColor = 'neutralSubtle',
+      fillColor = 'primary',
+      height = 4,
+      rounded = 'full',
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const clamped = Math.max(0, Math.min(1, value));
+    const borderRadius = resolveRadius(rounded);
+
+    return (
+      <View
+        ref={ref}
+        accessibilityRole="progressbar"
+        accessibilityValue={{ min: 0, max: 100, now: Math.round(clamped * 100) }}
+        style={[
+          styles.track,
+          {
+            height,
+            borderRadius,
+            backgroundColor: resolveColor(trackColor),
+          },
+          style,
+        ]}
+        {...props}
+      >
+        <View
+          style={[
+            styles.fill,
+            {
+              width: `${clamped * 100}%`,
+              borderRadius,
+              backgroundColor: resolveColor(fillColor),
+            },
+          ]}
+        />
+      </View>
+    );
+  },
+);
+
+ProgressIndicator.displayName = 'ProgressIndicator';

--- a/packages/ui-native/src/primitives/ProgressIndicator/ProgressIndicator.types.ts
+++ b/packages/ui-native/src/primitives/ProgressIndicator/ProgressIndicator.types.ts
@@ -1,0 +1,17 @@
+import type { ViewProps } from 'react-native';
+import type { ColorToken, RadiusToken } from '../../tokens';
+
+export interface ProgressIndicatorProps extends Omit<ViewProps, 'style'> {
+  /** Progress value between 0 and 1. */
+  value: number;
+  /** Track color. Defaults to 'neutralSubtle'. */
+  trackColor?: ColorToken | string;
+  /** Fill color. Defaults to 'primary'. */
+  fillColor?: ColorToken | string;
+  /** Height in pixels. Defaults to 4. */
+  height?: number;
+  /** Border radius. Defaults to 'full'. */
+  rounded?: RadiusToken | number;
+  /** Additional style overrides. */
+  style?: ViewProps['style'];
+}

--- a/packages/ui-native/src/primitives/ProgressIndicator/index.ts
+++ b/packages/ui-native/src/primitives/ProgressIndicator/index.ts
@@ -1,0 +1,2 @@
+export { ProgressIndicator } from './ProgressIndicator';
+export type { ProgressIndicatorProps } from './ProgressIndicator.types';

--- a/packages/ui-native/src/primitives/Radio/Radio.styles.ts
+++ b/packages/ui-native/src/primitives/Radio/Radio.styles.ts
@@ -1,0 +1,35 @@
+import { StyleSheet } from 'react-native';
+import { sdui } from '@amplify-ai/tokens-creator/react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: sdui.spacing.sm,
+  },
+  outer: {
+    width: 20,
+    height: 20,
+    borderRadius: sdui.radius.full,
+    borderWidth: sdui.borderWidth.medium,
+    borderColor: sdui.color.neutralWeak,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  outerSelected: {
+    borderColor: sdui.color.primary,
+  },
+  inner: {
+    width: 10,
+    height: 10,
+    borderRadius: sdui.radius.full,
+    backgroundColor: sdui.color.primary,
+  },
+  label: {
+    fontSize: sdui.fontSize.md,
+    color: sdui.color.neutralStrong,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+});

--- a/packages/ui-native/src/primitives/Radio/Radio.test.tsx
+++ b/packages/ui-native/src/primitives/Radio/Radio.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { Radio } from './Radio';
+
+describe('Radio', () => {
+  it('renders unselected by default', () => {
+    render(<Radio testID="radio" />);
+    const el = screen.getByTestId('radio');
+    expect(el.props.accessibilityState.selected).toBe(false);
+  });
+
+  it('renders selected state', () => {
+    render(<Radio testID="radio" selected />);
+    const el = screen.getByTestId('radio');
+    expect(el.props.accessibilityState.selected).toBe(true);
+  });
+
+  it('renders label', () => {
+    render(<Radio label="Option A" />);
+    expect(screen.getByText('Option A')).toBeTruthy();
+  });
+
+  it('has radio role', () => {
+    render(<Radio testID="radio" />);
+    expect(screen.getByTestId('radio').props.accessibilityRole).toBe('radio');
+  });
+
+  it('fires onPress', () => {
+    const onPress = jest.fn();
+    render(<Radio testID="radio" onPress={onPress} />);
+    fireEvent.press(screen.getByTestId('radio'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui-native/src/primitives/Radio/Radio.tsx
+++ b/packages/ui-native/src/primitives/Radio/Radio.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Pressable, View, Text as RNText } from 'react-native';
+import type { RadioProps } from './Radio.types';
+import { styles } from './Radio.styles';
+
+/**
+ * Radio — a single radio button with optional label.
+ * Group logic (mutual exclusion) is handled by the consumer.
+ */
+export const Radio = React.forwardRef<View, RadioProps>(
+  ({ selected = false, label, disabled = false, style, ...props }, ref) => {
+    return (
+      <Pressable
+        ref={ref}
+        disabled={disabled}
+        accessibilityRole="radio"
+        accessibilityState={{ selected, disabled }}
+        style={[styles.container, disabled && styles.disabled, style]}
+        {...props}
+      >
+        <View style={[styles.outer, selected && styles.outerSelected]}>
+          {selected && <View style={styles.inner} />}
+        </View>
+        {label && <RNText style={styles.label}>{label}</RNText>}
+      </Pressable>
+    );
+  },
+);
+
+Radio.displayName = 'Radio';

--- a/packages/ui-native/src/primitives/Radio/Radio.types.ts
+++ b/packages/ui-native/src/primitives/Radio/Radio.types.ts
@@ -1,0 +1,12 @@
+import type { PressableProps, ViewProps } from 'react-native';
+
+export interface RadioProps extends Omit<PressableProps, 'style'> {
+  /** Whether this radio is selected. */
+  selected?: boolean;
+  /** Label text. */
+  label?: string;
+  /** Disabled state. */
+  disabled?: boolean;
+  /** Additional style overrides. */
+  style?: ViewProps['style'];
+}

--- a/packages/ui-native/src/primitives/Radio/index.ts
+++ b/packages/ui-native/src/primitives/Radio/index.ts
@@ -1,0 +1,2 @@
+export { Radio } from './Radio';
+export type { RadioProps } from './Radio.types';

--- a/packages/ui-native/src/primitives/ScrollView/ScrollView.styles.ts
+++ b/packages/ui-native/src/primitives/ScrollView/ScrollView.styles.ts
@@ -1,0 +1,7 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  base: {
+    flex: 1,
+  },
+});

--- a/packages/ui-native/src/primitives/ScrollView/ScrollView.test.tsx
+++ b/packages/ui-native/src/primitives/ScrollView/ScrollView.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { Text as RNText } from 'react-native';
+import { ScrollView } from './ScrollView';
+
+describe('ScrollView', () => {
+  it('renders children', () => {
+    render(
+      <ScrollView testID="scroll">
+        <RNText>Content</RNText>
+      </ScrollView>,
+    );
+    expect(screen.getByTestId('scroll')).toBeTruthy();
+    expect(screen.getByText('Content')).toBeTruthy();
+  });
+
+  it('applies background color token', () => {
+    render(<ScrollView testID="scroll" bg="primary" />);
+    const el = screen.getByTestId('scroll');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.backgroundColor).toBe('#7C3AED');
+  });
+});

--- a/packages/ui-native/src/primitives/ScrollView/ScrollView.tsx
+++ b/packages/ui-native/src/primitives/ScrollView/ScrollView.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { ScrollView as RNScrollView } from 'react-native';
+import type { ScrollViewProps } from './ScrollView.types';
+import { styles } from './ScrollView.styles';
+import { resolveColor, resolveSpacing } from '../../theme/resolvers';
+
+/**
+ * ScrollView — a token-aware scrollable container.
+ */
+export const ScrollView = React.forwardRef<RNScrollView, ScrollViewProps>(
+  ({ bg, padding, style, ...props }, ref) => {
+    return (
+      <RNScrollView
+        ref={ref}
+        style={[
+          styles.base,
+          {
+            backgroundColor: resolveColor(bg),
+          },
+          style,
+        ]}
+        contentContainerStyle={{ padding: resolveSpacing(padding) }}
+        {...props}
+      />
+    );
+  },
+);
+
+ScrollView.displayName = 'ScrollView';

--- a/packages/ui-native/src/primitives/ScrollView/ScrollView.types.ts
+++ b/packages/ui-native/src/primitives/ScrollView/ScrollView.types.ts
@@ -1,0 +1,11 @@
+import type { ScrollViewProps as RNScrollViewProps } from 'react-native';
+import type { ColorToken, SpacingToken } from '../../tokens';
+
+export interface ScrollViewProps extends Omit<RNScrollViewProps, 'style'> {
+  /** Background color. */
+  bg?: ColorToken | string;
+  /** Content padding. */
+  padding?: SpacingToken | number;
+  /** Additional style overrides. */
+  style?: RNScrollViewProps['style'];
+}

--- a/packages/ui-native/src/primitives/ScrollView/index.ts
+++ b/packages/ui-native/src/primitives/ScrollView/index.ts
@@ -1,0 +1,2 @@
+export { ScrollView } from './ScrollView';
+export type { ScrollViewProps } from './ScrollView.types';

--- a/packages/ui-native/src/primitives/SearchBar/SearchBar.styles.ts
+++ b/packages/ui-native/src/primitives/SearchBar/SearchBar.styles.ts
@@ -1,0 +1,35 @@
+import { StyleSheet } from 'react-native';
+import { sdui } from '@amplify-ai/tokens-creator/react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: sdui.color.neutralSubtle,
+    borderRadius: sdui.radius.md,
+    paddingHorizontal: sdui.spacing.md,
+    height: 40,
+    gap: sdui.spacing.sm,
+  },
+  input: {
+    flex: 1,
+    fontSize: sdui.fontSize.md,
+    color: sdui.color.neutralStrong,
+    padding: 0,
+  },
+  searchIcon: {
+    fontSize: sdui.fontSize.lg,
+    color: sdui.color.neutralMedium,
+  },
+  clearButton: {
+    padding: sdui.spacing.xs,
+  },
+  clearText: {
+    fontSize: sdui.fontSize.sm,
+    color: sdui.color.neutralMedium,
+    fontWeight: '600',
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+});

--- a/packages/ui-native/src/primitives/SearchBar/SearchBar.test.tsx
+++ b/packages/ui-native/src/primitives/SearchBar/SearchBar.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { SearchBar } from './SearchBar';
+
+describe('SearchBar', () => {
+  it('renders with placeholder', () => {
+    render(<SearchBar />);
+    expect(screen.getByPlaceholderText('Search...')).toBeTruthy();
+  });
+
+  it('calls onChangeText', () => {
+    const onChangeText = jest.fn();
+    render(<SearchBar testID="search" onChangeText={onChangeText} />);
+    fireEvent.changeText(screen.getByTestId('search'), 'hello');
+    expect(onChangeText).toHaveBeenCalledWith('hello');
+  });
+
+  it('shows clear button when value is present', () => {
+    const onClear = jest.fn();
+    render(<SearchBar value="test" onClear={onClear} />);
+    const clearBtn = screen.getByLabelText('Clear search');
+    expect(clearBtn).toBeTruthy();
+    fireEvent.press(clearBtn);
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides clear button when value is empty', () => {
+    render(<SearchBar value="" onClear={jest.fn()} />);
+    expect(screen.queryByLabelText('Clear search')).toBeNull();
+  });
+});

--- a/packages/ui-native/src/primitives/SearchBar/SearchBar.tsx
+++ b/packages/ui-native/src/primitives/SearchBar/SearchBar.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { View, TextInput, Pressable, Text as RNText } from 'react-native';
+import type { SearchBarProps } from './SearchBar.types';
+import { styles } from './SearchBar.styles';
+
+/**
+ * SearchBar — a text input with search icon and optional clear button.
+ */
+export const SearchBar = React.forwardRef<TextInput, SearchBarProps>(
+  ({ value, onChangeText, onClear, disabled = false, style, ...props }, ref) => {
+    const showClear = value && value.length > 0 && onClear;
+
+    return (
+      <View style={[styles.container, disabled && styles.disabled]}>
+        <RNText style={styles.searchIcon} accessibilityElementsHidden>
+          ⌕
+        </RNText>
+        <TextInput
+          ref={ref}
+          value={value}
+          onChangeText={onChangeText}
+          editable={!disabled}
+          accessibilityRole="search"
+          placeholder="Search..."
+          placeholderTextColor="#78716C"
+          style={[styles.input, style]}
+          {...props}
+        />
+        {showClear && (
+          <Pressable onPress={onClear} style={styles.clearButton} accessibilityLabel="Clear search">
+            <RNText style={styles.clearText}>✕</RNText>
+          </Pressable>
+        )}
+      </View>
+    );
+  },
+);
+
+SearchBar.displayName = 'SearchBar';

--- a/packages/ui-native/src/primitives/SearchBar/SearchBar.types.ts
+++ b/packages/ui-native/src/primitives/SearchBar/SearchBar.types.ts
@@ -1,0 +1,14 @@
+import type { TextInputProps as RNTextInputProps } from 'react-native';
+
+export interface SearchBarProps extends Omit<RNTextInputProps, 'style'> {
+  /** Current search value. */
+  value?: string;
+  /** Called when text changes. */
+  onChangeText?: (text: string) => void;
+  /** Called when clear button is pressed. */
+  onClear?: () => void;
+  /** Disabled state. */
+  disabled?: boolean;
+  /** Additional style overrides for the container. */
+  style?: RNTextInputProps['style'];
+}

--- a/packages/ui-native/src/primitives/SearchBar/index.ts
+++ b/packages/ui-native/src/primitives/SearchBar/index.ts
@@ -1,0 +1,2 @@
+export { SearchBar } from './SearchBar';
+export type { SearchBarProps } from './SearchBar.types';

--- a/packages/ui-native/src/primitives/Section/Section.styles.ts
+++ b/packages/ui-native/src/primitives/Section/Section.styles.ts
@@ -1,0 +1,16 @@
+import { StyleSheet } from 'react-native';
+import { sdui } from '@amplify-ai/tokens-creator/react-native';
+
+export const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: sdui.spacing.md,
+  },
+  title: {
+    fontSize: sdui.fontSize.lg,
+    fontWeight: '600',
+    color: sdui.color.neutralStrong,
+  },
+});

--- a/packages/ui-native/src/primitives/Section/Section.test.tsx
+++ b/packages/ui-native/src/primitives/Section/Section.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { Text as RNText } from 'react-native';
+import { Section } from './Section';
+
+describe('Section', () => {
+  it('renders title', () => {
+    render(<Section title="Campaigns"><RNText>Content</RNText></Section>);
+    expect(screen.getByText('Campaigns')).toBeTruthy();
+  });
+
+  it('renders children', () => {
+    render(<Section><RNText>Body</RNText></Section>);
+    expect(screen.getByText('Body')).toBeTruthy();
+  });
+
+  it('renders headerRight', () => {
+    render(
+      <Section title="Earnings" headerRight={<RNText>See all</RNText>}>
+        <RNText>Content</RNText>
+      </Section>,
+    );
+    expect(screen.getByText('See all')).toBeTruthy();
+  });
+});

--- a/packages/ui-native/src/primitives/Section/Section.tsx
+++ b/packages/ui-native/src/primitives/Section/Section.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { View, Text as RNText } from 'react-native';
+import type { SectionProps } from './Section.types';
+import { styles } from './Section.styles';
+import { resolveColor, resolveSpacing } from '../../theme/resolvers';
+
+/**
+ * Section — a content group with an optional header row (title + trailing action).
+ * Common in SDUI page layouts for "Campaigns", "Earnings", etc.
+ */
+export const Section = React.forwardRef<View, SectionProps>(
+  (
+    {
+      title,
+      headerRight,
+      bg,
+      padding = 'lg',
+      mb = 'lg',
+      style,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <View
+        ref={ref}
+        style={[
+          {
+            backgroundColor: resolveColor(bg),
+            padding: resolveSpacing(padding),
+            marginBottom: resolveSpacing(mb),
+          },
+          style,
+        ]}
+        {...props}
+      >
+        {(title || headerRight) && (
+          <View style={styles.header}>
+            {title && <RNText style={styles.title}>{title}</RNText>}
+            {headerRight}
+          </View>
+        )}
+        {children}
+      </View>
+    );
+  },
+);
+
+Section.displayName = 'Section';

--- a/packages/ui-native/src/primitives/Section/Section.types.ts
+++ b/packages/ui-native/src/primitives/Section/Section.types.ts
@@ -1,0 +1,17 @@
+import type { ViewProps } from 'react-native';
+import type { ColorToken, SpacingToken } from '../../tokens';
+
+export interface SectionProps extends Omit<ViewProps, 'style'> {
+  /** Section heading. */
+  title?: string;
+  /** Trailing element in header row (e.g. "See all" link). */
+  headerRight?: React.ReactNode;
+  /** Background color. */
+  bg?: ColorToken | string;
+  /** Inner padding. Defaults to 'lg'. */
+  padding?: SpacingToken | number;
+  /** Margin bottom. Defaults to 'lg'. */
+  mb?: SpacingToken | number;
+  /** Additional style overrides. */
+  style?: ViewProps['style'];
+}

--- a/packages/ui-native/src/primitives/Section/index.ts
+++ b/packages/ui-native/src/primitives/Section/index.ts
@@ -1,0 +1,2 @@
+export { Section } from './Section';
+export type { SectionProps } from './Section.types';

--- a/packages/ui-native/src/primitives/SelectableItem/SelectableItem.styles.ts
+++ b/packages/ui-native/src/primitives/SelectableItem/SelectableItem.styles.ts
@@ -1,0 +1,32 @@
+import { StyleSheet } from 'react-native';
+import { sdui } from '@amplify-ai/tokens-creator/react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: sdui.spacing.lg,
+    paddingVertical: sdui.spacing.md,
+    gap: sdui.spacing.md,
+    backgroundColor: sdui.color.neutralInverse,
+  },
+  selected: {
+    backgroundColor: sdui.color.primaryWeak,
+  },
+  content: {
+    flex: 1,
+    gap: sdui.spacing.xs,
+  },
+  label: {
+    fontSize: sdui.fontSize.md,
+    fontWeight: '500',
+    color: sdui.color.neutralStrong,
+  },
+  description: {
+    fontSize: sdui.fontSize.sm,
+    color: sdui.color.neutralMedium,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+});

--- a/packages/ui-native/src/primitives/SelectableItem/SelectableItem.test.tsx
+++ b/packages/ui-native/src/primitives/SelectableItem/SelectableItem.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { SelectableItem } from './SelectableItem';
+
+describe('SelectableItem', () => {
+  it('renders label', () => {
+    render(<SelectableItem label="Item 1" />);
+    expect(screen.getByText('Item 1')).toBeTruthy();
+  });
+
+  it('renders description', () => {
+    render(<SelectableItem label="Item" description="Details here" />);
+    expect(screen.getByText('Details here')).toBeTruthy();
+  });
+
+  it('marks selected state', () => {
+    render(<SelectableItem testID="item" label="A" selected />);
+    const el = screen.getByTestId('item');
+    expect(el.props.accessibilityState.selected).toBe(true);
+  });
+
+  it('fires onPress', () => {
+    const onPress = jest.fn();
+    render(<SelectableItem testID="item" label="A" onPress={onPress} />);
+    fireEvent.press(screen.getByTestId('item'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui-native/src/primitives/SelectableItem/SelectableItem.tsx
+++ b/packages/ui-native/src/primitives/SelectableItem/SelectableItem.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Pressable, View, Text as RNText } from 'react-native';
+import type { SelectableItemProps } from './SelectableItem.types';
+import { styles } from './SelectableItem.styles';
+
+/**
+ * SelectableItem — a list item with leading/trailing slots, pressable
+ * for selection. Used in SDUI lists, settings, multi-select surfaces.
+ */
+export const SelectableItem = React.forwardRef<View, SelectableItemProps>(
+  (
+    {
+      label,
+      description,
+      selected = false,
+      disabled = false,
+      leading,
+      trailing,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <Pressable
+        ref={ref}
+        disabled={disabled}
+        accessibilityRole="button"
+        accessibilityState={{ selected, disabled }}
+        style={[
+          styles.container,
+          selected && styles.selected,
+          disabled && styles.disabled,
+          style,
+        ]}
+        {...props}
+      >
+        {leading}
+        <View style={styles.content}>
+          <RNText style={styles.label}>{label}</RNText>
+          {description && <RNText style={styles.description}>{description}</RNText>}
+        </View>
+        {trailing}
+      </Pressable>
+    );
+  },
+);
+
+SelectableItem.displayName = 'SelectableItem';

--- a/packages/ui-native/src/primitives/SelectableItem/SelectableItem.types.ts
+++ b/packages/ui-native/src/primitives/SelectableItem/SelectableItem.types.ts
@@ -1,0 +1,18 @@
+import type { PressableProps, ViewProps } from 'react-native';
+
+export interface SelectableItemProps extends Omit<PressableProps, 'style'> {
+  /** Primary label text. */
+  label: string;
+  /** Secondary description text. */
+  description?: string;
+  /** Whether the item is selected. */
+  selected?: boolean;
+  /** Disabled state. */
+  disabled?: boolean;
+  /** Leading element (icon, avatar, image). */
+  leading?: React.ReactNode;
+  /** Trailing element (checkbox, radio, badge). */
+  trailing?: React.ReactNode;
+  /** Additional style overrides. */
+  style?: ViewProps['style'];
+}

--- a/packages/ui-native/src/primitives/SelectableItem/index.ts
+++ b/packages/ui-native/src/primitives/SelectableItem/index.ts
@@ -1,0 +1,2 @@
+export { SelectableItem } from './SelectableItem';
+export type { SelectableItemProps } from './SelectableItem.types';

--- a/packages/ui-native/src/primitives/Separator/Separator.styles.ts
+++ b/packages/ui-native/src/primitives/Separator/Separator.styles.ts
@@ -1,0 +1,12 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  horizontal: {
+    height: 1,
+    alignSelf: 'stretch',
+  },
+  vertical: {
+    width: 1,
+    alignSelf: 'stretch',
+  },
+});

--- a/packages/ui-native/src/primitives/Separator/Separator.test.tsx
+++ b/packages/ui-native/src/primitives/Separator/Separator.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { Separator } from './Separator';
+
+describe('Separator', () => {
+  it('renders horizontal by default', () => {
+    render(<Separator testID="sep" />);
+    const el = screen.getByTestId('sep');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.height).toBe(1);
+    expect(flatStyle.alignSelf).toBe('stretch');
+  });
+
+  it('renders vertical', () => {
+    render(<Separator testID="sep" orientation="vertical" />);
+    const el = screen.getByTestId('sep');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.width).toBe(1);
+  });
+
+  it('resolves color token', () => {
+    render(<Separator testID="sep" color="primary" />);
+    const el = screen.getByTestId('sep');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.backgroundColor).toBe('#7C3AED');
+  });
+
+  it('applies spacing', () => {
+    render(<Separator testID="sep" spacing="md" />);
+    const el = screen.getByTestId('sep');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.marginVertical).toBe(12);
+  });
+});

--- a/packages/ui-native/src/primitives/Separator/Separator.tsx
+++ b/packages/ui-native/src/primitives/Separator/Separator.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { View } from 'react-native';
+import type { SeparatorProps } from './Separator.types';
+import { styles } from './Separator.styles';
+import { resolveColor, resolveSpacing } from '../../theme/resolvers';
+
+/**
+ * Separator — a thin line to visually divide content sections.
+ */
+export const Separator = React.forwardRef<View, SeparatorProps>(
+  (
+    {
+      orientation = 'horizontal',
+      color = 'neutralSubtle',
+      thickness = 1,
+      spacing,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const resolvedColor = resolveColor(color);
+    const resolvedSpacing = resolveSpacing(spacing);
+    const isHorizontal = orientation === 'horizontal';
+
+    return (
+      <View
+        ref={ref}
+        accessibilityRole="none"
+        style={[
+          isHorizontal ? styles.horizontal : styles.vertical,
+          {
+            backgroundColor: resolvedColor,
+            [isHorizontal ? 'height' : 'width']: thickness,
+            marginVertical: isHorizontal ? resolvedSpacing : undefined,
+            marginHorizontal: isHorizontal ? undefined : resolvedSpacing,
+          },
+          style,
+        ]}
+        {...props}
+      />
+    );
+  },
+);
+
+Separator.displayName = 'Separator';

--- a/packages/ui-native/src/primitives/Separator/Separator.types.ts
+++ b/packages/ui-native/src/primitives/Separator/Separator.types.ts
@@ -1,0 +1,15 @@
+import type { ViewProps } from 'react-native';
+import type { ColorToken, SpacingToken } from '../../tokens';
+
+export interface SeparatorProps extends Omit<ViewProps, 'style'> {
+  /** Orientation. Defaults to 'horizontal'. */
+  orientation?: 'horizontal' | 'vertical';
+  /** Color token or raw color string. Defaults to 'neutralSubtle'. */
+  color?: ColorToken | string;
+  /** Thickness in pixels. Defaults to 1. */
+  thickness?: number;
+  /** Margin on both sides of the separator. */
+  spacing?: SpacingToken | number;
+  /** Additional style overrides. */
+  style?: ViewProps['style'];
+}

--- a/packages/ui-native/src/primitives/Separator/index.ts
+++ b/packages/ui-native/src/primitives/Separator/index.ts
@@ -1,0 +1,2 @@
+export { Separator } from './Separator';
+export type { SeparatorProps } from './Separator.types';

--- a/packages/ui-native/src/primitives/Tab/Tab.styles.ts
+++ b/packages/ui-native/src/primitives/Tab/Tab.styles.ts
@@ -1,0 +1,30 @@
+import { StyleSheet } from 'react-native';
+import { sdui } from '@amplify-ai/tokens-creator/react-native';
+
+export const styles = StyleSheet.create({
+  base: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: sdui.spacing.lg,
+    paddingVertical: sdui.spacing.sm,
+    gap: sdui.spacing.xs,
+    borderBottomWidth: 2,
+    borderBottomColor: 'transparent',
+  },
+  active: {
+    borderBottomColor: sdui.color.primary,
+  },
+  label: {
+    fontSize: sdui.fontSize.md,
+    fontWeight: '500',
+    color: sdui.color.neutralMedium,
+  },
+  labelActive: {
+    color: sdui.color.primary,
+    fontWeight: '600',
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+});

--- a/packages/ui-native/src/primitives/Tab/Tab.test.tsx
+++ b/packages/ui-native/src/primitives/Tab/Tab.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { Tab } from './Tab';
+
+describe('Tab', () => {
+  it('renders label', () => {
+    render(<Tab label="Overview" />);
+    expect(screen.getByText('Overview')).toBeTruthy();
+  });
+
+  it('has tab accessibility role', () => {
+    render(<Tab testID="tab" label="A" />);
+    expect(screen.getByTestId('tab').props.accessibilityRole).toBe('tab');
+  });
+
+  it('marks active state', () => {
+    render(<Tab testID="tab" label="A" active />);
+    const el = screen.getByTestId('tab');
+    expect(el.props.accessibilityState.selected).toBe(true);
+  });
+
+  it('fires onPress', () => {
+    const onPress = jest.fn();
+    render(<Tab testID="tab" label="A" onPress={onPress} />);
+    fireEvent.press(screen.getByTestId('tab'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui-native/src/primitives/Tab/Tab.tsx
+++ b/packages/ui-native/src/primitives/Tab/Tab.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Pressable, View, Text as RNText } from 'react-native';
+import type { TabProps } from './Tab.types';
+import { styles } from './Tab.styles';
+
+/**
+ * Tab — a single tab item. Use inside a horizontal ScrollView or Row
+ * for a tab bar. Active state is controlled by the consumer.
+ */
+export const Tab = React.forwardRef<View, TabProps>(
+  ({ label, active = false, disabled = false, icon, style, ...props }, ref) => {
+    return (
+      <Pressable
+        ref={ref}
+        disabled={disabled}
+        accessibilityRole="tab"
+        accessibilityState={{ selected: active, disabled }}
+        style={[
+          styles.base,
+          active && styles.active,
+          disabled && styles.disabled,
+          style,
+        ]}
+        {...props}
+      >
+        {icon}
+        <RNText style={[styles.label, active && styles.labelActive]}>{label}</RNText>
+      </Pressable>
+    );
+  },
+);
+
+Tab.displayName = 'Tab';

--- a/packages/ui-native/src/primitives/Tab/Tab.types.ts
+++ b/packages/ui-native/src/primitives/Tab/Tab.types.ts
@@ -1,0 +1,14 @@
+import type { PressableProps, ViewProps } from 'react-native';
+
+export interface TabProps extends Omit<PressableProps, 'style'> {
+  /** Tab label text. */
+  label: string;
+  /** Whether this tab is active. */
+  active?: boolean;
+  /** Disabled state. */
+  disabled?: boolean;
+  /** Icon element. */
+  icon?: React.ReactNode;
+  /** Additional style overrides. */
+  style?: ViewProps['style'];
+}

--- a/packages/ui-native/src/primitives/Tab/index.ts
+++ b/packages/ui-native/src/primitives/Tab/index.ts
@@ -1,0 +1,2 @@
+export { Tab } from './Tab';
+export type { TabProps } from './Tab.types';

--- a/packages/ui-native/src/primitives/Tag/Tag.styles.ts
+++ b/packages/ui-native/src/primitives/Tag/Tag.styles.ts
@@ -1,0 +1,31 @@
+import { StyleSheet } from 'react-native';
+import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import type { TagVariant } from './Tag.types';
+
+type VariantColors = { bg: string; text: string; border: string };
+
+export const variantColors: Record<TagVariant, VariantColors> = {
+  default: { bg: sdui.color.neutralInverse, text: sdui.color.neutralStrong, border: sdui.color.neutralSubtle },
+  primary: { bg: sdui.color.primaryWeak, text: sdui.color.primary, border: sdui.color.primary },
+  positive: { bg: sdui.color.positiveWeak, text: sdui.color.positive, border: sdui.color.positive },
+  negative: { bg: sdui.color.negativeWeak, text: sdui.color.negative, border: sdui.color.negative },
+  notice: { bg: sdui.color.noticeWeak, text: sdui.color.notice, border: sdui.color.notice },
+  neutral: { bg: sdui.color.neutralSubtle, text: sdui.color.neutralMedium, border: sdui.color.neutralSubtle },
+};
+
+export const styles = StyleSheet.create({
+  base: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: sdui.spacing.sm,
+    paddingVertical: sdui.spacing.xs,
+    borderRadius: sdui.radius.xs,
+    borderWidth: sdui.borderWidth.thin,
+    gap: sdui.spacing.xs,
+    alignSelf: 'flex-start',
+  },
+  label: {
+    fontSize: sdui.fontSize.xs,
+    fontWeight: '500',
+  },
+});

--- a/packages/ui-native/src/primitives/Tag/Tag.test.tsx
+++ b/packages/ui-native/src/primitives/Tag/Tag.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { Tag } from './Tag';
+
+describe('Tag', () => {
+  it('renders label', () => {
+    render(<Tag label="Active" />);
+    expect(screen.getByText('Active')).toBeTruthy();
+  });
+
+  it('renders with variant colors', () => {
+    render(<Tag testID="tag" label="Error" variant="negative" />);
+    const el = screen.getByTestId('tag');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.backgroundColor).toBe('#FFEBEF');
+  });
+});

--- a/packages/ui-native/src/primitives/Tag/Tag.tsx
+++ b/packages/ui-native/src/primitives/Tag/Tag.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { View, Text as RNText } from 'react-native';
+import type { TagProps } from './Tag.types';
+import { styles, variantColors } from './Tag.styles';
+
+/**
+ * Tag — a small status label for metadata display (e.g. "Active", "Pending").
+ */
+export const Tag = React.forwardRef<View, TagProps>(
+  ({ label, variant = 'default', icon, style, ...props }, ref) => {
+    const colors = variantColors[variant];
+
+    return (
+      <View
+        ref={ref}
+        style={[
+          styles.base,
+          {
+            backgroundColor: colors.bg,
+            borderColor: colors.border,
+          },
+          style,
+        ]}
+        {...props}
+      >
+        {icon}
+        <RNText style={[styles.label, { color: colors.text }]}>{label}</RNText>
+      </View>
+    );
+  },
+);
+
+Tag.displayName = 'Tag';

--- a/packages/ui-native/src/primitives/Tag/Tag.types.ts
+++ b/packages/ui-native/src/primitives/Tag/Tag.types.ts
@@ -1,0 +1,15 @@
+import type { ViewProps } from 'react-native';
+import type { ColorToken } from '../../tokens';
+
+export type TagVariant = 'default' | 'primary' | 'positive' | 'negative' | 'notice' | 'neutral';
+
+export interface TagProps extends Omit<ViewProps, 'style'> {
+  /** Label text. */
+  label: string;
+  /** Visual variant. Defaults to 'default'. */
+  variant?: TagVariant;
+  /** Icon element. */
+  icon?: React.ReactNode;
+  /** Additional style overrides. */
+  style?: ViewProps['style'];
+}

--- a/packages/ui-native/src/primitives/Tag/index.ts
+++ b/packages/ui-native/src/primitives/Tag/index.ts
@@ -1,0 +1,2 @@
+export { Tag } from './Tag';
+export type { TagProps, TagVariant } from './Tag.types';

--- a/packages/ui-native/src/primitives/Text/Text.styles.ts
+++ b/packages/ui-native/src/primitives/Text/Text.styles.ts
@@ -1,0 +1,19 @@
+import { StyleSheet } from 'react-native';
+import type { TextVariant } from './Text.types';
+
+type VariantStyle = { fontSize: number; fontWeight: string };
+
+export const variantStyles: Record<TextVariant, VariantStyle> = {
+  display: { fontSize: 32, fontWeight: '700' },
+  title: { fontSize: 24, fontWeight: '700' },
+  heading: { fontSize: 20, fontWeight: '600' },
+  body: { fontSize: 14, fontWeight: '400' },
+  label: { fontSize: 12, fontWeight: '500' },
+  caption: { fontSize: 10, fontWeight: '400' },
+};
+
+export const styles = StyleSheet.create({
+  base: {
+    color: '#1C1917', // neutralStrong fallback
+  },
+});

--- a/packages/ui-native/src/primitives/Text/Text.test.tsx
+++ b/packages/ui-native/src/primitives/Text/Text.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { Text } from './Text';
+
+describe('Text', () => {
+  it('renders children', () => {
+    render(<Text testID="txt">Hello</Text>);
+    expect(screen.getByTestId('txt')).toBeTruthy();
+    expect(screen.getByText('Hello')).toBeTruthy();
+  });
+
+  it('applies variant defaults', () => {
+    const { getByTestId } = render(<Text testID="txt" variant="heading">H</Text>);
+    const el = getByTestId('txt');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.fontSize).toBe(20);
+  });
+
+  it('overrides size and weight', () => {
+    const { getByTestId } = render(<Text testID="txt" size="xl" weight="bold">Big</Text>);
+    const el = getByTestId('txt');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.fontSize).toBe(20);
+    expect(flatStyle.fontWeight).toBe('700');
+  });
+
+  it('resolves color tokens', () => {
+    const { getByTestId } = render(<Text testID="txt" color="primary">C</Text>);
+    const el = getByTestId('txt');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.color).toBe('#7C3AED');
+  });
+});

--- a/packages/ui-native/src/primitives/Text/Text.tsx
+++ b/packages/ui-native/src/primitives/Text/Text.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Text as RNText } from 'react-native';
+import type { TextProps } from './Text.types';
+import { styles, variantStyles } from './Text.styles';
+import { resolveColor, resolveFontSize, resolveFontWeight, resolveSpacing } from '../../theme/resolvers';
+
+/**
+ * Text — token-resolved typography primitive. Accepts a semantic variant
+ * or individual size/weight/color overrides.
+ */
+export const Text = React.forwardRef<RNText, TextProps>(
+  ({ variant = 'body', color, size, weight, align, mb, style, ...props }, ref) => {
+    const variantDefaults = variantStyles[variant];
+
+    return (
+      <RNText
+        ref={ref}
+        style={[
+          styles.base,
+          {
+            fontSize: resolveFontSize(size) ?? variantDefaults.fontSize,
+            fontWeight: (resolveFontWeight(weight) ?? variantDefaults.fontWeight) as RNText['props']['style'] extends infer S ? S extends { fontWeight?: infer W } ? W : string : string,
+            color: resolveColor(color) ?? styles.base.color,
+            textAlign: align,
+            marginBottom: resolveSpacing(mb),
+          },
+          style,
+        ]}
+        {...props}
+      />
+    );
+  },
+);
+
+Text.displayName = 'Text';

--- a/packages/ui-native/src/primitives/Text/Text.types.ts
+++ b/packages/ui-native/src/primitives/Text/Text.types.ts
@@ -1,0 +1,21 @@
+import type { TextProps as RNTextProps } from 'react-native';
+import type { ColorToken, FontSizeToken, FontWeightToken, SpacingToken } from '../../tokens';
+
+export type TextVariant = 'body' | 'caption' | 'label' | 'heading' | 'title' | 'display';
+
+export interface TextProps extends Omit<RNTextProps, 'style'> {
+  /** Semantic variant — sets default size + weight. */
+  variant?: TextVariant;
+  /** Color token or raw color string. */
+  color?: ColorToken | string;
+  /** Font size token or raw number. */
+  size?: FontSizeToken | number;
+  /** Font weight token. */
+  weight?: FontWeightToken;
+  /** Text alignment. */
+  align?: 'left' | 'center' | 'right';
+  /** Margin bottom for spacing. */
+  mb?: SpacingToken | number;
+  /** Additional RN style overrides. */
+  style?: RNTextProps['style'];
+}

--- a/packages/ui-native/src/primitives/Text/index.ts
+++ b/packages/ui-native/src/primitives/Text/index.ts
@@ -1,0 +1,2 @@
+export { Text } from './Text';
+export type { TextProps, TextVariant } from './Text.types';

--- a/packages/ui-native/src/theme/ThemeProvider.tsx
+++ b/packages/ui-native/src/theme/ThemeProvider.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext } from 'react';
+import { sdui } from '@amplify-ai/tokens-creator/react-native';
+
+type SduiTokens = typeof sdui;
+
+const ThemeContext = createContext<SduiTokens>(sdui);
+
+export interface ThemeProviderProps {
+  /** Override tokens — deep-merged with defaults from tokens-creator. */
+  tokens?: Partial<SduiTokens>;
+  children: React.ReactNode;
+}
+
+/**
+ * Provides SDUI tokens to the component tree. Optional — components
+ * fall back to the default sdui export from tokens-creator when no
+ * provider is present.
+ */
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ tokens: overrides, children }) => {
+  const value = overrides
+    ? {
+        color: { ...sdui.color, ...overrides.color },
+        spacing: { ...sdui.spacing, ...overrides.spacing },
+        fontSize: { ...sdui.fontSize, ...overrides.fontSize },
+        fontWeight: { ...sdui.fontWeight, ...overrides.fontWeight },
+        iconSize: { ...sdui.iconSize, ...overrides.iconSize },
+        radius: { ...sdui.radius, ...overrides.radius },
+        borderWidth: { ...sdui.borderWidth, ...overrides.borderWidth },
+        component: {
+          button: { ...sdui.component.button, ...overrides.component?.button },
+        },
+      }
+    : sdui;
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+/** Read current SDUI tokens from context. Falls back to default tokens. */
+export const useTheme = (): SduiTokens => useContext(ThemeContext);

--- a/packages/ui-native/src/theme/index.ts
+++ b/packages/ui-native/src/theme/index.ts
@@ -1,0 +1,11 @@
+export { ThemeProvider, useTheme } from './ThemeProvider';
+export type { ThemeProviderProps } from './ThemeProvider';
+export {
+  resolveColor,
+  resolveSpacing,
+  resolveFontSize,
+  resolveFontWeight,
+  resolveIconSize,
+  resolveRadius,
+  resolveBorderWidth,
+} from './resolvers';

--- a/packages/ui-native/src/theme/resolvers.ts
+++ b/packages/ui-native/src/theme/resolvers.ts
@@ -1,0 +1,70 @@
+/**
+ * Token resolvers — convert token names to concrete values using
+ * the sdui namespace from @amplify-ai/tokens-creator/react-native.
+ *
+ * Every resolver accepts either a token name OR a raw value (number/string).
+ * This lets components work with both token-driven SDUI props and one-off overrides.
+ */
+import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import type {
+  ColorToken,
+  SpacingToken,
+  FontSizeToken,
+  FontWeightToken,
+  IconSizeToken,
+  RadiusToken,
+  BorderWidthToken,
+} from '../tokens';
+
+/** Resolve a color token name to its hex value. Pass-through for raw strings. */
+export function resolveColor(token: ColorToken | string | undefined): string | undefined {
+  if (token === undefined) return undefined;
+  const resolved = (sdui.color as Record<string, string>)[token];
+  return resolved ?? token;
+}
+
+/** Resolve a spacing token to its numeric value. Pass-through for raw numbers. */
+export function resolveSpacing(token: SpacingToken | number | undefined): number | undefined {
+  if (token === undefined) return undefined;
+  if (typeof token === 'number') return token;
+  return (sdui.spacing as Record<string, number>)[token];
+}
+
+/** Resolve a font size token to its numeric value. */
+export function resolveFontSize(token: FontSizeToken | number | undefined): number | undefined {
+  if (token === undefined) return undefined;
+  if (typeof token === 'number') return token;
+  return (sdui.fontSize as Record<string, number>)[token];
+}
+
+/** Resolve a font weight token to its numeric string (for RN fontWeight). */
+export function resolveFontWeight(
+  token: FontWeightToken | string | undefined,
+): string | undefined {
+  if (token === undefined) return undefined;
+  const weight = (sdui.fontWeight as Record<string, number>)[token];
+  return weight !== undefined ? String(weight) : token;
+}
+
+/** Resolve an icon size token to its numeric value. */
+export function resolveIconSize(token: IconSizeToken | number | undefined): number | undefined {
+  if (token === undefined) return undefined;
+  if (typeof token === 'number') return token;
+  return (sdui.iconSize as Record<string, number>)[token];
+}
+
+/** Resolve a radius token to its numeric value. */
+export function resolveRadius(token: RadiusToken | number | undefined): number | undefined {
+  if (token === undefined) return undefined;
+  if (typeof token === 'number') return token;
+  return (sdui.radius as Record<string, number>)[token];
+}
+
+/** Resolve a border width token to its numeric value. */
+export function resolveBorderWidth(
+  token: BorderWidthToken | number | undefined,
+): number | undefined {
+  if (token === undefined) return undefined;
+  if (typeof token === 'number') return token;
+  return (sdui.borderWidth as Record<string, number>)[token];
+}

--- a/packages/ui-native/src/tokens.ts
+++ b/packages/ui-native/src/tokens.ts
@@ -1,0 +1,45 @@
+/**
+ * Token type definitions — string literal unions matching SDUI token keys
+ * from @amplify-ai/tokens-creator/react-native.
+ *
+ * Components accept these as props (e.g. <Box bg="primary" p="md" />)
+ * and resolve them to concrete values via theme/resolvers.ts.
+ */
+
+/** SDUI color token names — maps to sdui.color.* */
+export type ColorToken =
+  | 'neutralStrong'
+  | 'neutralMedium'
+  | 'neutralWeak'
+  | 'neutralSubtle'
+  | 'neutralInverse'
+  | 'primary'
+  | 'primaryWeak'
+  | 'positive'
+  | 'positiveWeak'
+  | 'notice'
+  | 'noticeWeak'
+  | 'negative'
+  | 'negativeWeak'
+  | 'offsetStrong'
+  | 'offsetMedium'
+  | 'offsetWeak'
+  | 'transparent';
+
+/** SDUI spacing token names — maps to sdui.spacing.* */
+export type SpacingToken = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'xxxl';
+
+/** SDUI font size token names — maps to sdui.fontSize.* */
+export type FontSizeToken = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'xxxl';
+
+/** SDUI font weight token names — maps to sdui.fontWeight.* */
+export type FontWeightToken = 'regular' | 'medium' | 'semibold' | 'bold';
+
+/** SDUI icon size token names — maps to sdui.iconSize.* */
+export type IconSizeToken = 'sm' | 'md' | 'lg' | 'xl';
+
+/** SDUI border radius token names — maps to sdui.radius.* */
+export type RadiusToken = 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
+
+/** SDUI border width token names — maps to sdui.borderWidth.* */
+export type BorderWidthToken = 'none' | 'thin' | 'medium' | 'thick';

--- a/packages/ui-native/src/types/tokens-creator.d.ts
+++ b/packages/ui-native/src/types/tokens-creator.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Type declarations for @amplify-ai/tokens-creator/react-native
+ *
+ * The tokens-creator package generates tokens.native.js at build time
+ * without .d.ts files. This declaration provides type safety for consumers.
+ */
+declare module '@amplify-ai/tokens-creator/react-native' {
+  export const colors: Record<string, string>;
+  export const fontSize: Record<string, number>;
+  export const spacing: Record<string, number>;
+
+  export const sdui: {
+    color: Record<string, string>;
+    spacing: Record<string, number>;
+    fontSize: Record<string, number>;
+    fontWeight: Record<string, number>;
+    iconSize: Record<string, number>;
+    radius: Record<string, number>;
+    borderWidth: Record<string, number>;
+    component: {
+      button: Record<string, number>;
+    };
+  };
+}

--- a/packages/ui-native/tsconfig.json
+++ b/packages/ui-native/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020"],
+    "jsx": "react-jsx",
+    "declaration": true,
+    "declarationDir": "dist",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.tsx", "**/*.test.ts"]
+}

--- a/packages/ui-native/tsup.config.ts
+++ b/packages/ui-native/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  // DTS generated separately via tsc — react-native JSX types conflict
+  // with @types/react@19 in the monorepo root, and tsup's rollup-plugin-dts
+  // doesn't honor skipLibCheck. tsc respects tsconfig.json's skipLibCheck.
+  dts: false,
+  external: ['react', 'react-native', '@amplify-ai/tokens-creator'],
+  clean: true,
+});


### PR DESCRIPTION
## Summary

- Adds `packages/ui-native/` — `@amplify-ai/ui-native@1.0.0`, the React Native primitive library for the Creator App SDUI rebuild
- **18 token-resolved components** consuming `@amplify-ai/tokens-creator/react-native`: Text, Icon, Image, Separator, Button, Card, Input, Chip, Checkbox, Radio, Tag, Tab, ProgressIndicator, SearchBar, SelectableItem, ImageStack, Section, ScrollView
- **Layout helpers**: Box (flex container with token props), Stack (directional wrapper)
- **Theme infrastructure**: ThemeProvider (React Context), 7 resolver utilities (`resolveColor`, `resolveSpacing`, `resolveFontSize`, `resolveFontWeight`, `resolveIconSize`, `resolveRadius`, `resolveBorderWidth`), token type unions
- **5-file component pattern**: `.types.ts`, `.styles.ts`, `.tsx`, `.test.tsx`, `index.ts` per primitive
- Build: tsup ESM + `tsc --emitDeclarationOnly --noCheck` (React 19 / RN type compat)
- CLAUDE.md with package boundaries, conventions, and component catalog
- Changeset entry for major release

### Boundaries enforced
- Zero `@one-impression/*` imports (verified)
- Zero `react-dom` imports (verified)
- No Zod schemas (those are in `sdk-native-sdui`)
- No SDUI renderers (those are in `sdui-runtime`)

### Dependencies
- Consumes `@amplify-ai/tokens-creator` (peer dep >=2.0.3)
- Consumed by downstream Steps 11/24/25/26 (`@amplify-ai/sdui-runtime` renderers)

## Test plan

- [x] `npm run build -w packages/ui-native` succeeds (34KB ESM + full .d.ts)
- [x] `grep -r '@one-impression' packages/ui-native/src/` returns nothing
- [x] `grep -r 'react-dom' packages/ui-native/src/` returns nothing
- [x] CLAUDE.md present with all required sections
- [x] Changeset entry present
- [ ] CI build passes
- [ ] Tests pass in RN environment (test deps are peer-only; full test suite runs in consumer app CI)

zenith:step-context step=002 slug=ui-native-v1 repo=amplify-design-system depends_on=[001] brief=264

🤖 Generated with [Claude Code](https://claude.com/claude-code)