### PR TITLE
feat(sdui-runtime): 5 page container renderers

### DIFF
--- a/.changeset/sdui-page-renderers.md
+++ b/.changeset/sdui-page-renderers.md
@@ -1,0 +1,16 @@
+---
+"@amplify-ai/sdui-runtime": minor
+---
+
+feat(sdui-runtime): add 5 page layout container renderers
+
+Adds PageStandard, PageStickyFooter, PageFeed, WebViewPage, and
+WebViewPageWithAction page container renderers under src/pages/.
+Populates the pageContainerRegistry so PageRoot can dispatch to the
+correct layout based on the BFF page envelope's layout field.
+
+- PageStandard: scrollable page with pull-to-refresh and back-press handling
+- PageStickyFooter: keyboard-aware layout with pinned footer for forms/checkout
+- PageFeed: FlatList-based infinite-scroll feed with filter chips, load-more, empty state
+- WebViewPage: full-screen WebView shell with optional title header
+- WebViewPageWithAction: WebView with URL-pattern interception for payment/OAuth flows

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -27,7 +27,8 @@
     "@one-impression/sdk-native-sdui": ">=1.0.0",
     "@amplify-ai/ui-native": ">=1.0.0",
     "@amplify-ai/tokens-creator": ">=2.0.3",
-    "@gorhom/bottom-sheet": "^5.0.0"
+    "@gorhom/bottom-sheet": "^5.0.0",
+    "react-native-webview": ">=13.0.0"
   },
   "dependencies": {
     "zustand": "^4.5.0",
@@ -39,6 +40,9 @@
       "optional": true
     },
     "@gorhom/bottom-sheet": {
+      "optional": true
+    },
+    "react-native-webview": {
       "optional": true
     }
   },

--- a/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
@@ -1,0 +1,184 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  BackHandler,
+  FlatList,
+  RefreshControl,
+  StyleSheet,
+  View,
+} from "react-native";
+import type { Page, Node, Action } from "@one-impression/sdk-native-sdui";
+import { Interpreter } from "../../interpreter/index.js";
+import { useActionEngine } from "../../action-engine/useActionEngine.js";
+import { useBottomSheetStore } from "../../bottom-sheet/useBottomSheetStore.js";
+import { usePageRefresh } from "../../hooks/usePageRefresh.js";
+import { useAppStateSession } from "../../hooks/useAppStateSession.js";
+
+interface PageProps {
+  page: Page;
+}
+
+interface FeedPageData {
+  filters?: Node[];
+  on_load_more?: Action;
+  loader?: Node;
+  empty_state?: Node;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  filterBar: {
+    flexDirection: "row",
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  filterChip: {
+    marginRight: 8,
+  },
+});
+
+/**
+ * Infinite-scroll feed page with horizontal filter chips.
+ * Legacy equivalent: PageType3.
+ *
+ * Uses FlatList (not ScrollView) for virtualized rendering of page.items.
+ * Supports:
+ * - Horizontal filter chips bar at the top
+ * - Infinite scroll via on_load_more action
+ * - Loader node displayed while fetching more items
+ * - Empty state node when items is empty
+ * - Pull-to-refresh via page.on_refresh
+ */
+export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
+  const actionEngine = useActionEngine();
+  const bottomSheetStore = useBottomSheetStore();
+  const { refreshing, onRefresh } = usePageRefresh(page.on_refresh);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const loadingMoreRef = useRef(false);
+
+  const pageData = (page.data as FeedPageData | undefined) ?? {};
+  const filters = pageData.filters;
+  const onLoadMore = pageData.on_load_more;
+  const loader = pageData.loader;
+  const emptyState = pageData.empty_state;
+
+  // Register inline bottom sheets
+  useEffect(() => {
+    if (page.bottom_sheets) {
+      for (const sheet of page.bottom_sheets) {
+        bottomSheetStore.open({
+          id: sheet.id,
+          title: sheet.title,
+          size: sheet.size ?? "medium",
+          items: sheet.items ?? [],
+          on_dismiss: sheet.on_dismiss,
+          on_open: sheet.on_open,
+        });
+        bottomSheetStore.close(sheet.id);
+      }
+    }
+  }, [page.bottom_sheets, bottomSheetStore]);
+
+  // Page lifecycle: on_load / on_dismount
+  useEffect(() => {
+    if (page.on_load) actionEngine.dispatch(page.on_load);
+    return () => {
+      if (page.on_dismount) actionEngine.dispatch(page.on_dismount);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // App foreground / background triggers
+  useAppStateSession(page.on_app_foreground, page.on_app_background);
+
+  // Hardware back-press handler (Android)
+  useEffect(() => {
+    if (!page.on_back_press) return;
+    const handler = () => {
+      actionEngine.dispatch(page.on_back_press!);
+      return true;
+    };
+    const subscription = BackHandler.addEventListener(
+      "hardwareBackPress",
+      handler,
+    );
+    return () => subscription.remove();
+  }, [actionEngine, page.on_back_press]);
+
+  // Infinite scroll — dispatch on_load_more when user scrolls near the bottom
+  const handleEndReached = useCallback(() => {
+    if (!onLoadMore || loadingMoreRef.current) return;
+    loadingMoreRef.current = true;
+    setLoadingMore(true);
+    actionEngine.dispatch(onLoadMore);
+    // Reset loading state after timeout as safety net.
+    // The BFF response will re-render the page with new/appended items.
+    setTimeout(() => {
+      loadingMoreRef.current = false;
+      setLoadingMore(false);
+    }, 5000);
+  }, [actionEngine, onLoadMore]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: Node }) => (
+      <Interpreter node={item} />
+    ),
+    [],
+  );
+
+  const keyExtractor = useCallback(
+    (item: Node, index: number) => item.id ?? `feed-item-${index}`,
+    [],
+  );
+
+  // Footer: show loader node while loading more items
+  const renderFooter = useCallback(() => {
+    if (loadingMore && loader) {
+      return <Interpreter node={loader} />;
+    }
+    return null;
+  }, [loadingMore, loader]);
+
+  // Empty state when no items
+  const renderEmpty = useCallback(() => {
+    if (emptyState) {
+      return <Interpreter node={emptyState} />;
+    }
+    return null;
+  }, [emptyState]);
+
+  // Filter chips bar rendered as FlatList header
+  const renderHeader = useCallback(() => {
+    if (!filters || filters.length === 0) return null;
+    return (
+      <View style={styles.filterBar}>
+        {filters.map((filterNode, i) => (
+          <View key={filterNode.id ?? `filter-${i}`} style={styles.filterChip}>
+            <Interpreter node={filterNode} />
+          </View>
+        ))}
+      </View>
+    );
+  }, [filters]);
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={page.items}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        ListHeaderComponent={renderHeader}
+        ListFooterComponent={renderFooter}
+        ListEmptyComponent={renderEmpty}
+        onEndReached={handleEndReached}
+        onEndReachedThreshold={0.5}
+        refreshControl={
+          page.on_refresh ? (
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+          ) : undefined
+        }
+      />
+    </View>
+  );
+}

--- a/packages/sdui-runtime/src/pages/PageFeed/index.ts
+++ b/packages/sdui-runtime/src/pages/PageFeed/index.ts
@@ -1,0 +1,1 @@
+export { PageFeedRenderer } from "./PageFeed.renderer.js";

--- a/packages/sdui-runtime/src/pages/PageStandard/PageStandard.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageStandard/PageStandard.renderer.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect } from "react";
+import { BackHandler, ScrollView, RefreshControl } from "react-native";
+import type { Page } from "@one-impression/sdk-native-sdui";
+import { Interpreter } from "../../interpreter/index.js";
+import { useActionEngine } from "../../action-engine/useActionEngine.js";
+import { useBottomSheetStore } from "../../bottom-sheet/useBottomSheetStore.js";
+import { usePageRefresh } from "../../hooks/usePageRefresh.js";
+import { useAppStateSession } from "../../hooks/useAppStateSession.js";
+
+interface PageProps {
+  page: Page;
+}
+
+/**
+ * Standard scrollable page layout.
+ * Legacy equivalent: PageType1.
+ *
+ * Renders page.items inside a ScrollView with pull-to-refresh support.
+ * Registers inline bottom sheets on mount and handles back-press + app-state lifecycle triggers.
+ */
+export function PageStandardRenderer({ page }: PageProps): React.ReactElement {
+  const actionEngine = useActionEngine();
+  const bottomSheetStore = useBottomSheetStore();
+  const { refreshing, onRefresh } = usePageRefresh(page.on_refresh);
+
+  // Register inline bottom sheets so sheet actions can open them later
+  useEffect(() => {
+    if (page.bottom_sheets) {
+      for (const sheet of page.bottom_sheets) {
+        // Sheets are pre-registered in the store keyed by their id.
+        // The sheet action handler resolves them from this store.
+        bottomSheetStore.open({
+          id: sheet.id,
+          title: sheet.title,
+          size: sheet.size ?? "medium",
+          items: sheet.items ?? [],
+          on_dismiss: sheet.on_dismiss,
+          on_open: sheet.on_open,
+        });
+        // Immediately close — we only need them registered, not visible.
+        bottomSheetStore.close(sheet.id);
+      }
+    }
+  }, [page.bottom_sheets, bottomSheetStore]);
+
+  // Page lifecycle: on_load / on_dismount
+  useEffect(() => {
+    if (page.on_load) actionEngine.dispatch(page.on_load);
+    return () => {
+      if (page.on_dismount) actionEngine.dispatch(page.on_dismount);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // App foreground / background triggers
+  useAppStateSession(page.on_app_foreground, page.on_app_background);
+
+  // Hardware back-press handler (Android)
+  useEffect(() => {
+    if (!page.on_back_press) return;
+    const handler = () => {
+      actionEngine.dispatch(page.on_back_press!);
+      return true; // Prevent default back behavior
+    };
+    const subscription = BackHandler.addEventListener(
+      "hardwareBackPress",
+      handler,
+    );
+    return () => subscription.remove();
+  }, [actionEngine, page.on_back_press]);
+
+  return (
+    <ScrollView
+      refreshControl={
+        page.on_refresh ? (
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        ) : undefined
+      }
+    >
+      {page.items.map((node, i) => (
+        <Interpreter key={node.id ?? `item-${i}`} node={node} />
+      ))}
+    </ScrollView>
+  );
+}

--- a/packages/sdui-runtime/src/pages/PageStandard/index.ts
+++ b/packages/sdui-runtime/src/pages/PageStandard/index.ts
@@ -1,0 +1,1 @@
+export { PageStandardRenderer } from "./PageStandard.renderer.js";

--- a/packages/sdui-runtime/src/pages/PageStickyFooter/PageStickyFooter.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageStickyFooter/PageStickyFooter.renderer.tsx
@@ -1,0 +1,136 @@
+import React, { useEffect } from "react";
+import {
+  BackHandler,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  RefreshControl,
+  View,
+  StyleSheet,
+} from "react-native";
+import type { Page } from "@one-impression/sdk-native-sdui";
+import { Interpreter } from "../../interpreter/index.js";
+import { useActionEngine } from "../../action-engine/useActionEngine.js";
+import { useBottomSheetStore } from "../../bottom-sheet/useBottomSheetStore.js";
+import { usePageRefresh } from "../../hooks/usePageRefresh.js";
+import { useAppStateSession } from "../../hooks/useAppStateSession.js";
+
+interface PageProps {
+  page: Page;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  bodyScroll: {
+    flex: 1,
+  },
+  footer: {
+    // Footer is pinned at the bottom, outside the scroll area
+  },
+});
+
+/**
+ * Keyboard-aware page layout with a sticky footer.
+ * Legacy equivalent: PageType2.
+ *
+ * Body items scroll inside a ScrollView while the footer node is pinned
+ * at the bottom of the screen. When `keyboard_aware` is true, the body
+ * wraps in a KeyboardAvoidingView so the footer stays above the keyboard.
+ *
+ * Used for forms, checkout flows, and apply-wizard screens.
+ */
+export function PageStickyFooterRenderer({
+  page,
+}: PageProps): React.ReactElement {
+  const actionEngine = useActionEngine();
+  const bottomSheetStore = useBottomSheetStore();
+  const { refreshing, onRefresh } = usePageRefresh(page.on_refresh);
+
+  const pageData = page.data as
+    | { footer?: unknown; keyboard_aware?: boolean }
+    | undefined;
+  const footer = pageData?.footer;
+  const keyboardAware = pageData?.keyboard_aware ?? false;
+
+  // Register inline bottom sheets
+  useEffect(() => {
+    if (page.bottom_sheets) {
+      for (const sheet of page.bottom_sheets) {
+        bottomSheetStore.open({
+          id: sheet.id,
+          title: sheet.title,
+          size: sheet.size ?? "medium",
+          items: sheet.items ?? [],
+          on_dismiss: sheet.on_dismiss,
+          on_open: sheet.on_open,
+        });
+        bottomSheetStore.close(sheet.id);
+      }
+    }
+  }, [page.bottom_sheets, bottomSheetStore]);
+
+  // Page lifecycle: on_load / on_dismount
+  useEffect(() => {
+    if (page.on_load) actionEngine.dispatch(page.on_load);
+    return () => {
+      if (page.on_dismount) actionEngine.dispatch(page.on_dismount);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // App foreground / background triggers
+  useAppStateSession(page.on_app_foreground, page.on_app_background);
+
+  // Hardware back-press handler (Android)
+  useEffect(() => {
+    if (!page.on_back_press) return;
+    const handler = () => {
+      actionEngine.dispatch(page.on_back_press!);
+      return true;
+    };
+    const subscription = BackHandler.addEventListener(
+      "hardwareBackPress",
+      handler,
+    );
+    return () => subscription.remove();
+  }, [actionEngine, page.on_back_press]);
+
+  const bodyContent = (
+    <ScrollView
+      style={styles.bodyScroll}
+      refreshControl={
+        page.on_refresh ? (
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        ) : undefined
+      }
+    >
+      {page.items.map((node, i) => (
+        <Interpreter key={node.id ?? `item-${i}`} node={node} />
+      ))}
+    </ScrollView>
+  );
+
+  const wrappedBody = keyboardAware ? (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+    >
+      {bodyContent}
+    </KeyboardAvoidingView>
+  ) : (
+    bodyContent
+  );
+
+  return (
+    <View style={styles.container}>
+      {wrappedBody}
+      {footer ? (
+        <View style={styles.footer}>
+          <Interpreter node={footer as any} />
+        </View>
+      ) : null}
+    </View>
+  );
+}

--- a/packages/sdui-runtime/src/pages/PageStickyFooter/index.ts
+++ b/packages/sdui-runtime/src/pages/PageStickyFooter/index.ts
@@ -1,0 +1,1 @@
+export { PageStickyFooterRenderer } from "./PageStickyFooter.renderer.js";

--- a/packages/sdui-runtime/src/pages/WebViewPage/WebViewPage.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/WebViewPage/WebViewPage.renderer.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect } from "react";
+import { BackHandler, StyleSheet, Text, View } from "react-native";
+import { WebView } from "react-native-webview";
+import type { Page } from "@one-impression/sdk-native-sdui";
+import { useActionEngine } from "../../action-engine/useActionEngine.js";
+import { useAppStateSession } from "../../hooks/useAppStateSession.js";
+
+interface PageProps {
+  page: Page;
+}
+
+interface WebViewPageData {
+  url: string;
+  title?: string;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#E0E0E0",
+    backgroundColor: "#FFFFFF",
+  },
+  headerTitle: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#1A1A1A",
+  },
+  webview: {
+    flex: 1,
+  },
+});
+
+/**
+ * Simple WebView shell page.
+ * Legacy equivalent: WebViewPage.
+ *
+ * Renders a full-screen react-native-webview loading the URL from page.data.url.
+ * Optionally shows a simple header bar with page.data.title.
+ *
+ * Note: This is a documented exception for the renderer-no-direct-rn-imports rule
+ * -- WebView requires direct RN usage and peer-dep on react-native-webview.
+ */
+export function WebViewPageRenderer({ page }: PageProps): React.ReactElement {
+  const actionEngine = useActionEngine();
+
+  const pageData = page.data as WebViewPageData | undefined;
+  const url = pageData?.url ?? "";
+  const title = pageData?.title ?? page.title;
+
+  // Page lifecycle: on_load / on_dismount
+  useEffect(() => {
+    if (page.on_load) actionEngine.dispatch(page.on_load);
+    return () => {
+      if (page.on_dismount) actionEngine.dispatch(page.on_dismount);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // App foreground / background triggers
+  useAppStateSession(page.on_app_foreground, page.on_app_background);
+
+  // Hardware back-press handler (Android)
+  useEffect(() => {
+    if (!page.on_back_press) return;
+    const handler = () => {
+      actionEngine.dispatch(page.on_back_press!);
+      return true;
+    };
+    const subscription = BackHandler.addEventListener(
+      "hardwareBackPress",
+      handler,
+    );
+    return () => subscription.remove();
+  }, [actionEngine, page.on_back_press]);
+
+  return (
+    <View style={styles.container}>
+      {title ? (
+        <View style={styles.header}>
+          <Text style={styles.headerTitle} numberOfLines={1}>
+            {title}
+          </Text>
+        </View>
+      ) : null}
+      <WebView
+        style={styles.webview}
+        source={{ uri: url }}
+        startInLoadingState
+        javaScriptEnabled
+      />
+    </View>
+  );
+}

--- a/packages/sdui-runtime/src/pages/WebViewPage/index.ts
+++ b/packages/sdui-runtime/src/pages/WebViewPage/index.ts
@@ -1,0 +1,1 @@
+export { WebViewPageRenderer } from "./WebViewPage.renderer.js";

--- a/packages/sdui-runtime/src/pages/WebViewPageWithAction/WebViewPageWithAction.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/WebViewPageWithAction/WebViewPageWithAction.renderer.tsx
@@ -1,0 +1,174 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import { BackHandler, StyleSheet, View } from "react-native";
+import { WebView } from "react-native-webview";
+import type {
+  WebViewNavigation,
+  ShouldStartLoadRequest,
+} from "react-native-webview/lib/WebViewTypes";
+import type { Page, Action } from "@one-impression/sdk-native-sdui";
+import { useActionEngine } from "../../action-engine/useActionEngine.js";
+import { useAppStateSession } from "../../hooks/useAppStateSession.js";
+
+interface PageProps {
+  page: Page;
+}
+
+interface UrlPattern {
+  pattern: string;
+  action: string;
+}
+
+interface WebViewActionPageData {
+  url: string;
+  url_patterns?: UrlPattern[];
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  webview: {
+    flex: 1,
+  },
+});
+
+/**
+ * Checks whether a URL matches any of the configured patterns.
+ * Returns the action string to dispatch if a match is found, otherwise null.
+ */
+function matchUrlPattern(
+  url: string,
+  patterns: UrlPattern[],
+): string | null {
+  for (const entry of patterns) {
+    try {
+      const regex = new RegExp(entry.pattern);
+      if (regex.test(url)) {
+        return entry.action;
+      }
+    } catch {
+      // Invalid regex — skip this pattern silently.
+      // In production the BFF should always send valid patterns,
+      // but we guard against malformed data defensively.
+    }
+  }
+  return null;
+}
+
+/**
+ * WebView page with URL-pattern action routing.
+ * Legacy equivalent: WebViewPageType2.
+ *
+ * Renders a WebView and intercepts navigation requests. For each URL the
+ * WebView attempts to load, checks against page.data.url_patterns:
+ * - If a pattern matches, the navigation is blocked and the corresponding
+ *   action is dispatched via the action engine.
+ * - Otherwise, normal WebView navigation proceeds.
+ *
+ * Used for payment flows, OAuth callbacks, and third-party forms where
+ * specific redirect URLs need to trigger native actions.
+ */
+export function WebViewPageWithActionRenderer({
+  page,
+}: PageProps): React.ReactElement {
+  const actionEngine = useActionEngine();
+  const webViewRef = useRef<WebView>(null);
+
+  const pageData = page.data as WebViewActionPageData | undefined;
+  const url = pageData?.url ?? "";
+  const urlPatterns = pageData?.url_patterns ?? [];
+
+  // Page lifecycle: on_load / on_dismount
+  useEffect(() => {
+    if (page.on_load) actionEngine.dispatch(page.on_load);
+    return () => {
+      if (page.on_dismount) actionEngine.dispatch(page.on_dismount);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // App foreground / background triggers
+  useAppStateSession(page.on_app_foreground, page.on_app_background);
+
+  // Hardware back-press handler (Android)
+  useEffect(() => {
+    if (!page.on_back_press) return;
+    const handler = () => {
+      actionEngine.dispatch(page.on_back_press!);
+      return true;
+    };
+    const subscription = BackHandler.addEventListener(
+      "hardwareBackPress",
+      handler,
+    );
+    return () => subscription.remove();
+  }, [actionEngine, page.on_back_press]);
+
+  /**
+   * Intercept navigation before it starts (iOS + Android).
+   * If the URL matches a pattern, block the navigation and dispatch the action.
+   */
+  const handleShouldStartLoad = useCallback(
+    (request: ShouldStartLoadRequest): boolean => {
+      if (urlPatterns.length === 0) return true;
+
+      const matchedAction = matchUrlPattern(request.url, urlPatterns);
+      if (matchedAction) {
+        // Dispatch the action string as an Action object.
+        // The BFF sends the action as a serialized string that the
+        // action engine knows how to parse and execute.
+        try {
+          const parsed = JSON.parse(matchedAction) as Action;
+          actionEngine.dispatch(parsed);
+        } catch {
+          // If the action isn't valid JSON, treat it as a raw action type
+          actionEngine.dispatch({ type: matchedAction } as unknown as Action);
+        }
+        return false; // Block the WebView navigation
+      }
+
+      return true; // Allow normal navigation
+    },
+    [actionEngine, urlPatterns],
+  );
+
+  /**
+   * Fallback handler for navigation state changes.
+   * Some platforms may not reliably fire onShouldStartLoadWithRequest,
+   * so we also check navigation state changes as a safety net.
+   */
+  const handleNavigationStateChange = useCallback(
+    (navState: WebViewNavigation) => {
+      if (urlPatterns.length === 0 || !navState.url) return;
+
+      const matchedAction = matchUrlPattern(navState.url, urlPatterns);
+      if (matchedAction) {
+        // Stop loading the matched URL
+        if (webViewRef.current) {
+          webViewRef.current.stopLoading();
+        }
+        try {
+          const parsed = JSON.parse(matchedAction) as Action;
+          actionEngine.dispatch(parsed);
+        } catch {
+          actionEngine.dispatch({ type: matchedAction } as unknown as Action);
+        }
+      }
+    },
+    [actionEngine, urlPatterns],
+  );
+
+  return (
+    <View style={styles.container}>
+      <WebView
+        ref={webViewRef}
+        style={styles.webview}
+        source={{ uri: url }}
+        startInLoadingState
+        javaScriptEnabled
+        onShouldStartLoadWithRequest={handleShouldStartLoad}
+        onNavigationStateChange={handleNavigationStateChange}
+      />
+    </View>
+  );
+}

--- a/packages/sdui-runtime/src/pages/WebViewPageWithAction/index.ts
+++ b/packages/sdui-runtime/src/pages/WebViewPageWithAction/index.ts
@@ -1,0 +1,1 @@
+export { WebViewPageWithActionRenderer } from "./WebViewPageWithAction.renderer.js";

--- a/packages/sdui-runtime/src/pages/index.ts
+++ b/packages/sdui-runtime/src/pages/index.ts
@@ -1,0 +1,5 @@
+export { PageStandardRenderer } from "./PageStandard/index.js";
+export { PageStickyFooterRenderer } from "./PageStickyFooter/index.js";
+export { PageFeedRenderer } from "./PageFeed/index.js";
+export { WebViewPageRenderer } from "./WebViewPage/index.js";
+export { WebViewPageWithActionRenderer } from "./WebViewPageWithAction/index.js";

--- a/packages/sdui-runtime/src/registries/pages.ts
+++ b/packages/sdui-runtime/src/registries/pages.ts
@@ -1,13 +1,26 @@
 import type { ComponentType } from "react";
 import type { Page } from "@one-impression/sdk-native-sdui";
+import { PageStandardRenderer } from "../pages/PageStandard/index.js";
+import { PageStickyFooterRenderer } from "../pages/PageStickyFooter/index.js";
+import { PageFeedRenderer } from "../pages/PageFeed/index.js";
+import { WebViewPageRenderer } from "../pages/WebViewPage/index.js";
+import { WebViewPageWithActionRenderer } from "../pages/WebViewPageWithAction/index.js";
 
 /**
  * Registry mapping page layout strings to page container renderers.
- * Populated by task 026 (sdui-page-renderers).
+ * Consumed by PageRoot to dispatch to the correct page container
+ * based on the BFF page envelope's `layout` field.
  *
- * Shape: { "standard": PageStandard, "feed": PageFeed, ... }
+ * Layout keys correspond to the PageLayout enum from sdk-native-sdui:
+ * "standard" | "sticky_footer" | "feed" | "web_view" | "web_view_action"
  */
 export const pageContainerRegistry: Record<
   string,
   ComponentType<{ page: Page }>
-> = {};
+> = {
+  standard: PageStandardRenderer,
+  sticky_footer: PageStickyFooterRenderer,
+  feed: PageFeedRenderer,
+  web_view: WebViewPageRenderer,
+  web_view_action: WebViewPageWithActionRenderer,
+};

--- a/packages/sdui-runtime/tsup.config.ts
+++ b/packages/sdui-runtime/tsup.config.ts
@@ -20,5 +20,7 @@ export default defineConfig({
     "expo-notifications",
     "expo-secure-store",
     "expo-web-browser",
+    // WebView used by page renderers (WebViewPage, WebViewPageWithAction)
+    "react-native-webview",
   ],
 });


### PR DESCRIPTION
## Summary
- **Brief #264, Task 26** — Page layout containers for `@amplify-ai/sdui-runtime`
- 5 page renderers dispatched by `PageRoot` via layout type:
  - **PageStandard**: ScrollView + RefreshControl + lifecycle triggers
  - **PageStickyFooter**: KeyboardAvoidingView + sticky footer section
  - **PageFeed**: FlatList with virtualized infinite scroll, filter chips, empty state, on_load_more
  - **WebViewPage**: react-native-webview shell with loading indicator
  - **WebViewPageWithAction**: WebView + URL-pattern action routing for OAuth/callback flows
- Registry maps 5 `standard|sticky_footer|feed|web_view|web_view_action` layout types

## Test plan
- [ ] `npm run build` passes
- [ ] PageStandard renders sections in ScrollView with pull-to-refresh
- [ ] PageFeed renders items in FlatList with infinite scroll
- [ ] WebViewPage loads URL in WebView with loading state
- [ ] PageRoot dispatches to correct container based on layout type

🤖 Generated with [Claude Code](https://claude.com/claude-code)