### PR TITLE
docs(zenith): update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,13 @@ packages/
   tokens-atmosphere/  — Atmosphere tokens (gold accent, dark-first themes)
   tokens-creator/     — Creator App tokens (SDUI mappings, mobile-optimized)
   ui/                 — Shared React components (Button, Badge, Card, EmptyState, Skeleton)
+  ui-native/          — React Native primitives for Creator App SDUI (18 components, consumes @amplify-ai/tokens-creator/react-native)
+                        Layout: Box, Stack
+                        Foundation: Text, Icon, Image, Separator
+                        Interactive: Button, Card, Input, Chip, Checkbox, Radio, Tag, Tab
+                        Composite: ProgressIndicator, SearchBar, SelectableItem, ImageStack, Section, ScrollView
+                        Plus: ThemeProvider, token type unions (ColorToken, SpacingToken, etc.), and resolver utilities
+                        Each primitive follows the 5-file pattern: types, styles, component, test, index
   storybook/          — Component documentation and visual testing
   eslint-config/      — Design system lint rules (no-hardcoded-colors, no-raw-spacing, prefer-token-import)
   feature-flags/      — Feature flag utilities


### PR DESCRIPTION
## Summary
- **Trigger:** commit `73a9333`
- **File updated:** `CLAUDE.md`
- **Confidence:** 🟡 0.70
- **Reason:** A new major package `@amplify-ai/ui-native` with 18 React Native primitives, ThemeProvider, token type unions, and resolver utilities has been added to the monorepo, which engineers need to know about for usage, conventions, and the 5-file component pattern.

This is an automated documentation update by Zenith. Needs human review.

---
Generated by [Zenith AI CTO](https://github.com/one-impression/zenith-coding-agent)