### PR TITLE
fix(ci): add --access public to npm publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
             echo "Publishing @amplify-ai/$pkg..."
             (
               cd packages/$pkg
-              OUTPUT=$(npm publish 2>&1) && echo "$OUTPUT" || {
+              OUTPUT=$(npm publish --access public 2>&1) && echo "$OUTPUT" || {
                 EXIT_CODE=$?
                 echo "$OUTPUT"
                 if echo "$OUTPUT" | grep -qE 'EPUBLISHCONFLICT|already been published|You cannot publish over the previously published versions|cannot publish over the previously published'; then


### PR DESCRIPTION
## Summary

- Adds `--access public` to the `npm publish` command in the CI publish step
- First-time publish of new scoped packages (`@amplify-ai/ui-native`, `@amplify-ai/sdui-runtime`) was failing with **402 "You must sign up for private packages"** because npm defaults new scoped packages to private access
- The `--access public` flag is idempotent for already-published packages — no impact on `tokens-creator`, `tokens-brand`, etc.

## Context

This is a **blocker for Brief #264** — `amplify-creator-app` depends on `@amplify-ai/ui-native@^1.0.0` and `@amplify-ai/sdui-runtime@^1.0.0`, neither of which have been published to npm yet.

## Test plan

- [ ] Merge to main → CI triggers → verify `@amplify-ai/ui-native` and `@amplify-ai/sdui-runtime` appear on npmjs.com
- [ ] Existing packages (`tokens-creator`, `tokens-brand`, etc.) publish with no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)