### PR TITLE
feat: add Oportunities theme + Studio brand to design system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the public packages of `amplify-design-system`.
 
+## [Unreleased] feat/oportunities-theme branch
+
+### Added
+- `@amplify-ai/tokens-oportunities@1.0.0` — Oportunities theme tokens (Studio direction)
+- `@amplify-ai/brand-oportunities@1.0.0` — Oportunities brand assets
+- 6 new composed components in `@amplify-ai/ui` (`Wordmark`, `SignalDot`, `CreatorIntentCard`, `BrandInterestCard`, `IntentFeed`, `AppIconOportunities`) — versioning will be 2.12.0 on merge
+- Storybook: Oportunities theme registered + 8 brand guidelines docs added
+
 ## 2.13.0 — 2026-05-08
 
 ### Added (additive — `@amplify-ai/ui`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,3 +84,22 @@ Build script (`scripts/build-tokens.js`) generates CSS variables, SCSS, JSON, JS
 3. **All token changes** go through direct PR (Pixel will detect drift and auto-cascade)
 4. **ESLint rules** exist in `packages/eslint-config/rules/` but are NOT enforced in product repos yet
 5. **Breaking changes** to CSS variable names or values require a migration note in the PR description
+
+## Oportunities theme (newest product line)
+
+Oportunities is the newest product theme in this monorepo. It ships as the
+Studio-direction brand for One Impression's creator-intent platform.
+
+- **Tokens**: `packages/tokens-oportunities/` — apricot palette, Geist + Inter + JBM, light + dark
+- **Brand assets**: `packages/brand-oportunities/` — logos, app icons, favicons, social templates, business cards, email signature
+- **Brand decisions**: `packages/brand-oportunities/BRAND-DECISIONS.md` — founder-approved, do not change without sign-off
+- **Engineer hand-off**: `packages/brand-oportunities/ENGINEER-HANDOFF.md` — how to consume in a product app
+- **Components**: 6 new composed components in `@amplify-ai/ui` (`Wordmark`, `SignalDot`, `CreatorIntentCard`, `BrandInterestCard`, `IntentFeed`, `AppIconOportunities`)
+
+**Composition rule**: Oportunities components compose from `tokens-foundation`
+primitives + existing `@amplify-ai/ui` primitives (Card, Avatar, Badge, etc.).
+**Never invent new primitives for Oportunities** — add a composed component
+that wraps existing primitives instead. If a true primitive is missing, raise
+it in `@amplify-ai/ui` first so all themes benefit.
+
+**Spelling**: single-P "Oportunities" everywhere. Not "Opportunities".

--- a/PR-DESCRIPTION.md
+++ b/PR-DESCRIPTION.md
@@ -1,0 +1,48 @@
+# feat: add Oportunities theme + Studio brand to design system
+
+This PR introduces the **Oportunities** product theme (Studio direction) to the federated design system, alongside the existing brand/creator/atmosphere/studio/marketing themes.
+
+## What's added
+
+### 4 new packages
+- **`@amplify-ai/tokens-oportunities@1.0.0`** — Studio-direction tokens (apricot palette, Geist + Inter + JBM, light + dark)
+- **`@amplify-ai/brand-oportunities@1.0.0`** — brand asset library (logo SVGs, app icons, favicons, social templates, business cards, email signature, full `BRAND-DECISIONS.md`)
+
+### 6 new components in `@amplify-ai/ui` (will release as 2.12.0)
+- `Wordmark` — Oportunities wordmark with optional gradient-sweep animation
+- `SignalDot` — the apricot period as a standalone animated mark
+- `CreatorIntentCard` — signature product card (composes `Card` + `Avatar` + `Badge`)
+- `BrandInterestCard` — creator-side inbox card
+- `IntentFeed` — filterable container
+- `AppIconOportunities` — the locked "op." app icon as a React component
+
+All composed from existing primitives — no new primitives introduced.
+
+### Storybook
+- Oportunities theme registered in theme switcher
+- 8 brand guidelines docs: Brand overview, Logo, Color, Typography, Components, Voice, AppIcon, Favicon
+
+## What's NOT in this PR (Phase 2)
+Marketing site templates, email transactional/marketing templates, push notif spec, WhatsApp message templates, full social templates, slide deck cover, Slack notification format. These ship in a follow-up PR (`feat/oportunities-templates`).
+
+## Locked brand decisions (founder-approved)
+Documented in `packages/brand-oportunities/BRAND-DECISIONS.md` — full record of:
+- Wordmark spec
+- Signature animation
+- App icon + favicon (light + dark)
+- Voice register
+- Application contexts
+- Sizing scale
+
+## Test plan
+- [ ] `npm install` from clean state
+- [ ] `npm run build` succeeds for all workspaces
+- [ ] `npm run storybook` launches; Oportunities theme selectable; all 8 docs render
+- [ ] `npm run test -w packages/ui` passes
+- [ ] Pixel drift detection picks up the new package within 6 hours of merge
+- [ ] Engineer can import + use components in a sample product
+
+## Migration / breaking changes
+None. All additions are net-new. No existing API changed.
+
+Generated with Claude Code

--- a/README.md
+++ b/README.md
@@ -35,14 +35,21 @@ Federated design tokens and shared UI components for all One Impression products
                                |
                     npm install @amplify-ai/tokens-*
                                |
-          +--------------------+--------------------+
-          |                    |                    |
-  +-------v------+   +--------v-------+   +-------v--------+
-  |    Brand     |   |   Creator App  |   |  Atmosphere    |
-  | one-dashboard|   |  one_club_app  |   | odin-agent/web |
-  |    -web      |   |                |   |                |
-  +--------------+   +----------------+   +----------------+
+          +---------+----------+----------+----------+
+          |         |          |          |          |
+  +-------v----+ +--v-------+ +v--------+ +v---------+
+  |   Brand    | | Creator  | |Atmosphere| |Oportunities|
+  |one-dashboard| | App      | |odin-agent| | (Studio  |
+  |    -web    | |one_club  | |   /web   | | direction)|
+  |            | |   _app   | |          | |          |
+  +------------+ +----------+ +----------+ +----------+
 ```
+
+The federated model supports per-product themes: each product owns its
+own `tokens-<product>` package that composes the shared `tokens-foundation`
+primitives. New product lines (e.g. **Oportunities**) ship as a new
+`tokens-<product>` + `brand-<product>` pair without touching any other
+product's tokens.
 
 ## This repo is the BUILD SYSTEM. Pixel is the BRAIN.
 
@@ -66,6 +73,8 @@ Federated design tokens and shared UI components for all One Impression products
 | `@amplify-ai/tokens-brand` | Brand platform colors & theme | one-dashboard-web |
 | `@amplify-ai/tokens-atmosphere` | Atmosphere dashboard colors & theme | odin-agent/web |
 | `@amplify-ai/tokens-creator` | Creator app colors & SDUI mapping | one_club_app |
+| `@amplify-ai/tokens-oportunities` | Oportunities theme tokens (Studio direction, apricot palette) | oportunities apps (TBD) |
+| `@amplify-ai/brand-oportunities` | Oportunities brand asset library (logos, app icons, favicons, social, decisions doc) | oportunities apps (TBD) |
 | `@amplify-ai/ui` | Shared React UI components | Web products |
 | `@amplify-ai/eslint-config` | Design system lint rules | All products |
 | `@amplify-ai/feature-flags` | Feature flag utilities | All products |

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,10 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@amplify-ai/brand-oportunities": {
+      "resolved": "packages/brand-oportunities",
+      "link": true
+    },
     "node_modules/@amplify-ai/eslint-config": {
       "resolved": "packages/eslint-config",
       "link": true
@@ -59,6 +63,10 @@
     },
     "node_modules/@amplify-ai/tokens-foundation": {
       "resolved": "packages/tokens-foundation",
+      "link": true
+    },
+    "node_modules/@amplify-ai/tokens-oportunities": {
+      "resolved": "packages/tokens-oportunities",
       "link": true
     },
     "node_modules/@amplify-ai/tokens-studio": {
@@ -505,7 +513,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -523,7 +530,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -541,7 +547,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -559,7 +564,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -577,7 +581,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -595,7 +598,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -613,7 +615,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -631,7 +632,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -649,7 +649,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -667,7 +666,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -685,7 +683,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -703,7 +700,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -721,7 +717,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -739,7 +734,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -757,7 +751,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -775,7 +768,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -793,7 +785,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -811,7 +802,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -829,7 +819,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -847,7 +836,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -865,7 +853,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -883,7 +870,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -901,7 +887,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -919,7 +904,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -937,7 +921,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -955,7 +938,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10080,7 +10062,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10098,7 +10079,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10116,7 +10096,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10134,7 +10113,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10152,7 +10130,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10170,7 +10147,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10188,7 +10164,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10206,7 +10181,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10224,7 +10198,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10242,7 +10215,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10260,7 +10232,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10278,7 +10249,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10296,7 +10266,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10314,7 +10283,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10332,7 +10300,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10350,7 +10317,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10368,7 +10334,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10386,7 +10351,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10404,7 +10368,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10422,7 +10385,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10440,7 +10402,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10458,7 +10419,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10476,7 +10436,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10494,7 +10453,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10512,7 +10470,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10530,7 +10487,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12458,6 +12414,10 @@
         }
       }
     },
+    "packages/brand-oportunities": {
+      "name": "@amplify-ai/brand-oportunities",
+      "version": "1.0.0"
+    },
     "packages/eslint-config": {
       "name": "@amplify-ai/eslint-config",
       "version": "2.1.0",
@@ -12511,13 +12471,17 @@
         "@gorhom/bottom-sheet": "^5.0.0",
         "@one-impression/sdk-native-sdui": ">=1.0.0",
         "react": ">=18.0.0",
-        "react-native": ">=0.72.0"
+        "react-native": ">=0.72.0",
+        "react-native-webview": ">=13.0.0"
       },
       "peerDependenciesMeta": {
         "@gorhom/bottom-sheet": {
           "optional": true
         },
         "@one-impression/sdk-native-sdui": {
+          "optional": true
+        },
+        "react-native-webview": {
           "optional": true
         }
       }
@@ -12616,6 +12580,16 @@
       "version": "1.0.0",
       "peerDependencies": {
         "@amplify-ai/tokens-foundation": "^2.1.0"
+      }
+    },
+    "packages/tokens-oportunities": {
+      "name": "@amplify-ai/tokens-oportunities",
+      "version": "1.0.0",
+      "dependencies": {
+        "@amplify-ai/tokens-foundation": "^2.1.0"
+      },
+      "devDependencies": {
+        "style-dictionary": "^4.3.0"
       }
     },
     "packages/tokens-studio": {

--- a/packages/brand-oportunities/BRAND-DECISIONS.md
+++ b/packages/brand-oportunities/BRAND-DECISIONS.md
@@ -1,0 +1,157 @@
+# Oportunities — Locked Brand Decisions
+
+Final record of every brand decision for **Oportunities** as of 2026-05-19.
+This file is the source-of-truth for the asset package. Token values live in
+`@amplify-ai/tokens-oportunities`.
+
+---
+
+## Theme direction
+
+**Studio** — chosen from 8 candidate directions on 2026-05-19.
+
+Rationale: warm-cream + apricot + Geist evokes "creative studio" rather than
+"saas product," differentiating from the dominant blue-grey B2B SaaS look.
+Apricot period is the brand's signature mnemonic.
+
+---
+
+## Wordmark
+
+| Property | Value |
+|---|---|
+| Glyph | `oportunities.` (single-P spelling, lowercase, trailing period) |
+| Typeface | Geist (Vercel), weight 600 |
+| Tracking | -0.04em |
+| Ink color | `#0F0D0B` on light surfaces |
+| Period color | `#E89252` (apricot) on light, `#F0A668` (brighter apricot) on dark |
+| Clear-space | 1 × cap-height on all sides (minimum) |
+| Minimum size | 11 px wordmark height (favicon) — below this use the `op.` mark |
+| Forbidden | Outlining, drop-shadow, scaling the period independently, replacing typeface |
+
+### Signature gradient
+Apricot → terracotta → purple, 0% → 50% → 100%:
+- `#E89252` → `#D87B6E` → `#6B4FA0`
+
+Used only as a **static snapshot** on wordmark in marketing hero / OG moments.
+Live animation (e.g. landing page sweep) is reserved for product-marketing surfaces
+and **must not** be used in product UI (would distract from primary task).
+
+---
+
+## App icon
+
+| Property | Value |
+|---|---|
+| Mark | `op.` (first two letters + apricot period) |
+| Shape | iOS squircle, corner radius **22.37%** of canvas width |
+| Light variant | Cream `#FDF8F3` background, dark `#0F0D0B` glyph, `#E89252` period |
+| Dark variant | Dark `#0F0D0B` background, cream `#F4ECE0` glyph, `#F0A668` period |
+| Sizes shipped | 1024 (asset stores), 180 (iOS touch), 512 (PWA maskable) |
+| Safe zone | 80% of canvas (51 px padding at 512 — required for PWA maskable) |
+| Glyph alignment | Optical center; period sits on the baseline, not below |
+
+---
+
+## Favicon
+
+| Property | Value |
+|---|---|
+| Mark | `op.` at 32+; bare apricot dot + small `op` at 16 |
+| Light SVG | `#FDF8F3` background, dark glyph |
+| Dark SVG | `#0F0D0B` background, light glyph |
+| Safari pinned-tab | Monochrome SVG mask (Safari applies user tint) |
+| Theme color (meta) | `#E89252` (apricot) |
+| Background color (manifest) | `#FDF8F3` (cream) |
+
+---
+
+## Voice register
+
+Two registers, applied per-context:
+
+### Direct-confident
+Used for: **push notifications, primary buttons, error messages, tooltips**.
+- Short. Verb-first. Imperative or declarative.
+- No hedging ("might," "perhaps," "consider").
+- No filler ("just," "simply").
+- Examples:
+  - Push: `New collab from L'Oréal — 48h to respond.`
+  - Button: `Send brief`
+  - Error: `Payout blocked — bank IFSC invalid. Fix bank details.`
+  - Tooltip: `Locked until KYC complete.`
+
+### Tool-curious
+Used for: **empty states, success moments, email subject lines, marketing copy**.
+- Warmer. Asks the user a question or offers a thought.
+- Slightly playful but never cute.
+- No exclamation marks beyond 1 per surface.
+- Examples:
+  - Empty: `No briefs yet. Run intent scan to find your first.`
+  - Success: `Brief sent. We'll surface replies as they arrive.`
+  - Subject: `Three creators matched your brief this week.`
+  - Marketing: `Creator intent, visible.`
+
+---
+
+## Application contexts (10 confirmed)
+
+The brand applies across:
+
+1. Product UI (web app on `oportunities.in`)
+2. Mobile app (iOS + Android home-screen icons)
+3. PWA install (manifest, maskable icon)
+4. Browser favicon (light + dark + Safari pinned)
+5. Email transactional (logo header, brand color accents)
+6. Email signature (HTML + minimal variants)
+7. LinkedIn company page (cover + post template)
+8. Instagram (post + story templates)
+9. X / Twitter (banner + OG image)
+10. Print: business cards (89 × 54 mm), with future expansion to pitch decks
+
+---
+
+## Sizing scale
+
+Type and component sizing follow the foundation fluid-type scale (token package),
+but for the **brand assets** specifically:
+
+| Pixel size | Use |
+|---|---|
+| 11 px | Minimum wordmark height — favicon |
+| 16 px | Favicon @ 1× |
+| 20 px | UI nav wordmark, dense surfaces |
+| 24 px | Standard product header wordmark |
+| 32 px | Email signature wordmark |
+| 40 px | Marketing landing nav wordmark |
+| 56 px | Hero wordmark on product pages |
+| 72 px | LinkedIn post / IG post wordmark |
+| 88 px | Default brand-asset wordmark (default SVG viewBox) |
+| 96 px | LinkedIn cover, X banner |
+| 120 px | OG image wordmark, hero on marketing landing |
+| 560 px | App icon glyph (1024 canvas) |
+| 96 px | App icon glyph (180 canvas) |
+
+---
+
+## What changes vs other Amplify brands
+
+- **Single-P spelling** "Oportunities" — distinctive, registered, do **NOT** correct to "Opportunities."
+- **Apricot period** is non-negotiable. It's the brand mark.
+- **Geist**, not Inter (Inter is the Amplify-platform default).
+- **Cream**, not white. `#FDF8F3` background everywhere; pure `#FFFFFF` is reserved for medical / sterile contexts (not us).
+- **No icon family** beyond the `op.` mark. We borrow Lucide for product UI but never iconise the brand itself.
+
+---
+
+## Decision log
+
+| Date | Decision | Source |
+|---|---|---|
+| 2026-05-19 | Studio direction chosen from 8 candidates | Founder pick |
+| 2026-05-19 | Asset package v1.0.0 created | This PR |
+
+Pending decisions (NOT in this asset package):
+- Long-form brand voice doc (separate concern, lives in marketing wiki)
+- Motion grammar for in-product transitions (handled by `@amplify-ai/tokens-foundation/motion`)
+- Sound / haptics (deferred until mobile app GA)

--- a/packages/brand-oportunities/ENGINEER-HANDOFF.md
+++ b/packages/brand-oportunities/ENGINEER-HANDOFF.md
@@ -1,0 +1,79 @@
+# Oportunities — Engineer hand-off guide
+
+## What's been built (all in this PR)
+- `@amplify-ai/tokens-oportunities@1.0.0`
+- `@amplify-ai/brand-oportunities@1.0.0`
+- New components in `@amplify-ai/ui` (`Wordmark`, `SignalDot`, `CreatorIntentCard`, `BrandInterestCard`, `IntentFeed`, `AppIconOportunities`)
+- Storybook theme + 8 brand guidelines docs
+
+## How to consume in a product app
+
+### Step 1: install tokens + UI
+```bash
+npm install @amplify-ai/tokens-oportunities @amplify-ai/ui @amplify-ai/brand-oportunities
+```
+
+### Step 2: load CSS or Tailwind
+
+Option A (CSS vars):
+```ts
+import '@amplify-ai/tokens-oportunities/css';
+```
+
+Option B (Tailwind preset):
+```ts
+// tailwind.config.ts
+import oportunitiesPreset from '@amplify-ai/tokens-oportunities/tailwind';
+export default { presets: [oportunitiesPreset], ... };
+```
+
+### Step 3: use components
+```tsx
+import { Wordmark, SignalDot, CreatorIntentCard } from '@amplify-ai/ui';
+
+<Wordmark size="xl" animated />
+<SignalDot size={24} live />
+<CreatorIntentCard creator={...} intent={...} aiFitScore={94} onUnlock={...} />
+```
+
+### Step 4: brand assets
+```ts
+import { wordmark, appIcon } from '@amplify-ai/brand-oportunities';
+// Or reference directly:
+<img src="/node_modules/@amplify-ai/brand-oportunities/assets/logo/wordmark-default.svg" />
+```
+
+## What you still need to build (product code, not design system)
+
+### Brand product (desktop SPA)
+- Authentication wiring
+- Backend API integration
+- Stripe payment integration
+- Real intent data feed
+
+### Creator app (mobile)
+- iOS / Android app shell
+- Push notification handling
+- WhatsApp deep-link handler
+
+### Internal admin
+- Real admin auth + RBAC
+- Real database queries
+- Audit log infrastructure
+
+## Locked brand decisions (DO NOT change without sign-off)
+- Wordmark: `oportunities.` Geist 600, -0.04em, solid apricot period
+- Signature animation: apricot→purple gradient sweep
+- App icon: V1 default base (`op.` on cream / dark)
+- Favicon: V1 default base
+- Voice register: Direct-confident (push/buttons/errors/tooltips) + Tool-curious (empty/success/email/marketing)
+- Palette: locked apricot family (see `tokens-oportunities/tokens/theme-light.json`)
+
+## Pixel governance
+Once this PR merges:
+- Pixel agent will detect the new `tokens-oportunities` package within 6 hours
+- Pixel will start drift monitoring for Oportunities
+- Brand cascade enabled when tokens change here
+
+## Questions
+File issues on this PR or ping Apaksh on Slack.

--- a/packages/brand-oportunities/README.md
+++ b/packages/brand-oportunities/README.md
@@ -1,0 +1,106 @@
+# @amplify-ai/brand-oportunities
+
+Locked brand assets for **Oportunities** — the creator-intent intelligence platform.
+Theme direction: **Studio** (Geist + apricot period).
+
+This package ships ready-to-use SVG/HTML assets — no build step, no token wiring.
+For runtime tokens (colors, type, spacing), use `@amplify-ai/tokens-oportunities`.
+
+---
+
+## Folder layout
+
+```
+assets/
+  logo/                  6 wordmark variants
+  icons/                 App icons (light + dark, 1024 + 180, PWA maskable, spec)
+  favicons/              Favicon sources (SVG + per-size + safari pinned tab + webmanifest)
+  social/                LinkedIn cover/post, IG post/story, X banner, OG image
+  business-cards/        Front + back at 89 × 54 mm (300 DPI print spec)
+  email-signature/       Full + minimal HTML signature templates
+```
+
+---
+
+## Naming convention
+
+`<asset-type>-<variant>-<size>.svg`
+
+Examples:
+- `wordmark-on-dark.svg`
+- `app-icon-light-1024.svg`
+- `linkedin-cover-1584x396.svg`
+- `business-card-front-89x54.svg`
+
+Sizes follow the platform's native canvas spec where one exists (LinkedIn cover is
+always 1584×396, an iPhone touch icon is always 180×180, etc).
+
+---
+
+## How to use each asset
+
+### Logo / wordmark
+- **`wordmark-default.svg`** — Transparent background, dark ink. Default for most surfaces.
+- **`wordmark-on-light.svg`** — Cream `#FDF8F3` background bundled, for printed material.
+- **`wordmark-on-dark.svg`** — Dark `#0F0D0B` background, cream wordmark, **brighter** apricot period (`#F0A668`) for AA contrast.
+- **`wordmark-monochrome.svg`** — Uses `currentColor` for fill — drop into any single-ink context (engraving, foiling, single-color print).
+- **`wordmark-with-gradient.svg`** — Static snapshot of the **signature** apricot → purple gradient sweep. Use sparingly: brand moments, cover heroes.
+- **`wordmark-spec.svg`** — Reference only. Shows clear-space rule (1× cap-height all sides) and bounding box.
+
+### App icons
+- iOS / Android home-screen: `app-icon-{light,dark}-{1024,180}.svg`
+- iOS touch icon (`<link rel="apple-touch-icon">`): `app-icon-light-180.svg`
+- PWA maskable (`purpose="maskable"`): `pwa-maskable-icon-512.svg` (respects 80% safe-zone)
+- Specification reference: `app-icon-spec.svg` (squircle radius 22.37%, safe-zone, glyph alignment)
+
+### Favicons
+- Modern browsers: link `favicon-light.svg` (with `<meta name="theme-color">`)
+- Legacy: `favicon-{16,32,180}.png` (these files contain SVG sources at the spec dimension; render to PNG before deploy)
+- Safari pinned tab: `safari-pinned-tab.svg` (monochrome — Safari applies tint)
+- PWA manifest: `site.webmanifest`
+
+### Social
+Each file is the **exact** size requested by the platform. Replace `{...}` placeholder text in headlines before publishing.
+
+### Business cards
+Print-ready at 89 × 54 mm (standard EU/UK card). Includes 3 mm safety margin via inner padding. Replace `Apaksh Gupta` / `Founder` placeholders before press.
+
+### Email signature
+Two variants:
+- `email-signature.html` — full, includes inline-SVG wordmark
+- `email-signature-minimal.html` — text-only, maximum client compatibility (Outlook, older Gmail web)
+
+Both use only email-safe inline CSS. **No** external stylesheets, **no** JavaScript, **no** web fonts.
+
+Placeholder substitution: `{name}`, `{title}`, `{email}`, `{phone}` — replace via your CRM / signature manager.
+
+---
+
+## License & usage
+
+Internal use across the One Impression / Amplify organization. Team members may use
+these assets freely for any legitimate Oportunities work (presentations, social
+posts, business cards, email signatures, marketing material).
+
+**Do not** distribute the source files outside the org. **Do not** modify the
+wordmark proportions, the apricot period color, or the squircle radius — these are
+locked.
+
+---
+
+## Programmatic access
+
+```js
+import { wordmark, appIcon, favicon, brandColors } from '@amplify-ai/brand-oportunities';
+
+// Returns asset paths relative to the package root.
+console.log(wordmark.default); // 'assets/logo/wordmark-default.svg'
+console.log(brandColors.apricot); // '#E89252'
+```
+
+---
+
+## Related packages
+
+- **`@amplify-ai/tokens-oportunities`** — runtime tokens (colors, type, spacing) as CSS / SCSS / JS
+- **`@amplify-ai/ui`** — shared components themed via tokens-oportunities

--- a/packages/brand-oportunities/assets/business-cards/business-card-back-89x54.svg
+++ b/packages/brand-oportunities/assets/business-cards/business-card-back-89x54.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Business card BACK
+  Print spec: 89mm × 54mm at 300 DPI = 1051 × 638 px
+-->
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 1051 638"
+     width="89mm" height="54mm"
+     role="img" aria-label="oportunities business card back">
+  <title>oportunities business card — BACK (89×54mm)</title>
+  <defs>
+    <style>
+      .bg { fill: #FDF8F3; }
+      .label {
+        font-family: "Geist Mono", "JetBrains Mono", ui-monospace, monospace;
+        font-weight: 400;
+        font-size: 18px;
+        letter-spacing: 0.04em;
+        fill: #6B4FA0;
+        text-transform: uppercase;
+      }
+      .value {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 500;
+        font-size: 30px;
+        letter-spacing: -0.01em;
+        fill: #0F0D0B;
+      }
+      .dot-mark {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 600;
+        font-size: 200px;
+        letter-spacing: -0.04em;
+      }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect class="bg" x="0" y="0" width="1051" height="638"/>
+
+  <!-- Large apricot period as decorative mark -->
+  <text x="820" y="500" class="dot-mark" fill="#E89252">.</text>
+
+  <!-- Contact block -->
+  <text x="72" y="180" class="label">EMAIL</text>
+  <text x="72" y="230" class="value">apaksh@oportunities.in</text>
+
+  <text x="72" y="320" class="label">PHONE</text>
+  <text x="72" y="370" class="value">+91 98XXX XXXXX</text>
+
+  <text x="72" y="460" class="label">WEB</text>
+  <text x="72" y="510" class="value">oportunities.in</text>
+
+  <!-- Apricot accent bar bottom-left -->
+  <rect x="72" y="580" width="80" height="6" fill="#E89252"/>
+</svg>

--- a/packages/brand-oportunities/assets/business-cards/business-card-front-89x54.svg
+++ b/packages/brand-oportunities/assets/business-cards/business-card-front-89x54.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Business card FRONT
+  Print spec: 89mm × 54mm at 300 DPI = 1051 × 638 px
+  Bleed: include 3mm safety margin (35px each side)
+-->
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 1051 638"
+     width="89mm" height="54mm"
+     role="img" aria-label="oportunities business card front">
+  <title>oportunities business card — FRONT (89×54mm)</title>
+  <defs>
+    <style>
+      .bg { fill: #FDF8F3; }
+      .wm {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 600;
+        font-size: 96px;
+        letter-spacing: -0.04em;
+        fill: #0F0D0B;
+      }
+      .wm-dot { fill: #E89252; }
+      .name {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 500;
+        font-size: 36px;
+        letter-spacing: -0.01em;
+        fill: #0F0D0B;
+      }
+      .role {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 400;
+        font-size: 22px;
+        fill: #4A453F;
+      }
+      .safe {
+        fill: none;
+        stroke: none;
+      }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect class="bg" x="0" y="0" width="1051" height="638"/>
+
+  <!-- Safe area (no print, just guides hidden via stroke=none) -->
+  <rect class="safe" x="35" y="35" width="981" height="568"/>
+
+  <!-- Wordmark, top-left within safe area -->
+  <text x="72" y="180" class="wm">oportunities</text>
+  <text x="72" y="180" class="wm wm-dot" dx="540">.</text>
+
+  <!-- Name -->
+  <text x="72" y="500" class="name">Apaksh Gupta</text>
+  <!-- Role -->
+  <text x="72" y="550" class="role">Founder</text>
+
+  <!-- Apricot accent bar bottom-right -->
+  <rect x="900" y="540" width="80" height="6" fill="#E89252"/>
+</svg>

--- a/packages/brand-oportunities/assets/email-signature/email-signature-minimal.html
+++ b/packages/brand-oportunities/assets/email-signature/email-signature-minimal.html
@@ -1,0 +1,28 @@
+<!--
+  Oportunities email signature — MINIMAL variant
+  Text-only, no SVG. Maximum email-client compatibility.
+  Placeholders: {name}, {title}, {email}, {phone}
+-->
+<table cellpadding="0" cellspacing="0" border="0" role="presentation"
+       style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; color: #0F0D0B; border-collapse: collapse; line-height: 1.4;">
+  <tr>
+    <td style="padding: 0 0 4px 0; font-size: 14px; font-weight: 600; color: #0F0D0B; letter-spacing: -0.01em;">
+      {name}
+      <span style="color: #4A453F; font-weight: 400;">&nbsp;·&nbsp;{title}</span>
+    </td>
+  </tr>
+  <tr>
+    <td style="padding: 0 0 4px 0; font-size: 13px; color: #4A453F;">
+      <a href="mailto:{email}" style="color: #4A453F; text-decoration: none;">{email}</a>
+      <span style="color: #E89252; font-weight: 700;">&nbsp;·&nbsp;</span>
+      <a href="tel:{phone}" style="color: #4A453F; text-decoration: none;">{phone}</a>
+    </td>
+  </tr>
+  <tr>
+    <td style="padding: 0 0 0 0; font-size: 13px; color: #0F0D0B; font-weight: 500;">
+      oportunities<span style="color: #E89252;">.</span>
+      <span style="color: #6B4FA0; font-weight: 400;">&nbsp;·&nbsp;</span>
+      <a href="https://oportunities.in" style="color: #6B4FA0; text-decoration: none;">oportunities.in</a>
+    </td>
+  </tr>
+</table>

--- a/packages/brand-oportunities/assets/email-signature/email-signature.html
+++ b/packages/brand-oportunities/assets/email-signature/email-signature.html
@@ -1,0 +1,46 @@
+<!--
+  Oportunities email signature — FULL variant
+  Email-safe inline CSS only. No JS, no external stylesheets, no web fonts.
+  Placeholders: {name}, {title}, {email}, {phone}
+  Wordmark rendered as inline SVG so it scales crisply in all clients.
+-->
+<table cellpadding="0" cellspacing="0" border="0" role="presentation"
+       style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; color: #0F0D0B; border-collapse: collapse; line-height: 1.4;">
+  <tr>
+    <td style="padding: 0 0 8px 0;">
+      <!-- Wordmark (inline SVG) -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="180" height="32" viewBox="0 0 540 96" aria-label="oportunities">
+        <text x="0" y="74" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-weight="600" font-size="80" letter-spacing="-3" fill="#0F0D0B">oportunities</text>
+        <text x="0" y="74" dx="486" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-weight="600" font-size="80" letter-spacing="-3" fill="#E89252">.</text>
+      </svg>
+    </td>
+  </tr>
+  <tr>
+    <td style="padding: 4px 0 0 0; font-size: 15px; font-weight: 600; color: #0F0D0B; letter-spacing: -0.01em;">
+      {name}
+    </td>
+  </tr>
+  <tr>
+    <td style="padding: 2px 0 10px 0; font-size: 13px; color: #4A453F;">
+      {title}
+    </td>
+  </tr>
+  <tr>
+    <td style="padding: 0 0 4px 0; font-size: 13px; color: #4A453F;">
+      <a href="mailto:{email}" style="color: #4A453F; text-decoration: none;">{email}</a>
+      <span style="color: #E89252; font-weight: 700;">&nbsp;·&nbsp;</span>
+      <a href="tel:{phone}" style="color: #4A453F; text-decoration: none;">{phone}</a>
+    </td>
+  </tr>
+  <tr>
+    <td style="padding: 2px 0 0 0; font-size: 12px; color: #6B4FA0;">
+      <a href="https://oportunities.in" style="color: #6B4FA0; text-decoration: none;">oportunities.in</a>
+    </td>
+  </tr>
+  <tr>
+    <td style="padding: 12px 0 0 0;">
+      <!-- Apricot divider -->
+      <div style="width: 48px; height: 3px; background: #E89252; line-height: 0; font-size: 0;">&nbsp;</div>
+    </td>
+  </tr>
+</table>

--- a/packages/brand-oportunities/assets/favicons/favicon-16.png
+++ b/packages/brand-oportunities/assets/favicons/favicon-16.png
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Pixel-grade favicon source — render at 16×16 px via SVG rasterizer.
+     Stored as SVG (filename .png by spec for downstream tooling convenience). -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" role="img" aria-label="oportunities favicon 16">
+  <title>oportunities favicon — 16×16 pixel-perfect</title>
+  <rect x="0" y="0" width="16" height="16" rx="3" ry="3" fill="#FDF8F3"/>
+  <!-- At 16px, glyph reduces to apricot dot mark for clarity -->
+  <circle cx="11.5" cy="11" r="2" fill="#E89252"/>
+  <text x="2" y="12" font-family="Geist, Inter, sans-serif" font-weight="700" font-size="10" letter-spacing="-0.04em" fill="#0F0D0B">op</text>
+</svg>

--- a/packages/brand-oportunities/assets/favicons/favicon-180.png
+++ b/packages/brand-oportunities/assets/favicons/favicon-180.png
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Apple touch icon source — render at 180×180 px via SVG rasterizer. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180" width="180" height="180" role="img" aria-label="oportunities apple touch icon 180">
+  <title>oportunities apple-touch-icon — 180×180</title>
+  <defs>
+    <clipPath id="appleTouchSquircle">
+      <rect x="0" y="0" width="180" height="180" rx="40" ry="40"/>
+    </clipPath>
+  </defs>
+  <g clip-path="url(#appleTouchSquircle)">
+    <rect x="0" y="0" width="180" height="180" fill="#FDF8F3"/>
+    <text x="32" y="120" font-family="Geist, Inter, sans-serif" font-weight="600" font-size="98" letter-spacing="-0.04em" fill="#0F0D0B">op</text>
+    <text x="122" y="120" font-family="Geist, Inter, sans-serif" font-weight="600" font-size="98" letter-spacing="-0.04em" fill="#E89252">.</text>
+  </g>
+</svg>

--- a/packages/brand-oportunities/assets/favicons/favicon-32.png
+++ b/packages/brand-oportunities/assets/favicons/favicon-32.png
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Pixel-grade favicon source — render at 32×32 px via SVG rasterizer. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" role="img" aria-label="oportunities favicon 32">
+  <title>oportunities favicon — 32×32</title>
+  <rect x="0" y="0" width="32" height="32" rx="7" ry="7" fill="#FDF8F3"/>
+  <text x="4" y="22" font-family="Geist, Inter, sans-serif" font-weight="600" font-size="18" letter-spacing="-0.04em" fill="#0F0D0B">op</text>
+  <text x="22" y="22" font-family="Geist, Inter, sans-serif" font-weight="600" font-size="18" letter-spacing="-0.04em" fill="#E89252">.</text>
+</svg>

--- a/packages/brand-oportunities/assets/favicons/favicon-dark.svg
+++ b/packages/brand-oportunities/assets/favicons/favicon-dark.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="oportunities favicon dark">
+  <title>oportunities favicon (dark)</title>
+  <defs>
+    <style>
+      .fav-text {
+        font-family: "Geist", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 600;
+        font-size: 36px;
+        letter-spacing: -0.04em;
+        fill: #F4ECE0;
+      }
+      .fav-dot { fill: #F0A668; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="64" height="64" rx="14" ry="14" fill="#0F0D0B"/>
+  <text x="8" y="44" class="fav-text">op</text>
+  <text x="44" y="44" class="fav-text fav-dot">.</text>
+</svg>

--- a/packages/brand-oportunities/assets/favicons/favicon-light.svg
+++ b/packages/brand-oportunities/assets/favicons/favicon-light.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="oportunities favicon light">
+  <title>oportunities favicon (light)</title>
+  <defs>
+    <style>
+      .fav-text {
+        font-family: "Geist", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 600;
+        font-size: 36px;
+        letter-spacing: -0.04em;
+        fill: #0F0D0B;
+      }
+      .fav-dot { fill: #E89252; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="64" height="64" rx="14" ry="14" fill="#FDF8F3"/>
+  <text x="8" y="44" class="fav-text">op</text>
+  <text x="44" y="44" class="fav-text fav-dot">.</text>
+</svg>

--- a/packages/brand-oportunities/assets/favicons/safari-pinned-tab.svg
+++ b/packages/brand-oportunities/assets/favicons/safari-pinned-tab.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Safari pinned-tab mask — must be a single-color monochrome SVG. Safari applies the user's tint. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="oportunities safari pinned tab mask">
+  <title>oportunities — safari pinned tab mask (monochrome)</title>
+  <g fill="black">
+    <text x="6" y="44" font-family="Geist, Inter, sans-serif" font-weight="600" font-size="36" letter-spacing="-0.04em">op.</text>
+  </g>
+</svg>

--- a/packages/brand-oportunities/assets/favicons/site.webmanifest
+++ b/packages/brand-oportunities/assets/favicons/site.webmanifest
@@ -1,0 +1,38 @@
+{
+  "name": "oportunities.",
+  "short_name": "op.",
+  "description": "Oportunities — creator-intent intelligence platform",
+  "start_url": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#FDF8F3",
+  "theme_color": "#E89252",
+  "icons": [
+    {
+      "src": "/favicon-16.png",
+      "sizes": "16x16",
+      "type": "image/png"
+    },
+    {
+      "src": "/favicon-32.png",
+      "sizes": "32x32",
+      "type": "image/png"
+    },
+    {
+      "src": "/favicon-180.png",
+      "sizes": "180x180",
+      "type": "image/png"
+    },
+    {
+      "src": "/pwa-maskable-icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "/favicon-light.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/packages/brand-oportunities/assets/icons/app-icon-dark-1024.svg
+++ b/packages/brand-oportunities/assets/icons/app-icon-dark-1024.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" role="img" aria-label="oportunities app icon dark">
+  <title>oportunities app icon (dark) — 1024×1024</title>
+  <defs>
+    <clipPath id="squircleDark">
+      <rect x="0" y="0" width="1024" height="1024" rx="229" ry="229"/>
+    </clipPath>
+    <style>
+      .icon-text {
+        font-family: "Geist", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 600;
+        font-size: 560px;
+        letter-spacing: -0.04em;
+        fill: #F4ECE0;
+      }
+      .icon-dot { fill: #F0A668; }
+    </style>
+  </defs>
+  <g clip-path="url(#squircleDark)">
+    <rect x="0" y="0" width="1024" height="1024" fill="#0F0D0B"/>
+    <text x="180" y="680" class="icon-text">op</text>
+    <text x="700" y="680" class="icon-text icon-dot">.</text>
+  </g>
+</svg>

--- a/packages/brand-oportunities/assets/icons/app-icon-dark-180.svg
+++ b/packages/brand-oportunities/assets/icons/app-icon-dark-180.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180" role="img" aria-label="oportunities app icon dark 180">
+  <title>oportunities app icon (dark) — 180×180 (iOS touch icon)</title>
+  <defs>
+    <clipPath id="squircleDark180">
+      <rect x="0" y="0" width="180" height="180" rx="40" ry="40"/>
+    </clipPath>
+    <style>
+      .icon-text {
+        font-family: "Geist", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 600;
+        font-size: 98px;
+        letter-spacing: -0.04em;
+        fill: #F4ECE0;
+      }
+      .icon-dot { fill: #F0A668; }
+    </style>
+  </defs>
+  <g clip-path="url(#squircleDark180)">
+    <rect x="0" y="0" width="180" height="180" fill="#0F0D0B"/>
+    <text x="32" y="120" class="icon-text">op</text>
+    <text x="122" y="120" class="icon-text icon-dot">.</text>
+  </g>
+</svg>

--- a/packages/brand-oportunities/assets/icons/app-icon-light-1024.svg
+++ b/packages/brand-oportunities/assets/icons/app-icon-light-1024.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" role="img" aria-label="oportunities app icon light">
+  <title>oportunities app icon (light) — 1024×1024</title>
+  <defs>
+    <clipPath id="squircle">
+      <rect x="0" y="0" width="1024" height="1024" rx="229" ry="229"/>
+    </clipPath>
+    <style>
+      .icon-text {
+        font-family: "Geist", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 600;
+        font-size: 560px;
+        letter-spacing: -0.04em;
+        fill: #0F0D0B;
+      }
+      .icon-dot { fill: #E89252; }
+    </style>
+  </defs>
+  <g clip-path="url(#squircle)">
+    <rect x="0" y="0" width="1024" height="1024" fill="#FDF8F3"/>
+    <text x="180" y="680" class="icon-text">op</text>
+    <text x="700" y="680" class="icon-text icon-dot">.</text>
+  </g>
+</svg>

--- a/packages/brand-oportunities/assets/icons/app-icon-light-180.svg
+++ b/packages/brand-oportunities/assets/icons/app-icon-light-180.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180" role="img" aria-label="oportunities app icon light 180">
+  <title>oportunities app icon (light) — 180×180 (iOS touch icon)</title>
+  <defs>
+    <clipPath id="squircle180">
+      <rect x="0" y="0" width="180" height="180" rx="40" ry="40"/>
+    </clipPath>
+    <style>
+      .icon-text {
+        font-family: "Geist", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 600;
+        font-size: 98px;
+        letter-spacing: -0.04em;
+        fill: #0F0D0B;
+      }
+      .icon-dot { fill: #E89252; }
+    </style>
+  </defs>
+  <g clip-path="url(#squircle180)">
+    <rect x="0" y="0" width="180" height="180" fill="#FDF8F3"/>
+    <text x="32" y="120" class="icon-text">op</text>
+    <text x="122" y="120" class="icon-text icon-dot">.</text>
+  </g>
+</svg>

--- a/packages/brand-oportunities/assets/icons/app-icon-spec.svg
+++ b/packages/brand-oportunities/assets/icons/app-icon-spec.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 1200" role="img" aria-label="oportunities app icon specification">
+  <title>oportunities app icon — spec / annotation</title>
+  <defs>
+    <clipPath id="squircleSpec">
+      <rect x="200" y="100" width="1024" height="1024" rx="229" ry="229"/>
+    </clipPath>
+    <style>
+      .icon-text {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 600;
+        font-size: 560px;
+        letter-spacing: -0.04em;
+        fill: #0F0D0B;
+      }
+      .icon-dot { fill: #E89252; }
+      .safe-zone {
+        fill: none;
+        stroke: #6B4FA0;
+        stroke-width: 4;
+        stroke-dasharray: 12 8;
+      }
+      .corner-radius {
+        fill: none;
+        stroke: #E89252;
+        stroke-width: 3;
+      }
+      .anno {
+        font-family: "Geist Mono", ui-monospace, monospace;
+        font-size: 24px;
+        fill: #6B4FA0;
+      }
+      .anno-title {
+        font-family: "Geist", sans-serif;
+        font-weight: 600;
+        font-size: 32px;
+        fill: #0F0D0B;
+      }
+      .dim {
+        stroke: #6B4FA0;
+        stroke-width: 1.5;
+      }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1400" height="1200" fill="#FDF8F3"/>
+
+  <!-- Icon -->
+  <g clip-path="url(#squircleSpec)">
+    <rect x="200" y="100" width="1024" height="1024" fill="#FDF8F3"/>
+    <text x="380" y="780" class="icon-text">op</text>
+    <text x="900" y="780" class="icon-text icon-dot">.</text>
+  </g>
+
+  <!-- Squircle outline (visible) -->
+  <rect x="200" y="100" width="1024" height="1024" rx="229" ry="229" fill="none" stroke="#0F0D0B" stroke-width="2"/>
+
+  <!-- Safe zone: 80% of canvas -->
+  <rect class="safe-zone" x="302" y="202" width="820" height="820" rx="184" ry="184"/>
+
+  <!-- Annotations -->
+  <text x="50" y="60" class="anno-title">oportunities app icon — spec</text>
+
+  <line class="dim" x1="200" y1="50" x2="1224" y2="50"/>
+  <text x="712" y="40" class="anno" text-anchor="middle">1024 × 1024 px canvas</text>
+
+  <line class="dim" x1="1290" y1="100" x2="1290" y2="329"/>
+  <text x="1300" y="220" class="anno">r = 229 (22.37%)</text>
+  <text x="1300" y="250" class="anno">iOS squircle</text>
+
+  <text x="320" y="1170" class="anno">Safe zone (80%) — keep glyphs inside dashed purple line</text>
+  <text x="50" y="1100" class="anno">Glyph: "op" 560 px Geist 600, tracking -0.04em</text>
+  <text x="50" y="1130" class="anno">Period: apricot #E89252 (light) / #F0A668 (dark)</text>
+</svg>

--- a/packages/brand-oportunities/assets/icons/pwa-maskable-icon-512.svg
+++ b/packages/brand-oportunities/assets/icons/pwa-maskable-icon-512.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="oportunities PWA maskable icon">
+  <title>oportunities PWA maskable icon — 512×512 (80% safe-zone)</title>
+  <defs>
+    <style>
+      .icon-text {
+        font-family: "Geist", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 600;
+        font-size: 220px;
+        letter-spacing: -0.04em;
+        fill: #0F0D0B;
+      }
+      .icon-dot { fill: #E89252; }
+    </style>
+  </defs>
+  <!-- Full-bleed background — required for maskable -->
+  <rect x="0" y="0" width="512" height="512" fill="#FDF8F3"/>
+  <!-- Safe-zone is the central 80% (51px padding on each side). Glyphs sized to fit. -->
+  <text x="120" y="320" class="icon-text">op</text>
+  <text x="320" y="320" class="icon-text icon-dot">.</text>
+</svg>

--- a/packages/brand-oportunities/assets/logo/wordmark-default.svg
+++ b/packages/brand-oportunities/assets/logo/wordmark-default.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 120" role="img" aria-label="oportunities">
+  <title>oportunities wordmark</title>
+  <defs>
+    <style>
+      .wm-text {
+        font-family: "Geist", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 600;
+        font-size: 88px;
+        letter-spacing: -0.04em;
+        fill: #0F0D0B;
+      }
+      .wm-dot {
+        fill: #E89252;
+      }
+    </style>
+  </defs>
+  <text x="20" y="92" class="wm-text">oportunities</text>
+  <text x="20" y="92" class="wm-text wm-dot" dx="492">.</text>
+</svg>

--- a/packages/brand-oportunities/assets/logo/wordmark-monochrome.svg
+++ b/packages/brand-oportunities/assets/logo/wordmark-monochrome.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 120" role="img" aria-label="oportunities monochrome">
+  <title>oportunities monochrome wordmark (single-ink)</title>
+  <defs>
+    <style>
+      .wm-text {
+        font-family: "Geist", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 600;
+        font-size: 88px;
+        letter-spacing: -0.04em;
+        fill: currentColor;
+      }
+    </style>
+  </defs>
+  <g color="#0F0D0B">
+    <text x="20" y="92" class="wm-text">oportunities.</text>
+  </g>
+</svg>

--- a/packages/brand-oportunities/assets/logo/wordmark-on-dark.svg
+++ b/packages/brand-oportunities/assets/logo/wordmark-on-dark.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 200" role="img" aria-label="oportunities on dark background">
+  <title>oportunities wordmark on dark</title>
+  <defs>
+    <style>
+      .bg { fill: #0F0D0B; }
+      .wm-text {
+        font-family: "Geist", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 600;
+        font-size: 88px;
+        letter-spacing: -0.04em;
+        fill: #F4ECE0;
+      }
+      .wm-dot { fill: #F0A668; }
+    </style>
+  </defs>
+  <rect class="bg" x="0" y="0" width="600" height="200"/>
+  <text x="40" y="132" class="wm-text">oportunities</text>
+  <text x="40" y="132" class="wm-text wm-dot" dx="492">.</text>
+</svg>

--- a/packages/brand-oportunities/assets/logo/wordmark-on-light.svg
+++ b/packages/brand-oportunities/assets/logo/wordmark-on-light.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 200" role="img" aria-label="oportunities on light background">
+  <title>oportunities wordmark on cream</title>
+  <defs>
+    <style>
+      .bg { fill: #FDF8F3; }
+      .wm-text {
+        font-family: "Geist", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 600;
+        font-size: 88px;
+        letter-spacing: -0.04em;
+        fill: #0F0D0B;
+      }
+      .wm-dot { fill: #E89252; }
+    </style>
+  </defs>
+  <rect class="bg" x="0" y="0" width="600" height="200"/>
+  <text x="40" y="132" class="wm-text">oportunities</text>
+  <text x="40" y="132" class="wm-text wm-dot" dx="492">.</text>
+</svg>

--- a/packages/brand-oportunities/assets/logo/wordmark-spec.svg
+++ b/packages/brand-oportunities/assets/logo/wordmark-spec.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 260" role="img" aria-label="oportunities wordmark spec with clear-space rules">
+  <title>oportunities wordmark — clear-space spec (1x cap-height padding)</title>
+  <defs>
+    <style>
+      .bg { fill: #FDF8F3; }
+      .wm-text {
+        font-family: "Geist", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 600;
+        font-size: 88px;
+        letter-spacing: -0.04em;
+        fill: #0F0D0B;
+      }
+      .wm-dot { fill: #E89252; }
+      .clear-space {
+        fill: none;
+        stroke: #E89252;
+        stroke-width: 1.5;
+        stroke-dasharray: 6 4;
+      }
+      .bbox {
+        fill: none;
+        stroke: #6B4FA0;
+        stroke-width: 1;
+        stroke-dasharray: 2 2;
+      }
+      .anno {
+        font-family: "Geist Mono", "JetBrains Mono", ui-monospace, monospace;
+        font-size: 11px;
+        fill: #6B4FA0;
+      }
+      .dim-line {
+        stroke: #6B4FA0;
+        stroke-width: 1;
+      }
+    </style>
+  </defs>
+  <rect class="bg" x="0" y="0" width="800" height="260"/>
+
+  <!-- Clear space box (1x cap-height = ~64px padding) -->
+  <rect class="clear-space" x="40" y="40" width="720" height="180" rx="4"/>
+
+  <!-- Wordmark bbox -->
+  <rect class="bbox" x="104" y="104" width="592" height="64"/>
+
+  <!-- Wordmark -->
+  <text x="104" y="158" class="wm-text">oportunities</text>
+  <text x="104" y="158" class="wm-text wm-dot" dx="492">.</text>
+
+  <!-- Annotations -->
+  <line class="dim-line" x1="40" y1="20" x2="104" y2="20"/>
+  <text x="50" y="14" class="anno">1× X</text>
+  <text x="44" y="240" class="anno">Clear-space: 1× cap-height (X) on all sides — minimum</text>
+  <line class="dim-line" x1="104" y1="180" x2="696" y2="180"/>
+  <text x="380" y="195" class="anno" text-anchor="middle">wordmark bbox</text>
+</svg>

--- a/packages/brand-oportunities/assets/logo/wordmark-with-gradient.svg
+++ b/packages/brand-oportunities/assets/logo/wordmark-with-gradient.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 120" role="img" aria-label="oportunities with apricot to purple gradient">
+  <title>oportunities wordmark with signature gradient</title>
+  <defs>
+    <linearGradient id="apricotPurple" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#E89252"/>
+      <stop offset="50%" stop-color="#D87B6E"/>
+      <stop offset="100%" stop-color="#6B4FA0"/>
+    </linearGradient>
+    <style>
+      .wm-text {
+        font-family: "Geist", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 600;
+        font-size: 88px;
+        letter-spacing: -0.04em;
+        fill: url(#apricotPurple);
+      }
+      .wm-dot { fill: #E89252; }
+    </style>
+  </defs>
+  <text x="20" y="92" class="wm-text">oportunities</text>
+  <text x="20" y="92" class="wm-text wm-dot" dx="492">.</text>
+</svg>

--- a/packages/brand-oportunities/assets/social/ig-post-1080x1080.svg
+++ b/packages/brand-oportunities/assets/social/ig-post-1080x1080.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1080" role="img" aria-label="oportunities Instagram square post">
+  <title>oportunities — Instagram post (1080×1080)</title>
+  <defs>
+    <linearGradient id="igBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#FDF8F3"/>
+      <stop offset="100%" stop-color="#F4ECE0"/>
+    </linearGradient>
+    <style>
+      .wm {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 600;
+        font-size: 60px;
+        letter-spacing: -0.04em;
+        fill: #0F0D0B;
+      }
+      .wm-dot { fill: #E89252; }
+      .headline {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 600;
+        font-size: 100px;
+        letter-spacing: -0.03em;
+        fill: #0F0D0B;
+      }
+      .sub {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 400;
+        font-size: 32px;
+        fill: #4A453F;
+      }
+    </style>
+  </defs>
+  <rect width="1080" height="1080" fill="url(#igBg)"/>
+  <!-- Wordmark -->
+  <text x="80" y="120" class="wm">oportunities</text>
+  <text x="80" y="120" class="wm wm-dot" dx="338">.</text>
+  <!-- Headline -->
+  <text x="80" y="500" class="headline">{Big idea</text>
+  <text x="80" y="620" class="headline">in two lines.}</text>
+  <!-- Sub -->
+  <text x="80" y="720" class="sub">{Short supporting line.}</text>
+  <!-- Apricot accent -->
+  <circle cx="960" cy="980" r="40" fill="#E89252"/>
+</svg>

--- a/packages/brand-oportunities/assets/social/ig-story-1080x1920.svg
+++ b/packages/brand-oportunities/assets/social/ig-story-1080x1920.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1920" role="img" aria-label="oportunities Instagram story">
+  <title>oportunities — Instagram story (1080×1920)</title>
+  <defs>
+    <linearGradient id="storyBg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#FDF8F3"/>
+      <stop offset="100%" stop-color="#F4ECE0"/>
+    </linearGradient>
+    <style>
+      .wm {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 600;
+        font-size: 64px;
+        letter-spacing: -0.04em;
+        fill: #0F0D0B;
+      }
+      .wm-dot { fill: #E89252; }
+      .headline {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 600;
+        font-size: 110px;
+        letter-spacing: -0.03em;
+        fill: #0F0D0B;
+      }
+      .sub {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 400;
+        font-size: 36px;
+        fill: #4A453F;
+      }
+    </style>
+  </defs>
+  <rect width="1080" height="1920" fill="url(#storyBg)"/>
+  <!-- Wordmark top -->
+  <text x="80" y="200" class="wm">oportunities</text>
+  <text x="80" y="200" class="wm wm-dot" dx="358">.</text>
+  <!-- Headline (vertical center) -->
+  <text x="80" y="900" class="headline">{Headline</text>
+  <text x="80" y="1030" class="headline">on multiple</text>
+  <text x="80" y="1160" class="headline">lines.}</text>
+  <!-- Sub -->
+  <text x="80" y="1280" class="sub">{Supporting sentence.}</text>
+  <!-- Footer accent -->
+  <circle cx="540" cy="1780" r="36" fill="#E89252"/>
+  <text x="540" y="1880" text-anchor="middle" class="sub">swipe up</text>
+</svg>

--- a/packages/brand-oportunities/assets/social/linkedin-cover-1584x396.svg
+++ b/packages/brand-oportunities/assets/social/linkedin-cover-1584x396.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1584 396" role="img" aria-label="oportunities LinkedIn cover">
+  <title>oportunities — LinkedIn company cover (1584×396)</title>
+  <defs>
+    <linearGradient id="liBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#FDF8F3"/>
+      <stop offset="100%" stop-color="#F4ECE0"/>
+    </linearGradient>
+    <linearGradient id="liGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#E89252"/>
+      <stop offset="100%" stop-color="#6B4FA0"/>
+    </linearGradient>
+    <style>
+      .wm {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 600;
+        font-size: 96px;
+        letter-spacing: -0.04em;
+        fill: #0F0D0B;
+      }
+      .wm-dot { fill: #E89252; }
+      .tag {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 400;
+        font-size: 28px;
+        letter-spacing: -0.01em;
+        fill: #4A453F;
+      }
+    </style>
+  </defs>
+  <rect width="1584" height="396" fill="url(#liBg)"/>
+  <!-- Decorative gradient bar -->
+  <rect x="0" y="0" width="1584" height="6" fill="url(#liGradient)"/>
+  <!-- Wordmark -->
+  <text x="120" y="200" class="wm">oportunities</text>
+  <text x="120" y="200" class="wm wm-dot" dx="540">.</text>
+  <!-- Tagline -->
+  <text x="120" y="260" class="tag">Creator-intent intelligence for the next billion brand-creator collaborations.</text>
+</svg>

--- a/packages/brand-oportunities/assets/social/linkedin-post-1200x627.svg
+++ b/packages/brand-oportunities/assets/social/linkedin-post-1200x627.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 627" role="img" aria-label="oportunities LinkedIn post template">
+  <title>oportunities — LinkedIn post template (1200×627)</title>
+  <defs>
+    <linearGradient id="lipBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#FDF8F3"/>
+      <stop offset="100%" stop-color="#F4ECE0"/>
+    </linearGradient>
+    <style>
+      .wm {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 600;
+        font-size: 64px;
+        letter-spacing: -0.04em;
+        fill: #0F0D0B;
+      }
+      .wm-dot { fill: #E89252; }
+      .headline {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 600;
+        font-size: 72px;
+        letter-spacing: -0.03em;
+        fill: #0F0D0B;
+      }
+      .sub {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 400;
+        font-size: 26px;
+        fill: #4A453F;
+      }
+    </style>
+  </defs>
+  <rect width="1200" height="627" fill="url(#lipBg)"/>
+  <!-- Wordmark top-left -->
+  <text x="80" y="100" class="wm">oportunities</text>
+  <text x="80" y="100" class="wm wm-dot" dx="360">.</text>
+  <!-- Main headline -->
+  <text x="80" y="320" class="headline">{Your headline</text>
+  <text x="80" y="410" class="headline">here.}</text>
+  <!-- Subhead -->
+  <text x="80" y="490" class="sub">{Supporting line — replace with one-sentence pitch.}</text>
+  <!-- Apricot accent dot -->
+  <circle cx="1080" cy="540" r="32" fill="#E89252"/>
+</svg>

--- a/packages/brand-oportunities/assets/social/og-image-1200x630.svg
+++ b/packages/brand-oportunities/assets/social/og-image-1200x630.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="oportunities open graph default image">
+  <title>oportunities — Open Graph default (1200×630)</title>
+  <defs>
+    <linearGradient id="ogBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#FDF8F3"/>
+      <stop offset="100%" stop-color="#F4ECE0"/>
+    </linearGradient>
+    <style>
+      .wm {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 600;
+        font-size: 120px;
+        letter-spacing: -0.04em;
+        fill: #0F0D0B;
+      }
+      .wm-dot { fill: #E89252; }
+      .tag {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 400;
+        font-size: 32px;
+        fill: #4A453F;
+      }
+    </style>
+  </defs>
+  <rect width="1200" height="630" fill="url(#ogBg)"/>
+  <text x="80" y="340" class="wm">oportunities</text>
+  <text x="80" y="340" class="wm wm-dot" dx="676">.</text>
+  <text x="80" y="410" class="tag">Creator-intent intelligence platform.</text>
+  <circle cx="1080" cy="540" r="32" fill="#E89252"/>
+</svg>

--- a/packages/brand-oportunities/assets/social/x-banner-1500x500.svg
+++ b/packages/brand-oportunities/assets/social/x-banner-1500x500.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1500 500" role="img" aria-label="oportunities X banner">
+  <title>oportunities — X / Twitter banner (1500×500)</title>
+  <defs>
+    <linearGradient id="xBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#FDF8F3"/>
+      <stop offset="100%" stop-color="#F4ECE0"/>
+    </linearGradient>
+    <linearGradient id="xAccent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#E89252"/>
+      <stop offset="100%" stop-color="#6B4FA0"/>
+    </linearGradient>
+    <style>
+      .wm {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 600;
+        font-size: 96px;
+        letter-spacing: -0.04em;
+        fill: #0F0D0B;
+      }
+      .wm-dot { fill: #E89252; }
+      .tag {
+        font-family: "Geist", "Inter", sans-serif;
+        font-weight: 400;
+        font-size: 28px;
+        fill: #4A453F;
+      }
+    </style>
+  </defs>
+  <rect width="1500" height="500" fill="url(#xBg)"/>
+  <rect x="0" y="494" width="1500" height="6" fill="url(#xAccent)"/>
+  <!-- Wordmark center-left -->
+  <text x="120" y="260" class="wm">oportunities</text>
+  <text x="120" y="260" class="wm wm-dot" dx="540">.</text>
+  <text x="120" y="320" class="tag">Creator-intent intelligence platform.</text>
+</svg>

--- a/packages/brand-oportunities/index.js
+++ b/packages/brand-oportunities/index.js
@@ -1,0 +1,70 @@
+/**
+ * @amplify-ai/brand-oportunities
+ * Asset path exports — resolve from package root.
+ */
+
+export const wordmark = {
+  default: 'assets/logo/wordmark-default.svg',
+  onLight: 'assets/logo/wordmark-on-light.svg',
+  onDark: 'assets/logo/wordmark-on-dark.svg',
+  monochrome: 'assets/logo/wordmark-monochrome.svg',
+  withGradient: 'assets/logo/wordmark-with-gradient.svg',
+  spec: 'assets/logo/wordmark-spec.svg',
+};
+
+export const appIcon = {
+  light1024: 'assets/icons/app-icon-light-1024.svg',
+  light180: 'assets/icons/app-icon-light-180.svg',
+  dark1024: 'assets/icons/app-icon-dark-1024.svg',
+  dark180: 'assets/icons/app-icon-dark-180.svg',
+  spec: 'assets/icons/app-icon-spec.svg',
+  pwaMaskable512: 'assets/icons/pwa-maskable-icon-512.svg',
+};
+
+export const favicon = {
+  light: 'assets/favicons/favicon-light.svg',
+  dark: 'assets/favicons/favicon-dark.svg',
+  size16: 'assets/favicons/favicon-16.png',
+  size32: 'assets/favicons/favicon-32.png',
+  size180: 'assets/favicons/favicon-180.png',
+  safariPinnedTab: 'assets/favicons/safari-pinned-tab.svg',
+  webmanifest: 'assets/favicons/site.webmanifest',
+};
+
+export const social = {
+  linkedinCover: 'assets/social/linkedin-cover-1584x396.svg',
+  linkedinPost: 'assets/social/linkedin-post-1200x627.svg',
+  igPost: 'assets/social/ig-post-1080x1080.svg',
+  igStory: 'assets/social/ig-story-1080x1920.svg',
+  xBanner: 'assets/social/x-banner-1500x500.svg',
+  ogImage: 'assets/social/og-image-1200x630.svg',
+};
+
+export const businessCard = {
+  front: 'assets/business-cards/business-card-front-89x54.svg',
+  back: 'assets/business-cards/business-card-back-89x54.svg',
+};
+
+export const emailSignature = {
+  full: 'assets/email-signature/email-signature.html',
+  minimal: 'assets/email-signature/email-signature-minimal.html',
+};
+
+export const brandColors = {
+  apricot: '#E89252',
+  apricotBright: '#F0A668',
+  cream: '#FDF8F3',
+  creamLight: '#F4ECE0',
+  ink: '#0F0D0B',
+  purple: '#6B4FA0',
+};
+
+export default {
+  wordmark,
+  appIcon,
+  favicon,
+  social,
+  businessCard,
+  emailSignature,
+  brandColors,
+};

--- a/packages/brand-oportunities/package.json
+++ b/packages/brand-oportunities/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@amplify-ai/brand-oportunities",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Oportunities brand assets — wordmark SVGs, app icons, favicons, social templates, business cards, email signature",
+  "main": "index.js",
+  "files": ["assets/", "README.md", "BRAND-DECISIONS.md", "index.js"],
+  "scripts": {
+    "validate": "node validate.js"
+  }
+}

--- a/packages/brand-oportunities/validate.js
+++ b/packages/brand-oportunities/validate.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Validate all assets in this package.
+ * - SVGs: must start with <?xml or <svg and contain valid root tag close
+ * - HTML signatures: must contain inline style attributes and no <script> tags
+ * - JSON manifest: must parse as JSON
+ *
+ * Exits non-zero if any asset fails. Intended for CI.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, extname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const ROOT = join(__dirname, 'assets');
+
+const errors = [];
+let total = 0;
+
+function walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) {
+      walk(p);
+    } else {
+      validateOne(p);
+    }
+  }
+}
+
+function validateOne(p) {
+  total += 1;
+  const rel = relative(__dirname, p);
+  const ext = extname(p);
+  const content = readFileSync(p, 'utf8');
+
+  if (ext === '.svg' || ext === '.png') {
+    // .png files in this package are SVG sources by spec — validate as SVG
+    if (!content.includes('<svg')) {
+      errors.push(`[${rel}] missing <svg root`);
+    }
+    if (!content.includes('</svg>')) {
+      errors.push(`[${rel}] missing </svg> close`);
+    }
+  } else if (ext === '.html') {
+    if (/<script/i.test(content)) {
+      errors.push(`[${rel}] contains <script> — email signatures must be JS-free`);
+    }
+    if (/<link[^>]+stylesheet/i.test(content)) {
+      errors.push(`[${rel}] external stylesheet — email signatures must be inline-CSS only`);
+    }
+    if (!/style=/.test(content)) {
+      errors.push(`[${rel}] no inline style attribute found`);
+    }
+  } else if (ext === '.webmanifest' || ext === '.json') {
+    try {
+      JSON.parse(content);
+    } catch (e) {
+      errors.push(`[${rel}] invalid JSON: ${e.message}`);
+    }
+  }
+}
+
+walk(ROOT);
+
+if (errors.length) {
+  console.error(`\n${errors.length} asset(s) failed validation:\n`);
+  for (const e of errors) console.error('  - ' + e);
+  process.exit(1);
+}
+
+console.log(`OK — ${total} asset(s) validated successfully.`);

--- a/packages/storybook/.storybook/main.ts
+++ b/packages/storybook/.storybook/main.ts
@@ -2,6 +2,7 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: [
+    '../stories/**/*.mdx',
     '../stories/**/*.stories.@(ts|tsx)',
     '../../ui/src/components/**/*.stories.@(ts|tsx)',
   ],

--- a/packages/storybook/.storybook/preview.ts
+++ b/packages/storybook/.storybook/preview.ts
@@ -1,6 +1,89 @@
 import type { Preview } from '@storybook/react';
 
+/**
+ * Theme switcher.
+ *
+ * Each entry maps a theme id to the published CSS module of its
+ * @amplify-ai/tokens-* package. The CSS is loaded lazily via a
+ * <link rel="stylesheet"> tag pointing at the package's exported
+ * /css entry — so Vite does NOT need to resolve it at build time.
+ *
+ * If a token package isn't installed/published yet, the <link> 404s
+ * silently and Storybook keeps rendering (no crash). When the package
+ * publishes, the theme starts working with no preview.ts changes.
+ */
+const THEMES = {
+  brand:        { label: 'Brand',        href: '/_themes/brand.css' },
+  atmosphere:   { label: 'Atmosphere',   href: '/_themes/atmosphere.css' },
+  creator:      { label: 'Creator',      href: '/_themes/creator.css' },
+  studio:       { label: 'Studio',       href: '/_themes/studio.css' },
+  marketing:    { label: 'Marketing',    href: '/_themes/marketing.css' },
+  oportunities: { label: 'Oportunities', href: '/_themes/oportunities.css' },
+} as const;
+
+type ThemeId = keyof typeof THEMES;
+
+const linked = new Set<ThemeId>();
+function ensureThemeLink(id: ThemeId) {
+  if (linked.has(id) || typeof document === 'undefined') return;
+  linked.add(id);
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = THEMES[id].href;
+  link.dataset.theme = id;
+  link.onerror = () => {
+    // Token package not yet built/published — keep going.
+    link.remove();
+  };
+  document.head.appendChild(link);
+}
+
+function applyTheme(id: ThemeId, mode: 'light' | 'dark') {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  root.setAttribute('data-theme', id);
+  root.setAttribute('data-mode', mode);
+  root.classList.toggle('dark', mode === 'dark');
+  ensureThemeLink(id);
+}
+
 const preview: Preview = {
+  globalTypes: {
+    theme: {
+      name: 'Theme',
+      description: 'Active product theme (loads the matching tokens-* CSS)',
+      defaultValue: 'brand',
+      toolbar: {
+        icon: 'paintbrush',
+        items: (Object.keys(THEMES) as ThemeId[]).map((id) => ({
+          value: id,
+          title: THEMES[id].label,
+        })),
+        dynamicTitle: true,
+      },
+    },
+    mode: {
+      name: 'Mode',
+      description: 'Light / dark mode',
+      defaultValue: 'light',
+      toolbar: {
+        icon: 'circlehollow',
+        items: [
+          { value: 'light', title: 'Light' },
+          { value: 'dark', title: 'Dark' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  decorators: [
+    (Story, context) => {
+      const id = (context.globals.theme as ThemeId) ?? 'brand';
+      const mode = (context.globals.mode as 'light' | 'dark') ?? 'light';
+      applyTheme(id, mode);
+      return Story(context);
+    },
+  ],
   parameters: {
     layout: 'centered',
     backgrounds: {
@@ -9,12 +92,23 @@ const preview: Preview = {
         { name: 'light', value: '#ffffff' },
         { name: 'dark', value: '#0a0a0a' },
         { name: 'brand', value: '#f5f3ff' },
+        { name: 'oportunities-cream', value: '#FDF8F3' },
+        { name: 'oportunities-ink', value: '#0F0D0B' },
       ],
     },
     controls: {
       matchers: {
         color: /(background|color)$/i,
         date: /Date$/i,
+      },
+    },
+    options: {
+      storySort: {
+        order: [
+          'Oportunities',
+          ['Brand', 'Logo', 'Color', 'Typography', 'Components', 'Voice', 'AppIcon', 'Favicon'],
+          'Components',
+        ],
       },
     },
   },

--- a/packages/storybook/public/_themes/oportunities.css
+++ b/packages/storybook/public/_themes/oportunities.css
@@ -1,0 +1,96 @@
+/* ──────────────────────────────────────────────────────────────────
+ * Oportunities theme — Storybook stub.
+ *
+ * Mirrors the CSS variables that @amplify-ai/tokens-oportunities/css
+ * publishes from tokens/theme-light.json + tokens/theme-dark.json.
+ *
+ * This stub exists so the Storybook theme switcher renders the
+ * Oportunities surface even before tokens-oportunities is built.
+ * When the package is built, you can swap this file for an
+ * `@import` of the real dist artifact.
+ * ────────────────────────────────────────────────────────────── */
+
+:root[data-theme='oportunities'] {
+  /* color — light (default) */
+  --color-bg: #FDF8F3;
+  --color-bg-elev: #FFFFFF;
+  --color-bg-soft: #F8F1E8;
+
+  --color-accent: #E68F47;
+  --color-accent-hover: #D67A35;
+  --color-accent-soft: #FFE9D2;
+
+  --color-ai-purple: #7B5BFF;
+  --color-ai-soft: #EFEAFF;
+
+  --color-text-primary: #1C1611;
+  --color-text-secondary: #5C5249;
+  --color-text-tertiary: #8A7F73;
+
+  --color-border: #EFE4D4;
+  --color-border-soft: #F5ECDE;
+
+  /* effort palette */
+  --color-effort-organic: #5A8E4F;
+  --color-effort-sample: #5C82B0;
+  --color-effort-sponsor: #E68F47;
+  --color-effort-paid: #968B7E;
+
+  /* status */
+  --color-status-success: #2F8A4F;
+  --color-status-warning: #C6892C;
+  --color-status-danger: #B33A3A;
+  --color-status-info: #3B6EB5;
+
+  /* typography */
+  --font-display: 'Geist', 'Inter Tight', sans-serif;
+  --font-body: 'Inter', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+
+  --letter-spacing-tight: -0.04em;
+  --weight-display: 600;
+  --weight-body-default: 500;
+
+  /* gradient */
+  --gradient-ai: linear-gradient(135deg, #E68F47 0%, #7B5BFF 100%);
+  --gradient-ai-sweep: linear-gradient(90deg, #E68F47 0%, #7B5BFF 50%, #E68F47 100%);
+}
+
+:root[data-theme='oportunities'][data-mode='dark'] {
+  --color-bg: #0F0D0B;
+  --color-bg-elev: #1A1714;
+  --color-bg-soft: #25201C;
+
+  --color-accent: #F0A668;
+  --color-accent-hover: #FFB47A;
+  --color-accent-soft: rgba(240, 166, 104, 0.12);
+
+  --color-ai-purple: #9B82FF;
+  --color-ai-soft: rgba(155, 130, 255, 0.14);
+
+  --color-text-primary: #F4ECE0;
+  --color-text-secondary: #A89E92;
+  --color-text-tertiary: #6A6258;
+
+  --color-border: #2D2723;
+  --color-border-soft: #383028;
+
+  --color-effort-organic: #7CB070;
+  --color-effort-sample: #7FA4D2;
+  --color-effort-sponsor: #F0A668;
+  --color-effort-paid: #B5AB9D;
+
+  --color-status-success: #52AC71;
+  --color-status-warning: #E0A84A;
+  --color-status-danger: #D5605E;
+  --color-status-info: #5F8EC8;
+}
+
+/* Optional: paint the Storybook canvas to match the Oportunities surface */
+:root[data-theme='oportunities'] body,
+:root[data-theme='oportunities'] .docs-story,
+:root[data-theme='oportunities'] .sb-show-main {
+  background: var(--color-bg);
+  color: var(--color-text-primary);
+  font-family: var(--font-body);
+}

--- a/packages/storybook/stories/oportunities/AppIcon.mdx
+++ b/packages/storybook/stories/oportunities/AppIcon.mdx
@@ -1,0 +1,143 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Oportunities/AppIcon" />
+
+# Oportunities — App Icon
+
+The home-screen presence. An apricot dot on cream (light) or warm-ink (dark). The dot
+references the wordmark's terminal period — same color, same role, same idea: _"this is
+oportunities."_
+
+> The mark is intentionally simple. At 32px it reads as a dot. At 1024px it reads as a
+> mark. Either way: apricot on a warm surface.
+
+---
+
+## Live — Light Mode
+
+<div style={{ display: 'flex', gap: 24, alignItems: 'flex-end', padding: 32, background: '#F5ECDE', borderRadius: 8 }}>
+  {[16, 32, 48, 64, 128, 256].map((size) => (
+    <div key={size} style={{ textAlign: 'center' }}>
+      <div style={{ width: size, height: size, background: '#FDF8F3', borderRadius: size * 0.22, display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid rgba(0,0,0,0.04)', boxShadow: size >= 64 ? '0 8px 24px rgba(28,22,17,0.08)' : 'none' }}>
+        <div style={{ width: size * 0.35, height: size * 0.35, borderRadius: '50%', background: '#E68F47' }} />
+      </div>
+      <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, color: '#8A7F73', marginTop: 8 }}>{size}px</div>
+    </div>
+  ))}
+</div>
+
+## Live — Dark Mode
+
+<div style={{ display: 'flex', gap: 24, alignItems: 'flex-end', padding: 32, background: '#F5ECDE', borderRadius: 8 }}>
+  {[16, 32, 48, 64, 128, 256].map((size) => (
+    <div key={size} style={{ textAlign: 'center' }}>
+      <div style={{ width: size, height: size, background: '#0F0D0B', borderRadius: size * 0.22, display: 'flex', alignItems: 'center', justifyContent: 'center', boxShadow: size >= 64 ? '0 8px 24px rgba(0,0,0,0.4)' : 'none' }}>
+        <div style={{ width: size * 0.35, height: size * 0.35, borderRadius: '50%', background: '#F0A668' }} />
+      </div>
+      <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, color: '#8A7F73', marginTop: 8 }}>{size}px</div>
+    </div>
+  ))}
+</div>
+
+---
+
+## Platform Specs
+
+### iOS
+
+| Asset | Size | Format | Notes |
+|---|---|---|---|
+| App icon (App Store) | 1024×1024 | PNG (no alpha) | Light variant; iOS adds rounding |
+| Spotlight / Settings | 80×80, 120×120 | PNG | Generated from 1024 |
+| Notification | 40×40, 60×60 | PNG | Generated from 1024 |
+| iOS does NOT use a dark icon | — | — | Apple handles dark via dynamic island only |
+
+Source: `app-icon-light-1024.svg` → exported as PNG (no transparency).
+
+### Android
+
+| Asset | Size | Format | Notes |
+|---|---|---|---|
+| Adaptive foreground | 432×432 | PNG (transparent) | Dot only, on transparent |
+| Adaptive background | 432×432 | PNG / color | `#FDF8F3` (light) or `#0F0D0B` (dark) |
+| Legacy launcher | 192×192 | PNG | Composited fallback |
+| Monochrome (Android 13+) | 432×432 | PNG (monochrome) | For Material You themed icons |
+
+Adaptive icon ensures the apricot dot is always visible regardless of launcher mask.
+
+### PWA / Web
+
+| Asset | Size | Format | Manifest key |
+|---|---|---|---|
+| Maskable | 512×512 | PNG | `purpose: "maskable"` |
+| Any | 192×192, 512×512 | PNG | `purpose: "any"` |
+| Apple touch icon | 180×180 | PNG | `<link rel="apple-touch-icon">` |
+| Theme color | — | `#FDF8F3` (light) / `#0F0D0B` (dark) | `<meta name="theme-color">` |
+
+Maskable safe zone: the apricot dot must stay within the inner 80% radius circle.
+
+### macOS
+
+| Asset | Size | Format | Notes |
+|---|---|---|---|
+| App icon (.icns) | 1024×1024 (master) | ICNS with all sizes | macOS rounds & shadows automatically |
+| Dock active state | — | uses light variant | macOS handles dark mode globally |
+
+---
+
+## Construction
+
+The dot is geometric, not optical:
+
+- **Background**: rounded square, radius = `size * 0.22` (matches iOS visual radius)
+- **Dot**: perfect circle, diameter = `size * 0.35`
+- **Position**: dead center, horizontally + vertically
+- **No shadow on the dot itself** — the icon container provides depth at large sizes
+
+```css
+.app-icon {
+  width: var(--size);
+  height: var(--size);
+  background: var(--bg);          /* cream or warm-ink */
+  border-radius: calc(var(--size) * 0.22);
+  display: grid;
+  place-items: center;
+}
+.app-icon::after {
+  content: '';
+  width: calc(var(--size) * 0.35);
+  height: calc(var(--size) * 0.35);
+  border-radius: 50%;
+  background: var(--apricot);     /* #E68F47 light, #F0A668 dark */
+}
+```
+
+---
+
+## React Usage
+
+```tsx
+import { AppIconOportunities } from '@amplify-ai/ui';
+
+<AppIconOportunities size={180} mode="light" platform="ios" />
+<AppIconOportunities size={512} mode="dark" platform="pwa" maskable />
+<AppIconOportunities size={64} mode="light" platform="android" adaptive />
+```
+
+Static asset paths (from `@amplify-ai/brand-oportunities`):
+
+```js
+import { appIcon } from '@amplify-ai/brand-oportunities';
+// appIcon.light1024 | light180 | dark1024 | dark180 | spec | pwaMaskable512
+```
+
+---
+
+## Do / Don't
+
+- **Do** export PNGs at exact pixel sizes (no auto-scaling at runtime).
+- **Do** ship a monochrome variant for Android themed icons.
+- **Do** use the cream background for light, warm-ink for dark — never pure white or pure black.
+- **Don't** add a wordmark inside the icon — the dot is the mark at this scale.
+- **Don't** apply gradients to the dot at icon sizes — the gradient is a wordmark-only treatment.
+- **Don't** add letters ("o", "O.") — too small to read, dilutes the mark.

--- a/packages/storybook/stories/oportunities/AppIconOportunities.stories.tsx
+++ b/packages/storybook/stories/oportunities/AppIconOportunities.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { AppIconOportunities } from '@amplify-ai/ui';
+
+const meta = {
+  title: 'Oportunities/AppIconOportunities',
+  component: AppIconOportunities,
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: { type: 'number', min: 24, max: 512, step: 8 } },
+    dark: { control: 'boolean' },
+  },
+  parameters: {
+    backgrounds: {
+      default: 'neutral',
+      values: [
+        { name: 'cream', value: '#FDF8F3' },
+        { name: 'ink', value: '#15110D' },
+        { name: 'neutral', value: '#E7E5E4' },
+      ],
+    },
+  },
+} satisfies Meta<typeof AppIconOportunities>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = { args: { size: 96 } };
+export const Dark: Story = { args: { size: 96, dark: true } };
+export const Small: Story = { args: { size: 40 } };
+export const Large: Story = { args: { size: 192 } };
+
+export const SizeGallery: Story = {
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 24 }}>
+      <AppIconOportunities size={32} />
+      <AppIconOportunities size={48} />
+      <AppIconOportunities size={64} />
+      <AppIconOportunities size={96} />
+      <AppIconOportunities size={128} />
+    </div>
+  ),
+};
+
+export const LightAndDark: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 24 }}>
+      <AppIconOportunities size={128} />
+      <AppIconOportunities size={128} dark />
+    </div>
+  ),
+};

--- a/packages/storybook/stories/oportunities/Brand.mdx
+++ b/packages/storybook/stories/oportunities/Brand.mdx
@@ -1,0 +1,129 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Oportunities/Brand" />
+
+# Oportunities — Brand Overview
+
+Creator-intent intelligence platform. The **Studio** direction (Geist + apricot period) is the locked
+brand expression — warm, intellectual, AI-native. Cream surfaces, apricot accents, AI-purple gradient,
+Geist wordmark with the signature `-0.04em` tracking and dot sweep.
+
+> **Voice anchor:** _"Heads up —"_  
+> Calm, observational, peer-not-vendor. Never breathless, never bro-y.
+
+---
+
+## Locked Studio Direction (Summary)
+
+| Pillar | Decision |
+|---|---|
+| Wordmark | Single-P **`oportunities.`** — Geist 600, `-0.04em` tracking, apricot dot |
+| Color period | **Apricot** — `#E68F47` (light) / `#F0A668` (dark), paired with AI purple `#7B5BFF` / `#9B82FF` |
+| Type stack | **Geist** display · **Inter** body · **JetBrains Mono** data |
+| Surface | **Cream** `#FDF8F3` (light) / **Warm ink** `#0F0D0B` (dark) |
+| AI moment | Apricot → purple gradient sweep (135°), 1.2s ease |
+| Voice | _"Heads up —"_ register; observational, peer, calm |
+
+---
+
+## Wordmark (Live)
+
+<div style={{ padding: '32px', background: '#FDF8F3', borderRadius: 8, border: '1px solid #EFE4D4' }}>
+  <object
+    data="/brand-oportunities/wordmark-with-gradient.svg"
+    type="image/svg+xml"
+    style={{ width: '320px', height: 'auto', display: 'block', margin: '0 auto' }}
+    aria-label="oportunities wordmark"
+  />
+</div>
+
+See **Logo** for clear-space rules, variants, and do/don't.
+
+---
+
+## Palette (Live Swatches)
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))', gap: 12 }}>
+  {[
+    { name: 'Apricot', hex: '#E68F47', text: '#fff' },
+    { name: 'Apricot Bright', hex: '#F0A668', text: '#1C1611' },
+    { name: 'AI Purple', hex: '#7B5BFF', text: '#fff' },
+    { name: 'Cream', hex: '#FDF8F3', text: '#1C1611' },
+    { name: 'Cream Light', hex: '#F4ECE0', text: '#1C1611' },
+    { name: 'Warm Ink', hex: '#0F0D0B', text: '#F4ECE0' },
+    { name: 'Organic', hex: '#5A8E4F', text: '#fff' },
+    { name: 'Sample', hex: '#5C82B0', text: '#fff' },
+  ].map((c) => (
+    <div key={c.hex} style={{ background: c.hex, color: c.text, padding: '16px 12px', borderRadius: 8, fontFamily: 'Geist, Inter, sans-serif', fontSize: 13 }}>
+      <div style={{ fontWeight: 600 }}>{c.name}</div>
+      <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, opacity: 0.85, marginTop: 4 }}>{c.hex}</div>
+    </div>
+  ))}
+</div>
+
+See **Color** for the full system, effort palette, and contrast.
+
+---
+
+## Type Stack (Live Specimens)
+
+<div style={{ display: 'grid', gap: 24, padding: 24, background: '#FDF8F3', borderRadius: 8 }}>
+  <div>
+    <div style={{ fontSize: 11, color: '#8A7F73', letterSpacing: '0.08em', textTransform: 'uppercase', marginBottom: 4 }}>Geist 600 · -0.04em</div>
+    <div style={{ fontFamily: 'Geist, Inter, sans-serif', fontSize: 48, fontWeight: 600, letterSpacing: '-0.04em', color: '#1C1611' }}>oportunities.</div>
+  </div>
+  <div>
+    <div style={{ fontSize: 11, color: '#8A7F73', letterSpacing: '0.08em', textTransform: 'uppercase', marginBottom: 4 }}>Inter 500 · body</div>
+    <div style={{ fontFamily: 'Inter, system-ui, sans-serif', fontSize: 16, fontWeight: 500, color: '#1C1611', lineHeight: 1.5 }}>Heads up — three creators just signaled interest in your category. None require outreach.</div>
+  </div>
+  <div>
+    <div style={{ fontSize: 11, color: '#8A7F73', letterSpacing: '0.08em', textTransform: 'uppercase', marginBottom: 4 }}>JetBrains Mono · data</div>
+    <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 14, color: '#1C1611' }}>3.42 ER · ₹1.2L CPM · 14 day window</div>
+  </div>
+</div>
+
+See **Typography** for the full ladder.
+
+---
+
+## Voice Register — 8 Product Moments
+
+| # | Moment | Pick |
+|---|---|---|
+| 1 | First signal arrives | _"Heads up — Aanya just liked 3 of your reels."_ |
+| 2 | Empty state | _"No signals yet. The feed will fill as creators engage."_ |
+| 3 | High-intent surface | _"This one feels real. Aanya saved your post on Tuesday and again today."_ |
+| 4 | AI suggestion | _"Want to test a sample drop? Three creators look ready."_ |
+| 5 | Confirmation | _"Sent. We'll let you know when Aanya replies."_ |
+| 6 | Error | _"Something's off. Retrying — give us a moment."_ |
+| 7 | Approval needed | _"Quick check — this brief mentions a competitor. Still send?"_ |
+| 8 | Win moment | _"Aanya said yes. Brief's in her inbox."_ |
+
+See **Voice** for the full register, lexicon, and microcopy library.
+
+---
+
+## Application Contexts (10)
+
+1. **Cockpit** — main intent dashboard
+2. **Mirror** — creator-side perception view (AI-rendered)
+3. **Map** — brand-side opportunity map (AI-rendered)
+4. **Feed** — chronological signal stream
+5. **Brief Studio** — composing outreach
+6. **Editor** — script + creative review
+7. **Auth / Onboarding** — first-run setup
+8. **Email** — system + brief notifications
+9. **PWA / App Icon** — home-screen presence
+10. **Marketing site** — oportunities.app landing
+
+---
+
+## Related Docs
+
+- **Logo** — wordmark variants, clear-space, do/don't
+- **Color** — palette, effort, status, contrast
+- **Typography** — Geist + Inter + JBM ladder
+- **Components** — CreatorIntentCard, BrandInterestCard, IntentFeed, SignalDot, AppIconOportunities, Wordmark
+- **Voice** — full register + lexicon
+- **AppIcon** — platform specs
+- **Favicon** — browser tab presence

--- a/packages/storybook/stories/oportunities/BrandInterestCard.stories.tsx
+++ b/packages/storybook/stories/oportunities/BrandInterestCard.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { BrandInterestCard } from '@amplify-ai/ui';
+
+const meta = {
+  title: 'Oportunities/BrandInterestCard',
+  component: BrandInterestCard,
+  tags: ['autodocs'],
+  parameters: {
+    backgrounds: {
+      default: 'cream',
+      values: [
+        { name: 'cream', value: '#FDF8F3' },
+        { name: 'ink', value: '#15110D' },
+      ],
+    },
+  },
+} satisfies Meta<typeof BrandInterestCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sampleBrand = {
+  name: 'Hush Sleep Co.',
+  category: 'Sleep tech · DTC',
+};
+
+const sampleInterest = {
+  headline: 'Wants you for spring launch',
+  message:
+    'Loved your wind-down rituals series. We have a 3-part story arc and would love your voice on it — paid + product seeded.',
+  aiFitScore: 91,
+};
+
+export const Default: Story = {
+  args: {
+    brand: sampleBrand,
+    interest: sampleInterest,
+    onReply: () => alert('Reply'),
+    onDecline: () => alert('Decline'),
+  },
+};
+
+export const WithLogo: Story = {
+  args: {
+    brand: {
+      ...sampleBrand,
+      logo: 'https://i.pravatar.cc/150?img=22',
+    },
+    interest: sampleInterest,
+    onReply: () => alert('Reply'),
+    onDecline: () => alert('Decline'),
+  },
+};
+
+export const NoAIScore: Story = {
+  args: {
+    brand: sampleBrand,
+    interest: { ...sampleInterest, aiFitScore: undefined },
+    onReply: () => alert('Reply'),
+    onDecline: () => alert('Decline'),
+  },
+};
+
+export const ReplyOnly: Story = {
+  args: {
+    brand: sampleBrand,
+    interest: sampleInterest,
+    onReply: () => alert('Reply'),
+  },
+};

--- a/packages/storybook/stories/oportunities/Color.mdx
+++ b/packages/storybook/stories/oportunities/Color.mdx
@@ -1,0 +1,137 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Oportunities/Color" />
+
+# Oportunities — Color System
+
+Warm, intellectual, AI-native. **Apricot** is the brand color, **AI purple** is its
+paired accent for AI-generated surfaces, and the **effort palette** classifies
+creator content by intent (organic / sample / sponsor / paid).
+
+All values authoritative from `@amplify-ai/tokens-oportunities` (`theme-light.json`, `theme-dark.json`).
+
+---
+
+## Brand Colors — Light
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: 12 }}>
+  {[
+    { name: 'bg',             hex: '#FDF8F3', desc: 'Cream page background' },
+    { name: 'bg-elev',        hex: '#FFFFFF', desc: 'Elevated cards / modals' },
+    { name: 'bg-soft',        hex: '#F8F1E8', desc: 'Subtle inset' },
+    { name: 'accent',         hex: '#E68F47', desc: 'Apricot — brand color' },
+    { name: 'accent-hover',   hex: '#D67A35', desc: 'Apricot on hover' },
+    { name: 'accent-soft',    hex: '#FFE9D2', desc: 'Subtle apricot tint' },
+    { name: 'ai-purple',      hex: '#7B5BFF', desc: 'AI accent — paired with apricot' },
+    { name: 'ai-soft',        hex: '#EFEAFF', desc: 'Subtle AI purple tint' },
+    { name: 'text-primary',   hex: '#1C1611', desc: 'Primary text — warm near-black' },
+    { name: 'text-secondary', hex: '#5C5249', desc: 'Secondary text' },
+    { name: 'text-tertiary',  hex: '#8A7F73', desc: 'Tertiary / muted' },
+    { name: 'border',         hex: '#EFE4D4', desc: 'Default border' },
+    { name: 'border-soft',    hex: '#F5ECDE', desc: 'Subtle divider' },
+  ].map((c) => (
+    <Swatch key={c.name} {...c} />
+  ))}
+</div>
+
+## Brand Colors — Dark
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: 12 }}>
+  {[
+    { name: 'bg',             hex: '#0F0D0B', desc: 'Deep warm-black' },
+    { name: 'bg-elev',        hex: '#1A1714', desc: 'Elevated dark' },
+    { name: 'bg-soft',        hex: '#25201C', desc: 'Subtle inset dark' },
+    { name: 'accent',         hex: '#F0A668', desc: 'Brightened apricot' },
+    { name: 'accent-hover',   hex: '#FFB47A', desc: 'Apricot on hover (brighter)' },
+    { name: 'ai-purple',      hex: '#9B82FF', desc: 'AI purple — brightened' },
+    { name: 'text-primary',   hex: '#F4ECE0', desc: 'Primary on dark' },
+    { name: 'text-secondary', hex: '#A89E92', desc: 'Secondary on dark' },
+    { name: 'text-tertiary',  hex: '#6A6258', desc: 'Tertiary on dark' },
+    { name: 'border',         hex: '#2D2723', desc: 'Default border dark' },
+    { name: 'border-soft',    hex: '#383028', desc: 'Subtle divider dark' },
+  ].map((c) => (
+    <Swatch key={c.name} {...c} dark />
+  ))}
+</div>
+
+---
+
+## Effort Palette
+
+Creator-intent classification — used in dashboards, lists, badges, the IntentFeed.
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12 }}>
+  {[
+    { name: 'organic', light: '#5A8E4F', dark: '#7CB070', desc: 'Organic — creator posted unprompted' },
+    { name: 'sample',  light: '#5C82B0', dark: '#7FA4D2', desc: 'Sample — try-before-buy' },
+    { name: 'sponsor', light: '#E68F47', dark: '#F0A668', desc: 'Sponsored — same as accent' },
+    { name: 'paid',    light: '#968B7E', dark: '#B5AB9D', desc: 'Paid placement — neutral' },
+  ].map((c) => (
+    <div key={c.name} style={{ borderRadius: 8, overflow: 'hidden', border: '1px solid #EFE4D4' }}>
+      <div style={{ background: c.light, color: '#fff', padding: 16 }}>
+        <div style={{ fontFamily: 'Inter, sans-serif', fontWeight: 600, fontSize: 14, textTransform: 'capitalize' }}>{c.name}</div>
+        <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, opacity: 0.95, marginTop: 2 }}>{c.light}</div>
+      </div>
+      <div style={{ background: c.dark, color: '#0F0D0B', padding: 16 }}>
+        <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11 }}>{c.dark} (dark)</div>
+      </div>
+      <div style={{ background: '#FDF8F3', padding: 12, fontFamily: 'Inter, sans-serif', fontSize: 12, color: '#5C5249' }}>{c.desc}</div>
+    </div>
+  ))}
+</div>
+
+---
+
+## Status Scale
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12 }}>
+  {[
+    { name: 'success', hex: '#2F8A4F' },
+    { name: 'warning', hex: '#C6892C' },
+    { name: 'danger',  hex: '#B33A3A' },
+    { name: 'info',    hex: '#3B6EB5' },
+  ].map((c) => (
+    <Swatch key={c.name} {...c} desc={`Status / ${c.name}`} />
+  ))}
+</div>
+
+---
+
+## Brand Gradient (LOCKED)
+
+`linear-gradient(135deg, #E68F47 0%, #7B5BFF 100%)` — used in the wordmark sweep,
+Mirror/Map AI surfaces, and the cockpit hero accent.
+
+<div style={{ height: 96, background: 'linear-gradient(135deg, #E68F47 0%, #7B5BFF 100%)', borderRadius: 8 }} />
+
+Sweep variant (animated): `linear-gradient(90deg, #E68F47 0%, #7B5BFF 50%, #E68F47 100%)` with
+`background-size: 200% 100%` and `background-position` animated.
+
+---
+
+## Combinations & Contrast
+
+| Foreground | Background | Ratio | WCAG |
+|---|---|---|---|
+| `#1C1611` text-primary | `#FDF8F3` bg-cream | 14.8:1 | AAA |
+| `#5C5249` text-secondary | `#FDF8F3` bg-cream | 6.9:1 | AAA |
+| `#8A7F73` text-tertiary | `#FDF8F3` bg-cream | 3.6:1 | AA Large |
+| `#FFFFFF` white | `#E68F47` accent | 2.9:1 | Fail body — use for large text only |
+| `#1C1611` text-primary | `#FFE9D2` accent-soft | 13.1:1 | AAA |
+| `#F4ECE0` text-primary | `#0F0D0B` bg-dark | 14.4:1 | AAA |
+
+**Rule:** never put white body text directly on apricot — use either large/heavy text only, or
+swap to the warm-ink text on apricot-soft for accents.
+
+---
+
+export const Swatch = ({ name, hex, desc, dark = false }) => (
+  <div style={{ borderRadius: 8, overflow: 'hidden', border: '1px solid #EFE4D4', background: '#fff' }}>
+    <div style={{ background: hex, height: 80 }} />
+    <div style={{ padding: 12, fontFamily: 'Inter, sans-serif' }}>
+      <div style={{ fontWeight: 600, fontSize: 13, color: '#1C1611' }}>{name}{dark ? ' (dark)' : ''}</div>
+      <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, color: '#5C5249', marginTop: 2 }}>{hex}</div>
+      {desc && <div style={{ fontSize: 12, color: '#8A7F73', marginTop: 4 }}>{desc}</div>}
+    </div>
+  </div>
+);

--- a/packages/storybook/stories/oportunities/Components.mdx
+++ b/packages/storybook/stories/oportunities/Components.mdx
@@ -1,0 +1,174 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Oportunities/Components" />
+
+# Oportunities — Composed Components
+
+Six product-level composed components built on top of the Canvas primitives,
+locked to the Oportunities theme. Each one is a composition of existing
+primitives (Card, Badge, Avatar, etc.) — no new structural patterns,
+just product-specific assembly + voice.
+
+> **Composition rule:** every Oportunities component reuses Canvas primitives.
+> They are NOT new building blocks — they are vertically-integrated examples
+> of brand + tone applied to existing parts.
+
+---
+
+## CreatorIntentCard
+
+Surfaces a creator's recent signals toward a brand. Used in the IntentFeed and Mirror surfaces.
+
+<div style={{ padding: 24, background: '#FDF8F3', borderRadius: 8 }}>
+  <div style={{ background: '#FFFFFF', padding: 20, borderRadius: 12, border: '1px solid #EFE4D4', maxWidth: 480, display: 'flex', gap: 16 }}>
+    <div style={{ width: 48, height: 48, borderRadius: '50%', background: 'linear-gradient(135deg, #E68F47, #7B5BFF)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#fff', fontFamily: 'Geist, sans-serif', fontWeight: 600, flexShrink: 0 }}>A</div>
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 4 }}>
+        <span style={{ fontFamily: 'Inter, sans-serif', fontWeight: 600, fontSize: 15, color: '#1C1611' }}>Aanya Mehra</span>
+        <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, color: '#8A7F73' }}>@aanyam</span>
+        <span style={{ marginLeft: 'auto', background: '#FFE9D2', color: '#D67A35', padding: '2px 8px', borderRadius: 4, fontFamily: 'JetBrains Mono, monospace', fontSize: 11, fontWeight: 600 }}>0.87</span>
+      </div>
+      <div style={{ fontFamily: 'Inter, sans-serif', fontSize: 14, color: '#5C5249', marginBottom: 12 }}>
+        Heads up — she saved your post Tuesday + replied to your story Thursday + viewed 3× today.
+      </div>
+      <div style={{ display: 'flex', gap: 6 }}>
+        <span style={{ background: '#F1F8EF', color: '#5A8E4F', padding: '2px 8px', borderRadius: 4, fontSize: 11, fontFamily: 'Inter, sans-serif' }}>organic</span>
+        <span style={{ background: '#F8F1E8', color: '#8A7F73', padding: '2px 8px', borderRadius: 4, fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }}>7d window</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+```tsx
+import { CreatorIntentCard } from '@amplify-ai/ui';
+
+<CreatorIntentCard
+  creator={{ name: 'Aanya Mehra', handle: 'aanyam', avatarUrl }}
+  signal={{ strength: 0.87, summary: 'saved your post Tuesday…' }}
+  effort="organic"
+  window="7d"
+  onOpen={() => navigate(`/creator/${creator.id}`)}
+/>
+```
+
+Composes: `Card` · `Avatar` · `Badge` · `SignalDot`
+
+---
+
+## BrandInterestCard
+
+Inverse view — a brand surfacing inside a creator's Mirror. Same shape, different perspective.
+
+<div style={{ padding: 24, background: '#FDF8F3', borderRadius: 8 }}>
+  <div style={{ background: '#FFFFFF', padding: 20, borderRadius: 12, border: '1px solid #EFE4D4', maxWidth: 480 }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 12 }}>
+      <div style={{ width: 40, height: 40, borderRadius: 8, background: '#0F0D0B', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#F0A668', fontFamily: 'Geist, sans-serif', fontWeight: 600, fontSize: 18 }}>N</div>
+      <div style={{ flex: 1 }}>
+        <div style={{ fontFamily: 'Inter, sans-serif', fontWeight: 600, fontSize: 15, color: '#1C1611' }}>Nourish & Co.</div>
+        <div style={{ fontFamily: 'Inter, sans-serif', fontSize: 12, color: '#8A7F73' }}>Plant-based snacks · interested in your audience</div>
+      </div>
+      <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 12, color: '#5A8E4F', fontWeight: 600 }}>+₹12K est.</div>
+    </div>
+    <div style={{ fontFamily: 'Inter, sans-serif', fontSize: 14, color: '#5C5249', lineHeight: 1.5 }}>
+      Heads up — Nourish has looked at your last 3 reels and wants to send a sample. Want us to draft a reply?
+    </div>
+  </div>
+</div>
+
+```tsx
+<BrandInterestCard
+  brand={{ name: 'Nourish & Co.', logoUrl, tagline: 'Plant-based snacks' }}
+  estValue="₹12K"
+  summary="Nourish has looked at your last 3 reels and wants to send a sample."
+  cta="Draft reply"
+/>
+```
+
+---
+
+## IntentFeed
+
+Chronological stream of CreatorIntentCard + BrandInterestCard, grouped by day.
+
+```tsx
+<IntentFeed
+  items={signals}
+  groupBy="day"
+  emptyState={<EmptyState title="No signals yet" body="The feed will fill as creators engage." />}
+/>
+```
+
+Composes: `CreatorIntentCard` · `BrandInterestCard` · `SignalDot` · `EmptyState` · `Skeleton`
+
+---
+
+## SignalDot
+
+Tiny status dot — colored by effort palette. Used inline in feed items, lists, KPIs.
+
+<div style={{ padding: 24, background: '#FDF8F3', borderRadius: 8, display: 'flex', gap: 32, alignItems: 'center' }}>
+  {[
+    { effort: 'organic', color: '#5A8E4F' },
+    { effort: 'sample',  color: '#5C82B0' },
+    { effort: 'sponsor', color: '#E68F47' },
+    { effort: 'paid',    color: '#968B7E' },
+  ].map((d) => (
+    <div key={d.effort} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <span style={{ width: 8, height: 8, borderRadius: '50%', background: d.color, display: 'inline-block', boxShadow: `0 0 0 4px ${d.color}22` }} />
+      <span style={{ fontFamily: 'Inter, sans-serif', fontSize: 13, color: '#1C1611', textTransform: 'capitalize' }}>{d.effort}</span>
+    </div>
+  ))}
+</div>
+
+```tsx
+<SignalDot effort="organic" pulse />
+<SignalDot effort="sponsor" size="lg" />
+```
+
+---
+
+## AppIconOportunities
+
+Native app icon — apricot dot on cream (light) or warm-ink (dark). See **AppIcon** for platform specs.
+
+<div style={{ display: 'flex', gap: 24, padding: 24, background: '#FDF8F3', borderRadius: 8, alignItems: 'flex-end' }}>
+  {[
+    { size: 32, bg: '#FDF8F3', dot: '#E68F47' },
+    { size: 64, bg: '#FDF8F3', dot: '#E68F47' },
+    { size: 128, bg: '#FDF8F3', dot: '#E68F47' },
+    { size: 64, bg: '#0F0D0B', dot: '#F0A668' },
+  ].map((i, idx) => (
+    <div key={idx} style={{ width: i.size, height: i.size, background: i.bg, borderRadius: i.size * 0.22, display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid rgba(0,0,0,0.06)' }}>
+      <div style={{ width: i.size * 0.35, height: i.size * 0.35, borderRadius: '50%', background: i.dot }} />
+    </div>
+  ))}
+</div>
+
+```tsx
+<AppIconOportunities size={64} mode="light" />
+<AppIconOportunities size={1024} mode="dark" platform="ios" />
+```
+
+---
+
+## Wordmark
+
+The brand wordmark — see **Logo** for full spec.
+
+```tsx
+<Wordmark variant="withGradient" size={48} />
+<Wordmark variant="onDark" />
+```
+
+---
+
+## Composition Matrix
+
+| Component | Built from | Used in |
+|---|---|---|
+| CreatorIntentCard | Card · Avatar · Badge · SignalDot | IntentFeed · Mirror · Cockpit |
+| BrandInterestCard | Card · Avatar · Badge · SignalDot | Mirror (creator) |
+| IntentFeed | CreatorIntentCard · BrandInterestCard · EmptyState | Cockpit (default) |
+| SignalDot | (primitive — `<span>` + tokens) | every list / feed / KPI |
+| AppIconOportunities | (primitive — SVG) | PWA · iOS · Android · macOS |
+| Wordmark | (primitive — SVG) | Nav · marketing · email · auth |

--- a/packages/storybook/stories/oportunities/CreatorIntentCard.stories.tsx
+++ b/packages/storybook/stories/oportunities/CreatorIntentCard.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CreatorIntentCard } from '@amplify-ai/ui';
+
+const meta = {
+  title: 'Oportunities/CreatorIntentCard',
+  component: CreatorIntentCard,
+  tags: ['autodocs'],
+  parameters: {
+    backgrounds: {
+      default: 'cream',
+      values: [
+        { name: 'cream', value: '#FDF8F3' },
+        { name: 'ink', value: '#15110D' },
+      ],
+    },
+  },
+} satisfies Meta<typeof CreatorIntentCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sampleCreator = {
+  name: 'Amrita Patel',
+  handle: '@amrita.notes',
+  niche: 'Slow-luxe lifestyle',
+  followers: 128_000,
+  avatarGradient: 'linear-gradient(135deg, #E68F47 0%, #7B5BFF 100%)',
+};
+
+const sampleIntent = {
+  headline:
+    'I want to partner with a sleep-tech brand on a 3-part story arc covering wind-down rituals.',
+  dateRange: 'Apr 22 – May 14',
+  vibe: 'editorial · slow-luxe · brand-led',
+  openTo: ['Story', 'Reel', 'IRL'],
+};
+
+export const Default: Story = {
+  args: {
+    creator: sampleCreator,
+    intent: sampleIntent,
+    aiFitScore: 87,
+    onUnlock: () => alert('Unlocked!'),
+  },
+};
+
+export const WithoutAIScore: Story = {
+  args: {
+    creator: sampleCreator,
+    intent: sampleIntent,
+    onUnlock: () => alert('Unlocked!'),
+  },
+};
+
+export const WithImage: Story = {
+  args: {
+    creator: {
+      ...sampleCreator,
+      avatarSrc: 'https://i.pravatar.cc/150?img=47',
+    },
+    intent: sampleIntent,
+    aiFitScore: 73,
+    onUnlock: () => alert('Unlocked!'),
+  },
+};
+
+export const MinimalIntent: Story = {
+  args: {
+    creator: sampleCreator,
+    intent: {
+      headline: 'Looking for a coffee brand to collab with this spring.',
+      dateRange: 'May',
+      vibe: 'casual · organic',
+    },
+    aiFitScore: 62,
+    onUnlock: () => alert('Unlocked!'),
+  },
+};

--- a/packages/storybook/stories/oportunities/Favicon.mdx
+++ b/packages/storybook/stories/oportunities/Favicon.mdx
@@ -1,0 +1,134 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Oportunities/Favicon" />
+
+# Oportunities — Favicon
+
+Browser-tab presence. Same apricot dot as the app icon — _at favicon scale, the dot IS the mark._
+No wordmark, no letters, no gradient: just a clean apricot circle on a warm-surface tile.
+
+---
+
+## Live — Light Theme
+
+<div style={{ display: 'flex', gap: 32, alignItems: 'flex-end', padding: 32, background: '#F5ECDE', borderRadius: 8 }}>
+  {[16, 32, 48, 180, 512].map((size) => (
+    <div key={size} style={{ textAlign: 'center' }}>
+      <div style={{ width: size, height: size, background: '#FDF8F3', borderRadius: Math.max(size * 0.18, 2), display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid rgba(0,0,0,0.06)', maxWidth: 96 }}>
+        <div style={{ width: size * 0.45, height: size * 0.45, borderRadius: '50%', background: '#E68F47', maxWidth: 44, maxHeight: 44 }} />
+      </div>
+      <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, color: '#8A7F73', marginTop: 8 }}>{size}px</div>
+    </div>
+  ))}
+</div>
+
+## Live — Dark Theme
+
+<div style={{ display: 'flex', gap: 32, alignItems: 'flex-end', padding: 32, background: '#F5ECDE', borderRadius: 8 }}>
+  {[16, 32, 48, 180, 512].map((size) => (
+    <div key={size} style={{ textAlign: 'center' }}>
+      <div style={{ width: size, height: size, background: '#0F0D0B', borderRadius: Math.max(size * 0.18, 2), display: 'flex', alignItems: 'center', justifyContent: 'center', maxWidth: 96 }}>
+        <div style={{ width: size * 0.45, height: size * 0.45, borderRadius: '50%', background: '#F0A668', maxWidth: 44, maxHeight: 44 }} />
+      </div>
+      <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, color: '#8A7F73', marginTop: 8 }}>{size}px</div>
+    </div>
+  ))}
+</div>
+
+> At 16px the favicon reads as a warm-orange dot. That's enough — recognizable, distinct,
+> and not competing with neighboring tabs.
+
+---
+
+## Browser Tab Mocks
+
+### Chrome — Light theme
+
+<div style={{ background: '#F1F3F4', padding: 12, borderRadius: 8, fontFamily: 'system-ui', maxWidth: 720 }}>
+  <div style={{ display: 'flex', gap: 4 }}>
+    <div style={{ background: '#fff', borderRadius: '8px 8px 0 0', padding: '6px 12px 6px 10px', display: 'flex', alignItems: 'center', gap: 8, fontSize: 12, color: '#202124', maxWidth: 220 }}>
+      <div style={{ width: 16, height: 16, background: '#FDF8F3', borderRadius: 3, display: 'grid', placeItems: 'center', flexShrink: 0 }}>
+        <div style={{ width: 7, height: 7, borderRadius: '50%', background: '#E68F47' }} />
+      </div>
+      <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>Cockpit · oportunities</span>
+    </div>
+    <div style={{ background: 'rgba(0,0,0,0.06)', borderRadius: '8px 8px 0 0', padding: '6px 12px', fontSize: 12, color: '#5F6368' }}>
+      Inbox · Gmail
+    </div>
+    <div style={{ background: 'rgba(0,0,0,0.06)', borderRadius: '8px 8px 0 0', padding: '6px 12px', fontSize: 12, color: '#5F6368' }}>
+      GitHub
+    </div>
+  </div>
+</div>
+
+### Chrome — Dark theme
+
+<div style={{ background: '#202124', padding: 12, borderRadius: 8, fontFamily: 'system-ui', maxWidth: 720, marginTop: 12 }}>
+  <div style={{ display: 'flex', gap: 4 }}>
+    <div style={{ background: '#292A2D', borderRadius: '8px 8px 0 0', padding: '6px 12px 6px 10px', display: 'flex', alignItems: 'center', gap: 8, fontSize: 12, color: '#E8EAED', maxWidth: 220 }}>
+      <div style={{ width: 16, height: 16, background: '#0F0D0B', borderRadius: 3, display: 'grid', placeItems: 'center', flexShrink: 0 }}>
+        <div style={{ width: 7, height: 7, borderRadius: '50%', background: '#F0A668' }} />
+      </div>
+      <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>Cockpit · oportunities</span>
+    </div>
+    <div style={{ background: 'rgba(255,255,255,0.04)', borderRadius: '8px 8px 0 0', padding: '6px 12px', fontSize: 12, color: '#9AA0A6' }}>
+      Inbox · Gmail
+    </div>
+    <div style={{ background: 'rgba(255,255,255,0.04)', borderRadius: '8px 8px 0 0', padding: '6px 12px', fontSize: 12, color: '#9AA0A6' }}>
+      GitHub
+    </div>
+  </div>
+</div>
+
+> The favicon is the only color in the row. That's the signal: _"that's us."_
+
+---
+
+## File Inventory
+
+From `@amplify-ai/brand-oportunities/assets/favicons/`:
+
+| File | Use |
+|---|---|
+| `favicon.ico` | Legacy fallback (16+32 multi-res) |
+| `favicon-16.png` | Tabs (some browsers prefer raster) |
+| `favicon-32.png` | Standard favicon, retina tab |
+| `favicon-180.png` | Apple touch icon |
+| `favicon-light.svg` | Modern SVG (light) |
+| `favicon-dark.svg` | Modern SVG (dark — used via `prefers-color-scheme`) |
+| `safari-pinned-tab.svg` | Safari pinned tab (single color, masked) |
+| `site.webmanifest` | PWA manifest with icon entries |
+
+---
+
+## Implementation — HTML `<head>`
+
+```html
+<!-- Modern SVG favicon (light + dark) -->
+<link rel="icon" href="/favicon-light.svg" type="image/svg+xml" media="(prefers-color-scheme: light)">
+<link rel="icon" href="/favicon-dark.svg"  type="image/svg+xml" media="(prefers-color-scheme: dark)">
+
+<!-- Raster fallbacks -->
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+
+<!-- Apple touch + Safari pinned -->
+<link rel="apple-touch-icon" sizes="180x180" href="/favicon-180.png">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#E68F47">
+
+<!-- Manifest + theme color -->
+<link rel="manifest" href="/site.webmanifest">
+<meta name="theme-color" content="#FDF8F3" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#0F0D0B" media="(prefers-color-scheme: dark)">
+```
+
+---
+
+## Do / Don't
+
+- **Do** use the SVG variant for modern browsers — it stays sharp at any DPR.
+- **Do** ship the dark SVG separately — browsers pick by `prefers-color-scheme`.
+- **Do** set `theme-color` so the address bar inherits cream / warm-ink.
+- **Don't** put a letter "o" inside the favicon — at 16px it becomes mush.
+- **Don't** use the gradient wordmark variant — gradients alias badly at favicon scale.
+- **Don't** ship a transparent-background favicon — the cream/ink tile is part of the mark.

--- a/packages/storybook/stories/oportunities/IntentFeed.stories.tsx
+++ b/packages/storybook/stories/oportunities/IntentFeed.stories.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { IntentFeed, type CreatorIntentCardProps, type IntentFeedFilters } from '@amplify-ai/ui';
+
+const meta = {
+  title: 'Oportunities/IntentFeed',
+  component: IntentFeed,
+  tags: ['autodocs'],
+  parameters: {
+    backgrounds: {
+      default: 'cream',
+      values: [
+        { name: 'cream', value: '#FDF8F3' },
+        { name: 'ink', value: '#15110D' },
+      ],
+    },
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof IntentFeed>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sampleCards: CreatorIntentCardProps[] = [
+  {
+    creator: {
+      name: 'Amrita Patel',
+      handle: '@amrita.notes',
+      niche: 'Slow-luxe lifestyle',
+      followers: 128_000,
+      avatarGradient: 'linear-gradient(135deg, #E68F47 0%, #7B5BFF 100%)',
+    },
+    intent: {
+      headline: 'Wind-down rituals × sleep-tech brand — 3-part arc.',
+      dateRange: 'Apr 22 – May 14',
+      vibe: 'editorial · slow-luxe',
+      openTo: ['Story', 'Reel'],
+    },
+    aiFitScore: 87,
+  },
+  {
+    creator: {
+      name: 'Jordan Kim',
+      handle: '@jkfilms',
+      niche: 'Cinematic travel',
+      followers: 412_000,
+      avatarGradient: 'linear-gradient(135deg, #7B5BFF 0%, #E68F47 100%)',
+    },
+    intent: {
+      headline: 'Open to a hotel-collab arc — would shoot at golden hour.',
+      dateRange: 'May 1 – Jun 5',
+      vibe: 'cinematic · slow-pan',
+      openTo: ['Reel', 'YouTube'],
+    },
+    aiFitScore: 73,
+  },
+  {
+    creator: {
+      name: 'Tara Vohra',
+      handle: '@tara.cooks',
+      niche: 'Modern Indian food',
+      followers: 56_000,
+      avatarGradient: 'linear-gradient(135deg, #E68F47 0%, #5C82B0 100%)',
+    },
+    intent: {
+      headline: 'Looking for a single-origin spice brand — paid recipe series.',
+      dateRange: 'Apr',
+      vibe: 'editorial · warm',
+      openTo: ['Reel', 'Newsletter'],
+    },
+    aiFitScore: 92,
+  },
+];
+
+const sampleFilters: IntentFeedFilters = {
+  category: ['Lifestyle', 'Food', 'Travel', 'Tech'],
+  effort: ['Organic', 'Sample', 'Sponsor', 'Paid'],
+  freshness: ['<24h', 'This week', 'This month'],
+};
+
+export const Default: Story = {
+  args: {
+    cards: sampleCards,
+    filters: sampleFilters,
+    heading: 'Live creator intents',
+    onUnlock: (idx) => alert(`Unlocked card ${idx}`),
+  },
+};
+
+export const WithActiveFilters: Story = {
+  args: {
+    cards: sampleCards,
+    filters: sampleFilters,
+    activeFilters: { category: ['Lifestyle'], effort: ['Organic'] },
+    heading: 'Live creator intents',
+    onFilter: (change) => console.log('filter change', change),
+  },
+};
+
+export const EmptyState: Story = {
+  args: {
+    cards: [],
+    filters: sampleFilters,
+    activeFilters: { category: ['Tech'], effort: ['Paid'] },
+    heading: 'Live creator intents',
+    emptyState: (
+      <div style={{ padding: 32, textAlign: 'center', color: '#5C5249' }}>
+        No intents match your filters yet. Loosen them to see more creators.
+      </div>
+    ),
+  },
+};
+
+export const Interactive: Story = {
+  args: { cards: sampleCards, filters: sampleFilters },
+  render: (args) => {
+    const [active, setActive] = React.useState<IntentFeedFilters>({});
+    return (
+      <IntentFeed
+        {...args}
+        activeFilters={active}
+        onFilter={({ group, value, selected }) => {
+          setActive((prev) => {
+            const cur = new Set(prev[group] ?? []);
+            if (selected) cur.add(value);
+            else cur.delete(value);
+            return { ...prev, [group]: Array.from(cur) };
+          });
+        }}
+      />
+    );
+  },
+};

--- a/packages/storybook/stories/oportunities/Logo.mdx
+++ b/packages/storybook/stories/oportunities/Logo.mdx
@@ -1,0 +1,130 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Oportunities/Logo" />
+
+# Oportunities — Logo
+
+The wordmark is the brand. Single-P **oportunities.** in Geist 600 at `-0.04em` tracking,
+with an apricot terminal dot. The gradient sweep variant (apricot → AI-purple) is the
+hero expression — used at app launch, marketing splash, and the cockpit header.
+
+---
+
+## Hero Wordmark (Gradient Sweep)
+
+<div style={{ padding: 48, background: '#FDF8F3', borderRadius: 12, border: '1px solid #EFE4D4', position: 'relative', overflow: 'hidden' }}>
+  <svg viewBox="0 0 600 120" role="img" aria-label="oportunities wordmark animated sweep" style={{ width: '100%', maxWidth: 480, display: 'block', margin: '0 auto' }}>
+    <defs>
+      <linearGradient id="sweep-anim" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stopColor="#E68F47">
+          <animate attributeName="stop-color" values="#E68F47;#7B5BFF;#E68F47" dur="3s" repeatCount="indefinite" />
+        </stop>
+        <stop offset="100%" stopColor="#7B5BFF">
+          <animate attributeName="stop-color" values="#7B5BFF;#E68F47;#7B5BFF" dur="3s" repeatCount="indefinite" />
+        </stop>
+      </linearGradient>
+    </defs>
+    <text x="20" y="92" fontFamily="Geist, Inter, sans-serif" fontWeight="600" fontSize="88" letterSpacing="-0.04em" fill="url(#sweep-anim)">oportunities.</text>
+  </svg>
+</div>
+
+The dot pulses subtly on idle (every 4s, opacity 1 → 0.6 → 1) — never fast, never blinky.
+
+---
+
+## Variants (All 6)
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 16 }}>
+  {[
+    { id: 'default',      label: 'Default',           bg: '#FDF8F3', path: '/brand-oportunities/wordmark-default.svg' },
+    { id: 'onLight',      label: 'On light',          bg: '#FFFFFF', path: '/brand-oportunities/wordmark-on-light.svg' },
+    { id: 'onDark',       label: 'On dark',           bg: '#0F0D0B', path: '/brand-oportunities/wordmark-on-dark.svg' },
+    { id: 'monochrome',   label: 'Monochrome',        bg: '#F4ECE0', path: '/brand-oportunities/wordmark-monochrome.svg' },
+    { id: 'withGradient', label: 'Apricot → purple', bg: '#FDF8F3', path: '/brand-oportunities/wordmark-with-gradient.svg' },
+    { id: 'spec',         label: 'Construction grid', bg: '#F8F1E8', path: '/brand-oportunities/wordmark-spec.svg' },
+  ].map((v) => (
+    <div key={v.id} style={{ background: v.bg, padding: 24, borderRadius: 8, border: '1px solid rgba(0,0,0,0.06)' }}>
+      <div style={{ fontFamily: 'Inter, sans-serif', fontSize: 11, color: v.bg === '#0F0D0B' ? '#A89E92' : '#8A7F73', letterSpacing: '0.08em', textTransform: 'uppercase', marginBottom: 12 }}>{v.label}</div>
+      <object data={v.path} type="image/svg+xml" style={{ width: '100%', height: 'auto', display: 'block' }} aria-label={`oportunities wordmark ${v.label}`} />
+    </div>
+  ))}
+</div>
+
+---
+
+## Clear-Space Rule
+
+Minimum clear space = **height of the "o"** on all four sides. Never crowd; the wordmark
+needs room to breathe.
+
+<div style={{ background: '#F8F1E8', padding: 32, borderRadius: 8, position: 'relative' }}>
+  <div style={{ outline: '1px dashed #E68F47', padding: '24px 32px', display: 'inline-block', background: '#FDF8F3' }}>
+    <div style={{ fontFamily: 'Geist, sans-serif', fontWeight: 600, fontSize: 48, letterSpacing: '-0.04em', color: '#1C1611', lineHeight: 1 }}>
+      oportunities<span style={{ color: '#E68F47' }}>.</span>
+    </div>
+  </div>
+  <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, color: '#8A7F73', marginTop: 8 }}>
+    Dashed line = clear-space boundary = height of "o" on all sides
+  </div>
+</div>
+
+---
+
+## Min-Size
+
+| Surface | Min wordmark height | Reasoning |
+|---|---|---|
+| Print | 8mm | Letter shapes legible at arm's length |
+| Web (raster) | 24px | Geist hinting clean at 24px |
+| Web (SVG) | 16px | SVG stays sharp |
+| App nav | 20px | Standard nav-bar height |
+| Favicon | use favicon mark, not wordmark | See **Favicon** |
+
+---
+
+## Do / Don't (6 Pairs)
+
+<div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+  {[
+    { ok: 'Apricot dot stays apricot on every background', no: 'Recolor the dot to "match" your surface' },
+    { ok: 'Lock `-0.04em` tracking on every render', no: 'Use default tracking — letters drift apart' },
+    { ok: 'Geist 600 — never lighter, never bold', no: 'Substitute Inter, Helvetica, or system-ui' },
+    { ok: 'Gradient sweeps apricot → purple, left to right', no: 'Reverse direction or swap accent colors' },
+    { ok: 'Single P — "oportunities"', no: 'Double P — "opportunities" is a different word' },
+    { ok: 'Keep clear-space at minimum 1× "o" height', no: 'Stack icons or text inside clear-space' },
+  ].map((p, i) => (
+    <>
+      <div key={`ok-${i}`} style={{ padding: 16, border: '1px solid #5A8E4F', borderRadius: 8, background: '#F1F8EF' }}>
+        <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, color: '#5A8E4F', marginBottom: 4 }}>DO</div>
+        <div style={{ fontFamily: 'Inter, sans-serif', fontSize: 14, color: '#1C1611' }}>{p.ok}</div>
+      </div>
+      <div key={`no-${i}`} style={{ padding: 16, border: '1px solid #B33A3A', borderRadius: 8, background: '#FBF0F0' }}>
+        <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, color: '#B33A3A', marginBottom: 4 }}>DON'T</div>
+        <div style={{ fontFamily: 'Inter, sans-serif', fontSize: 14, color: '#1C1611' }}>{p.no}</div>
+      </div>
+    </>
+  ))}
+</div>
+
+---
+
+## Implementation
+
+```tsx
+import { Wordmark } from '@amplify-ai/ui';
+
+// Default — picks light/dark from theme
+<Wordmark />
+
+// Force variant
+<Wordmark variant="withGradient" size={48} />
+<Wordmark variant="onDark" />
+<Wordmark variant="monochrome" color="#1C1611" />
+```
+
+Raw SVG paths (from `@amplify-ai/brand-oportunities`):
+
+```js
+import { wordmark } from '@amplify-ai/brand-oportunities';
+// wordmark.default | onLight | onDark | monochrome | withGradient | spec
+```

--- a/packages/storybook/stories/oportunities/SignalDot.stories.tsx
+++ b/packages/storybook/stories/oportunities/SignalDot.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { SignalDot } from '@amplify-ai/ui';
+
+const meta = {
+  title: 'Oportunities/SignalDot',
+  component: SignalDot,
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: { type: 'number', min: 6, max: 96, step: 2 } },
+    pulse: { control: 'boolean' },
+    gradient: { control: 'boolean' },
+    live: { control: 'boolean' },
+  },
+  parameters: {
+    backgrounds: {
+      default: 'cream',
+      values: [
+        { name: 'cream', value: '#FDF8F3' },
+        { name: 'ink', value: '#15110D' },
+      ],
+    },
+  },
+} satisfies Meta<typeof SignalDot>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = { args: { size: 16 } };
+export const Pulse: Story = { args: { size: 20, pulse: true } };
+export const Gradient: Story = { args: { size: 24, gradient: true } };
+export const Live: Story = { args: { size: 14, live: true } };
+export const LargeGradientLive: Story = { args: { size: 28, gradient: true, live: true } };
+
+export const Gallery: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 40, alignItems: 'center' }}>
+      <SignalDot size={16} />
+      <SignalDot size={20} pulse />
+      <SignalDot size={24} gradient />
+      <SignalDot size={14} live />
+      <SignalDot size={28} gradient live />
+    </div>
+  ),
+};

--- a/packages/storybook/stories/oportunities/Typography.mdx
+++ b/packages/storybook/stories/oportunities/Typography.mdx
@@ -1,0 +1,136 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Oportunities/Typography" />
+
+# Oportunities — Typography
+
+Three-font stack. **Geist** for display + the wordmark (the signature). **Inter** for body
++ UI. **JetBrains Mono** for numbers, code, and data — anywhere precision matters.
+
+> Pairing rule: Geist for moments of brand presence; Inter everywhere else;
+> JetBrains Mono only for numerical/system data.
+
+---
+
+## Geist — Display Scale
+
+Weight 600 only. Letter-spacing `-0.04em` on display sizes (≥32px), `-0.02em` on mid (20–28px),
+default on small. Use for the wordmark, hero headlines, section headers, and any "this is the brand
+speaking" moment.
+
+<div style={{ display: 'grid', gap: 16, padding: 24, background: '#FDF8F3', borderRadius: 8 }}>
+  {[
+    { size: 96, ls: '-0.04em', label: 'display-1 · 96/600' },
+    { size: 72, ls: '-0.04em', label: 'display-2 · 72/600' },
+    { size: 56, ls: '-0.04em', label: 'display-3 · 56/600' },
+    { size: 40, ls: '-0.04em', label: 'h1 · 40/600' },
+    { size: 32, ls: '-0.04em', label: 'h2 · 32/600' },
+    { size: 24, ls: '-0.02em', label: 'h3 · 24/600' },
+    { size: 20, ls: '-0.02em', label: 'h4 · 20/600' },
+  ].map((s) => (
+    <div key={s.size}>
+      <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 10, color: '#8A7F73', letterSpacing: '0.08em', marginBottom: 4 }}>{s.label}</div>
+      <div style={{ fontFamily: 'Geist, Inter, sans-serif', fontWeight: 600, fontSize: s.size, letterSpacing: s.ls, color: '#1C1611', lineHeight: 1.1 }}>
+        Heads up — three creators just signaled.
+      </div>
+    </div>
+  ))}
+</div>
+
+---
+
+## Inter — Body Scale
+
+Weight 500 default (crisp legibility on warm surfaces). 600 for emphasis, 400 for muted/long-form.
+Default line-height 1.5.
+
+<div style={{ display: 'grid', gap: 12, padding: 24, background: '#FFFFFF', borderRadius: 8, border: '1px solid #EFE4D4' }}>
+  {[
+    { size: 18, weight: 500, label: 'body-lg · 18/500' },
+    { size: 16, weight: 500, label: 'body · 16/500 (default)' },
+    { size: 14, weight: 500, label: 'body-sm · 14/500' },
+    { size: 13, weight: 500, label: 'caption · 13/500' },
+    { size: 11, weight: 600, label: 'label · 11/600 · uppercase · 0.08em', upper: true },
+  ].map((s) => (
+    <div key={s.label}>
+      <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 10, color: '#8A7F73', letterSpacing: '0.08em', marginBottom: 2 }}>{s.label}</div>
+      <div style={{ fontFamily: 'Inter, sans-serif', fontSize: s.size, fontWeight: s.weight, color: '#1C1611', lineHeight: 1.5, textTransform: s.upper ? 'uppercase' : 'none', letterSpacing: s.upper ? '0.08em' : 'normal' }}>
+        Aanya saved your post on Tuesday and again today.
+      </div>
+    </div>
+  ))}
+</div>
+
+---
+
+## JetBrains Mono — Data Scale
+
+Use for any value that is numeric, identifier, code, or system output. **Never** for body prose.
+
+<div style={{ display: 'grid', gap: 12, padding: 24, background: '#F8F1E8', borderRadius: 8 }}>
+  {[
+    { size: 32, label: 'data-xl · 32/500 — KPIs' },
+    { size: 20, label: 'data-lg · 20/500 — metrics' },
+    { size: 14, label: 'data · 14/500 — tables, inline' },
+    { size: 12, label: 'data-sm · 12/400 — captions, log lines' },
+  ].map((s) => (
+    <div key={s.size}>
+      <div style={{ fontFamily: 'Inter, sans-serif', fontSize: 10, color: '#8A7F73', letterSpacing: '0.08em', marginBottom: 2 }}>{s.label}</div>
+      <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: s.size, color: '#1C1611', lineHeight: 1.3 }}>
+        3.42 ER · ₹1.2L CPM · 14d window
+      </div>
+    </div>
+  ))}
+</div>
+
+---
+
+## Pairing Rules
+
+1. **Geist + Inter** — the canonical pair. Geist headline, Inter sub + body.
+2. **Inter + JBM** — UI default. Inter label + JBM value (e.g., "Engagement rate" / `3.42`).
+3. **Geist + JBM** — hero metric moment. Big Geist label, big JBM number underneath.
+4. **Never mix** Geist body with Geist display in the same block — Geist is for moments.
+
+---
+
+## Sample Composition
+
+<div style={{ padding: 32, background: '#FDF8F3', borderRadius: 12, border: '1px solid #EFE4D4', maxWidth: 600 }}>
+  <div style={{ fontFamily: 'Inter, sans-serif', fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', color: '#8A7F73', marginBottom: 8 }}>
+    This week
+  </div>
+  <div style={{ fontFamily: 'Geist, Inter, sans-serif', fontWeight: 600, fontSize: 40, letterSpacing: '-0.04em', color: '#1C1611', lineHeight: 1.1, marginBottom: 12 }}>
+    Heads up — Aanya is paying attention.
+  </div>
+  <div style={{ fontFamily: 'Inter, sans-serif', fontSize: 16, fontWeight: 500, color: '#5C5249', lineHeight: 1.5, marginBottom: 24 }}>
+    She saved your post on Tuesday, replied to your story on Thursday, and viewed your latest reel three times today. The pattern suggests she's open to a brief.
+  </div>
+  <div style={{ display: 'flex', gap: 24, paddingTop: 16, borderTop: '1px solid #EFE4D4' }}>
+    <div>
+      <div style={{ fontFamily: 'Inter, sans-serif', fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', color: '#8A7F73', marginBottom: 4 }}>Signal strength</div>
+      <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 24, color: '#E68F47' }}>0.87</div>
+    </div>
+    <div>
+      <div style={{ fontFamily: 'Inter, sans-serif', fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', color: '#8A7F73', marginBottom: 4 }}>Window</div>
+      <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 24, color: '#1C1611' }}>7d</div>
+    </div>
+  </div>
+</div>
+
+---
+
+## Implementation (tokens)
+
+```css
+/* From @amplify-ai/tokens-oportunities/css */
+:root {
+  --font-display: 'Geist', 'Inter Tight', sans-serif;
+  --font-body:    'Inter', system-ui, sans-serif;
+  --font-mono:    'JetBrains Mono', monospace;
+
+  --letter-spacing-tight: -0.04em;
+  --weight-display: 600;
+  --weight-body-default: 500;
+}
+```

--- a/packages/storybook/stories/oportunities/Voice.mdx
+++ b/packages/storybook/stories/oportunities/Voice.mdx
@@ -1,0 +1,177 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Oportunities/Voice" />
+
+# Oportunities — Voice
+
+The voice is the product. Calm. Observational. Peer, not vendor. Never breathless,
+never bro-y, never "AI is excited to help you!". The anchor phrase is **"Heads up —"**.
+
+> The product whispers what it sees. It does not shout, sell, or congratulate.
+
+---
+
+## Voice Register — 8 Product Moments (LOCKED)
+
+| # | Moment | Voice pick | What we avoid |
+|---|---|---|---|
+| 1 | First signal arrives | _"Heads up — Aanya just liked 3 of your reels."_ | _"You got a new signal!"_ |
+| 2 | Empty state | _"No signals yet. The feed will fill as creators engage."_ | _"Nothing here yet!"_ / _"Get started"_ |
+| 3 | High-intent surface | _"This one feels real. Aanya saved your post on Tuesday and again today."_ | _"HOT LEAD — Aanya is interested!"_ |
+| 4 | AI suggestion | _"Want to test a sample drop? Three creators look ready."_ | _"AI recommends: launch a sample campaign"_ |
+| 5 | Confirmation | _"Sent. We'll let you know when Aanya replies."_ | _"Success! Your brief was sent!"_ |
+| 6 | Error | _"Something's off. Retrying — give us a moment."_ | _"Error 500: An unknown error occurred."_ |
+| 7 | Approval needed | _"Quick check — this brief mentions a competitor. Still send?"_ | _"WARNING: Competitor mention detected."_ |
+| 8 | Win moment | _"Aanya said yes. Brief's in her inbox."_ | _"Congratulations! 🎉 Deal closed!"_ |
+
+---
+
+## The "Heads up —" Lexicon
+
+`"Heads up —"` is the opener for **passive observations**: things the product noticed,
+not things the user asked for. It signals that the system is paying attention without
+demanding the user's.
+
+**Use it for:**
+- New signals from creators / brands
+- Pattern changes (a creator's engagement drops, a brand changes posture)
+- Pre-action notices ("Heads up — this brief mentions a competitor")
+- Calendar / scheduling reminders
+
+**Don't use it for:**
+- Errors → use _"Something's off."_
+- Confirmations → use _"Sent."_ / _"Saved."_ / _"Done."_
+- High-stakes warnings → use _"Quick check —"_ instead
+
+### Companion openers
+
+| Opener | Used for |
+|---|---|
+| `Heads up —` | passive observation |
+| `Quick check —` | requires user input / approval |
+| `Something's off.` | system error |
+| `Worth noting —` | secondary observation, less urgent |
+| `One more thing —` | follow-on info after a confirmation |
+
+---
+
+## Do / Don't
+
+<div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+  {[
+    {
+      ok: '_"Heads up — Aanya saved your post."_',
+      no: '_"🚨 New signal: Aanya saved your post!"_',
+      why: 'no emojis at the front, no exclamations',
+    },
+    {
+      ok: '_"This one feels real."_',
+      no: '_"HOT LEAD DETECTED — high probability of conversion"_',
+      why: 'human language, not CRM language',
+    },
+    {
+      ok: '_"Want to test a sample drop?"_',
+      no: '_"AI suggests you should launch a sample campaign now."_',
+      why: 'a peer asks. AI does not "suggest you should"',
+    },
+    {
+      ok: '_"Sent. We\'ll let you know when Aanya replies."_',
+      no: '_"Successfully sent! You can track responses on the dashboard."_',
+      why: 'short, no over-explaining',
+    },
+    {
+      ok: '_"Something\'s off. Retrying — give us a moment."_',
+      no: '_"Oops! 😅 We hit a snag. Don\'t worry, we\'re on it!"_',
+      why: 'no apology theater, no emoji',
+    },
+    {
+      ok: '_"Aanya said yes. Brief\'s in her inbox."_',
+      no: '_"🎉 Congratulations! You closed a deal with Aanya!"_',
+      why: 'state the fact, let the user feel the win',
+    },
+  ].map((p, i) => (
+    <>
+      <div key={`ok-${i}`} style={{ padding: 16, border: '1px solid #5A8E4F', borderRadius: 8, background: '#F1F8EF', fontFamily: 'Inter, sans-serif' }}>
+        <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, color: '#5A8E4F', marginBottom: 6 }}>DO</div>
+        <div style={{ fontSize: 14, color: '#1C1611', marginBottom: 6 }} dangerouslySetInnerHTML={{ __html: p.ok.replace(/_(.+?)_/g, '<em>$1</em>') }} />
+        <div style={{ fontSize: 12, color: '#5C5249' }}>{p.why}</div>
+      </div>
+      <div key={`no-${i}`} style={{ padding: 16, border: '1px solid #B33A3A', borderRadius: 8, background: '#FBF0F0', fontFamily: 'Inter, sans-serif' }}>
+        <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, color: '#B33A3A', marginBottom: 6 }}>DON'T</div>
+        <div style={{ fontSize: 14, color: '#1C1611' }} dangerouslySetInnerHTML={{ __html: p.no.replace(/_(.+?)_/g, '<em>$1</em>') }} />
+      </div>
+    </>
+  ))}
+</div>
+
+---
+
+## Microcopy Library
+
+A starter pack of approved strings. Copy/paste into surfaces — don't reinvent.
+
+### Notifications
+
+```
+Heads up — Aanya just liked 3 of your reels.
+Heads up — Nourish & Co. has viewed your audience report.
+Heads up — your reply window with Aanya closes in 2 days.
+Worth noting — three creators in your category went active this week.
+```
+
+### Empty states
+
+```
+No signals yet. The feed will fill as creators engage.
+Nothing to review. We'll flag briefs that need a second look.
+Quiet week. We'll surface the next signal as it lands.
+```
+
+### AI suggestions
+
+```
+Want to test a sample drop? Three creators look ready.
+Want us to draft a reply to Aanya? You can edit before sending.
+This brief reads a little long. Want a tighter version?
+```
+
+### Confirmations
+
+```
+Sent. We'll let you know when Aanya replies.
+Saved. Pick this up anytime from the cockpit.
+Done. The brief is live and creators can see it.
+```
+
+### Approval gates
+
+```
+Quick check — this brief mentions a competitor. Still send?
+Quick check — sample is valued at ₹3K. Confirm send?
+Quick check — Aanya replied at 11pm. Send your reply now or queue for morning?
+```
+
+### Errors
+
+```
+Something's off. Retrying — give us a moment.
+That didn't go through. We saved your draft. Try again?
+Aanya's inbox is full right now. We'll retry in an hour.
+```
+
+### Win moments
+
+```
+Aanya said yes. Brief's in her inbox.
+Nourish accepted your sample. Tracking the shipment now.
+Three creators agreed today. See them all in the cockpit.
+```
+
+---
+
+## Implementation Notes
+
+- All UI strings live in `@amplify-ai/ui` component defaults — override per surface, never invent.
+- The opener (`Heads up —`) is rendered as a span with `font-weight: 600` to give it a soft visual anchor.
+- Em-dashes (`—`) not hyphens (`-`). Always.
+- No emojis at the **start** of strings. Mid-string emoji is fine if the source is user-generated.

--- a/packages/storybook/stories/oportunities/Wordmark.stories.tsx
+++ b/packages/storybook/stories/oportunities/Wordmark.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Wordmark } from '@amplify-ai/ui';
+
+const meta = {
+  title: 'Oportunities/Wordmark',
+  component: Wordmark,
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg', 'xl'] },
+    animated: { control: 'boolean' },
+    monochrome: { control: 'boolean' },
+  },
+  parameters: {
+    backgrounds: {
+      default: 'cream',
+      values: [
+        { name: 'cream', value: '#FDF8F3' },
+        { name: 'ink', value: '#15110D' },
+      ],
+    },
+  },
+} satisfies Meta<typeof Wordmark>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = { args: { size: 'lg' } };
+export const Small: Story = { args: { size: 'sm' } };
+export const Extra: Story = { args: { size: 'xl' } };
+export const Animated: Story = { args: { size: 'xl', animated: true } };
+export const Monochrome: Story = { args: { size: 'lg', monochrome: true } };
+export const AllSizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+      <Wordmark size="sm" />
+      <Wordmark size="md" />
+      <Wordmark size="lg" />
+      <Wordmark size="xl" />
+    </div>
+  ),
+};

--- a/packages/tokens-oportunities/README.md
+++ b/packages/tokens-oportunities/README.md
@@ -1,0 +1,107 @@
+# @amplify-ai/tokens-oportunities
+
+Oportunities design tokens — the Studio direction (Geist + apricot period) for the creator-intent intelligence platform.
+
+> Note the single-P spelling: **Oportunities**, never *Opportunities*.
+
+## What this is
+
+Token package for **Oportunities**, the creator-intent platform spanning three surfaces (brand platform, internal tool, creator app). These tokens encode the locked **Studio direction**:
+
+- **Apricot** (`#E68F47`) as the signature brand color — wordmark, primary actions
+- **AI purple** (`#7B5BFF`) paired with apricot in the brand gradient and on AI surfaces
+- **Geist** for display (wordmark + headers) at `weight 600` with `-0.04em` tracking — the wordmark's signature
+- **Inter** for body, **JetBrains Mono** for code/numbers
+- **Effort palette** (organic / sample / sponsor / paid) for creator-intent classification
+- **Light + dark themes** — cream-on-warm in light, warm-black-on-bright-apricot in dark
+
+## Locked Studio DNA
+
+These are **not negotiable** at the package level:
+
+| Element | Value |
+|---|---|
+| Wordmark color | `#E68F47` apricot |
+| Wordmark period (`.`) | Apricot, slightly oversized — part of the mark |
+| Sweep animation | Apricot → purple → apricot gradient sweep across letters |
+| Display font | `'Geist', 'Inter Tight', sans-serif` |
+| Display weight | `600` |
+| Display tracking | `-0.04em` |
+| Brand gradient | `linear-gradient(135deg, #E68F47 0%, #7B5BFF 100%)` |
+| Brand voice marker | `Heads up —` (em-dash prefix, casual) |
+
+## Consume
+
+Install:
+
+```bash
+npm install @amplify-ai/tokens-oportunities
+```
+
+### Tailwind v4
+
+```css
+/* globals.css */
+@import "@amplify-ai/tokens-oportunities/tailwind";
+```
+
+### Plain CSS
+
+```css
+/* globals.css */
+@import "@amplify-ai/tokens-oportunities/css";
+
+.button {
+  background: var(--amp-oportunities-theme-color-accent);
+  color: var(--amp-oportunities-theme-color-text-primary);
+  font-family: var(--amp-oportunities-font-display);
+  font-weight: var(--amp-oportunities-weight-display);
+  letter-spacing: var(--amp-oportunities-letter-spacing-tight);
+}
+```
+
+### JS / TS
+
+```ts
+import * as tokens from '@amplify-ai/tokens-oportunities/js';
+
+console.log(tokens.themeColorAccent); // '#E68F47'
+```
+
+### SCSS
+
+```scss
+@use '@amplify-ai/tokens-oportunities/scss' as oportunities;
+
+.button {
+  background: oportunities.$amp-oportunities-theme-color-accent;
+}
+```
+
+### JSON
+
+```ts
+import tokens from '@amplify-ai/tokens-oportunities/json';
+```
+
+## Foundation dependency
+
+This package depends on `@amplify-ai/tokens-foundation` for the primitive scales (spacing, radius, shadow, typography scale). Foundation primitives are **inherited as-is** — Oportunities only overrides semantic + cockpit layers.
+
+## Build
+
+```bash
+npm run build
+```
+
+Generates in `dist/`:
+
+- `variables.css` — CSS custom properties (light + dark via `[data-theme="dark"]`)
+- `variables.scss` — SCSS variables
+- `tailwind.css` — Tailwind v4 `@theme` preset
+- `tokens.json` — flat key-value JSON
+- `tokens.js` — ES module with named exports
+
+## Brand voice marker
+
+Oportunities-surfaced copy opens with `Heads up —` (em-dash, lowercase). This is encoded in product copy, not tokens, but listed here as the canonical brand-voice anchor.

--- a/packages/tokens-oportunities/build.js
+++ b/packages/tokens-oportunities/build.js
@@ -1,0 +1,7 @@
+// Delegates to shared build script
+import { execSync } from 'child_process';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '../..');
+execSync(`node ${join(root, 'scripts/build-tokens.js')} oportunities`, { stdio: 'inherit' });

--- a/packages/tokens-oportunities/package.json
+++ b/packages/tokens-oportunities/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@amplify-ai/tokens-oportunities",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Oportunities design tokens — Studio direction (Geist + apricot period) for the creator-intent intelligence platform",
+  "main": "dist/tokens.js",
+  "exports": {
+    "./css": "./dist/variables.css",
+    "./scss": "./dist/variables.scss",
+    "./tailwind": "./dist/tailwind.css",
+    "./json": "./dist/tokens.json",
+    "./js": "./dist/tokens.js",
+    ".": "./dist/tokens.js"
+  },
+  "scripts": {
+    "build": "node build.js"
+  },
+  "dependencies": {
+    "@amplify-ai/tokens-foundation": "^2.1.0"
+  },
+  "devDependencies": {
+    "style-dictionary": "^4.3.0"
+  },
+  "files": [
+    "dist/",
+    "tokens/"
+  ]
+}

--- a/packages/tokens-oportunities/tokens/theme-dark.json
+++ b/packages/tokens-oportunities/tokens/theme-dark.json
@@ -1,0 +1,43 @@
+{
+  "theme": {
+    "$description": "Oportunities — Dark theme. Brightened apricot for dark contrast; deep warm backgrounds preserve the Studio cream-on-warm DNA inverted.",
+    "product": "oportunities",
+    "mode": "dark",
+    "color": {
+      "$type": "color",
+      "bg":             { "$value": "#0F0D0B", "$description": "Deep warm-black page background" },
+      "bg-elev":        { "$value": "#1A1714", "$description": "Elevated surface (cards, modals) — dark" },
+      "bg-soft":        { "$value": "#25201C", "$description": "Subtle inset / recessed background — dark" },
+
+      "accent":         { "$value": "#F0A668", "$description": "Brightened apricot for dark contrast" },
+      "accent-hover":   { "$value": "#FFB47A", "$description": "Apricot on hover — even brighter" },
+      "accent-soft":    { "$value": "rgba(240, 166, 104, 0.12)", "$description": "Subtle apricot tint on dark surfaces" },
+
+      "ai-purple":      { "$value": "#9B82FF", "$description": "AI purple — brightened for dark contrast" },
+      "ai-soft":        { "$value": "rgba(155, 130, 255, 0.14)", "$description": "Subtle AI purple tint on dark surfaces" },
+
+      "text-primary":   { "$value": "#F4ECE0", "$description": "Primary text on dark — warm near-white" },
+      "text-secondary": { "$value": "#A89E92", "$description": "Secondary text on dark" },
+      "text-tertiary":  { "$value": "#6A6258", "$description": "Tertiary / muted text on dark" },
+
+      "border":         { "$value": "#2D2723", "$description": "Default border on dark" },
+      "border-soft":    { "$value": "#383028", "$description": "Subtle divider on dark" }
+    }
+  },
+  "effort": {
+    "$type": "color",
+    "$description": "Effort palette — dark variant. Slightly brightened for legibility on warm-black surfaces.",
+    "organic":  { "$value": "#7CB070", "$description": "Organic content effort — brightened green" },
+    "sample":   { "$value": "#7FA4D2", "$description": "Sample effort — brightened blue" },
+    "sponsor":  { "$value": "#F0A668", "$description": "Sponsored content effort — brightened apricot (matches accent)" },
+    "paid":     { "$value": "#B5AB9D", "$description": "Paid placement effort — brightened neutral" }
+  },
+  "status": {
+    "$type": "color",
+    "$description": "Oportunities status scale — dark variant.",
+    "success":  { "$value": "#52AC71", "$description": "Success / approved — dark" },
+    "warning":  { "$value": "#E0A84A", "$description": "Warning / needs attention — dark" },
+    "danger":   { "$value": "#D5605E", "$description": "Error / blocked / rejected — dark" },
+    "info":     { "$value": "#6090D2", "$description": "Informational — dark" }
+  }
+}

--- a/packages/tokens-oportunities/tokens/theme-light.json
+++ b/packages/tokens-oportunities/tokens/theme-light.json
@@ -1,0 +1,65 @@
+{
+  "theme": {
+    "$description": "Oportunities — Light theme. Studio-direction tokens for the creator-intent intelligence platform. Inherits primitives from tokens-foundation; layers Oportunities cockpit semantics (apricot + AI purple, Geist typography, effort palette) on top.",
+    "product": "oportunities",
+    "mode": "light",
+    "color": {
+      "$type": "color",
+      "bg":             { "$value": "#FDF8F3", "$description": "Cream page background — Oportunities signature surface" },
+      "bg-elev":        { "$value": "#FFFFFF", "$description": "Elevated surface (cards, modals)" },
+      "bg-soft":        { "$value": "#F8F1E8", "$description": "Subtle inset / recessed background" },
+
+      "accent":         { "$value": "#E68F47", "$description": "Apricot — THE Oportunities brand color (wordmark, primary actions)" },
+      "accent-hover":   { "$value": "#D67A35", "$description": "Apricot on hover (darker shade)" },
+      "accent-soft":    { "$value": "#FFE9D2", "$description": "Subtle apricot tint background" },
+
+      "ai-purple":      { "$value": "#7B5BFF", "$description": "AI accent — paired with apricot in brand gradient + Mirror/Map AI surfaces" },
+      "ai-soft":        { "$value": "#EFEAFF", "$description": "Subtle AI purple tint background" },
+
+      "text-primary":   { "$value": "#1C1611", "$description": "Primary text — warm near-black" },
+      "text-secondary": { "$value": "#5C5249", "$description": "Secondary text — warm mid-tone" },
+      "text-tertiary":  { "$value": "#8A7F73", "$description": "Tertiary / muted text" },
+
+      "border":         { "$value": "#EFE4D4", "$description": "Default border — warm cream" },
+      "border-soft":    { "$value": "#F5ECDE", "$description": "Subtle divider" }
+    }
+  },
+  "effort": {
+    "$type": "color",
+    "$description": "Effort palette — Oportunities-specific creator-intent classification (organic / sample / sponsor / paid). Used in dashboards, lists, badges.",
+    "organic":  { "$value": "#5A8E4F", "$description": "Organic content effort — green" },
+    "sample":   { "$value": "#5C82B0", "$description": "Sample / try-before-buy effort — blue" },
+    "sponsor":  { "$value": "#E68F47", "$description": "Sponsored content effort — apricot (same as accent)" },
+    "paid":     { "$value": "#968B7E", "$description": "Paid placement effort — neutral warm" }
+  },
+  "status": {
+    "$type": "color",
+    "$description": "Oportunities status scale — Studio-direction warm-tuned status indicators.",
+    "success":  { "$value": "#2F8A4F", "$description": "Success / approved" },
+    "warning":  { "$value": "#C6892C", "$description": "Warning / needs attention" },
+    "danger":   { "$value": "#B33A3A", "$description": "Error / blocked / rejected" },
+    "info":     { "$value": "#3B6EB5", "$description": "Informational / neutral signal" }
+  },
+  "font": {
+    "$type": "fontFamily",
+    "$description": "Oportunities typography — Geist for display (wordmark, headers), Inter for body, JetBrains Mono for code/numbers.",
+    "display": { "$value": "'Geist', 'Inter Tight', sans-serif", "$description": "Display / wordmark font — Geist at the heart of the Studio direction" },
+    "body":    { "$value": "'Inter', system-ui, sans-serif",     "$description": "Body / UI text font" },
+    "mono":    { "$value": "'JetBrains Mono', monospace",        "$description": "Monospace — numbers, code, data" }
+  },
+  "letter-spacing": {
+    "$type": "dimension",
+    "tight":   { "$value": "-0.04em", "$description": "Tight tracking — signature of the Oportunities wordmark (-0.04em)" }
+  },
+  "weight": {
+    "$type": "fontWeight",
+    "display":         { "$value": "600", "$description": "Display weight — Geist's brand weight" },
+    "body-default":    { "$value": "500", "$description": "Default body weight — Inter Medium for crisp legibility" }
+  },
+  "gradient": {
+    "$type": "other",
+    "$description": "Brand gradient — LOCKED. Apricot → AI purple, used in wordmark sweep animations and feature surfaces.",
+    "ai":        { "$value": "linear-gradient(135deg, #E68F47 0%, #7B5BFF 100%)", "$description": "Apricot → purple brand gradient (135deg)" },
+    "ai-sweep-anim": { "$value": "linear-gradient(90deg, #E68F47 0%, #7B5BFF 50%, #E68F47 100%)", "$description": "Sweep gradient used in the wordmark sweep animation — apricot → purple → apricot, animated via background-position" }
+  }
+}

--- a/packages/ui/component-status.json
+++ b/packages/ui/component-status.json
@@ -121,6 +121,12 @@
     "DiffOverlay": { "status": "beta", "since": "2.13.0", "notes": "Studio v0 Wave 4 — red/green pixel-diff layer over the Live pane; modes: highlight (mix-blend-multiply bands + legend) / swipe (vertical curtain) / side-by-side (1fr/1fr grid)." },
     "FlowContextSidebar": { "status": "beta", "since": "2.13.0", "notes": "Studio v0 Wave 4 — left-rail multi-step flow navigator implementing FlowSidebar SPEC v0 (PR #101); 260px expanded / 44px rail; status (default/in-progress/complete/skipped); roving tabindex; href|button chips; sticky Apply-to-all." },
     "RecentChangesPanel": { "status": "beta", "since": "2.13.0", "notes": "Studio v0 Wave 4 — right side-panel listing the last N git commits touching a file; 360px width via --amp-studio-theme-layout-history-panel-w; Esc closes." },
-    "ReplyAffordance": { "status": "beta", "since": "2.13.0", "notes": "Studio v0 Wave 4 — hover-revealed pill on a VariantCard that pre-fills the composer with @V<n> (Gen <m>): for chained iteration." }
+    "ReplyAffordance": { "status": "beta", "since": "2.13.0", "notes": "Studio v0 Wave 4 — hover-revealed pill on a VariantCard that pre-fills the composer with @V<n> (Gen <m>): for chained iteration." },
+    "Wordmark": { "status": "alpha", "since": "2.14.0", "notes": "Oportunities product primitive — the 'oportunities.' wordmark in Geist 600 with optional apricot→purple gradient-sweep animation; prefers-reduced-motion gated." },
+    "SignalDot": { "status": "alpha", "since": "2.14.0", "notes": "Oportunities product primitive — the apricot period as a standalone animated mark; supports pulse, conic-gradient fill, and 'live' presence rings; prefers-reduced-motion gated." },
+    "CreatorIntentCard": { "status": "alpha", "since": "2.14.0", "notes": "Oportunities product primitive — signature brand-side card surfacing a creator's declared intent + AI fit score + unlock CTA. Composes Card + Avatar + Badge." },
+    "BrandInterestCard": { "status": "alpha", "since": "2.14.0", "notes": "Oportunities product primitive — creator-side inbox card surfacing brand interest with reply/decline CTAs. Composes Card + Badge." },
+    "IntentFeed": { "status": "alpha", "since": "2.14.0", "notes": "Oportunities product primitive — container rendering a filter strip + responsive grid of CreatorIntentCards." },
+    "AppIconOportunities": { "status": "alpha", "since": "2.14.0", "notes": "Oportunities product primitive — the locked V1 'op.' app icon in an iOS squircle (border-radius 22.37%); light + dark variants." }
   }
 }

--- a/packages/ui/src/components/AppIconOportunities/AppIconOportunities.tsx
+++ b/packages/ui/src/components/AppIconOportunities/AppIconOportunities.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+/**
+ * AppIconOportunities — the locked V1 "op." app icon as a React component.
+ *
+ * Used in the marketing site, app store mockups, and anywhere the brand
+ * mark needs to appear as a square icon. The shape is an iOS-style
+ * squircle (border-radius ≈ 22.37% — the iOS continuous-corner radius).
+ *
+ * Layout: cream background, Geist 600 "op" in dark text, apricot period.
+ * In dark mode (`dark={true}`) the background flips to ink, the letters
+ * lighten, and the apricot period brightens to maintain contrast.
+ *
+ * Tokens consumed:
+ *   --amp-oportunities-theme-color-bg            (light surface)
+ *   --amp-oportunities-theme-color-bg-elev       (light contrast surface)
+ *   --amp-oportunities-theme-color-text-primary  (letters in light)
+ *   --amp-oportunities-theme-color-accent        (period)
+ *   --amp-oportunities-font-display              (Geist)
+ *   --amp-oportunities-letter-spacing-tight      (-0.04em)
+ *
+ * The icon ships with no motion — app icons are static by spec.
+ */
+
+export interface AppIconOportunitiesProps extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'children'> {
+  /** Pixel size of the (square) icon. Default 64. */
+  size?: number;
+  /** Render the dark variant (dark bg + lighter letters + brighter period). */
+  dark?: boolean;
+  /** Override the accessible label. Default 'Oportunities app icon'. */
+  label?: string;
+  className?: string;
+}
+
+// iOS continuous-corner squircle radius — 22.37% of the icon side.
+const SQUIRCLE_RADIUS_RATIO = 0.2237;
+
+// Light theme — cream bg + warm-ink letters + apricot period.
+const LIGHT_BG = '#FDF8F3';
+const LIGHT_LETTERS = '#1C1611';
+
+// Dark theme — deep ink bg + warm cream letters + brighter apricot period.
+const DARK_BG = '#15110D';
+const DARK_LETTERS = '#F4ECE0';
+const DARK_PERIOD = '#FFAE6B';
+
+export const AppIconOportunities = React.forwardRef<HTMLSpanElement, AppIconOportunitiesProps>(
+  ({ size = 64, dark = false, label = 'Oportunities app icon', className, style, ...rest }, ref) => {
+    const radius = Math.round(size * SQUIRCLE_RADIUS_RATIO);
+    // Tune internal type so "op." sits visually centred. Pull a hair to the left
+    // optically to balance the trailing period on the right.
+    const fontSize = Math.round(size * 0.46);
+
+    const bg = dark ? DARK_BG : 'var(--amp-oportunities-theme-color-bg, #FDF8F3)';
+    const letterColor = dark ? DARK_LETTERS : 'var(--amp-oportunities-theme-color-text-primary, #1C1611)';
+    const periodColor = dark ? DARK_PERIOD : 'var(--amp-oportunities-theme-color-accent, #E68F47)';
+
+    // Fallback static colours when CSS vars are not loaded, so the icon
+    // renders identically inside isolated marketing pages too.
+    const fallbackBg = dark ? DARK_BG : LIGHT_BG;
+    const fallbackLetter = dark ? DARK_LETTERS : LIGHT_LETTERS;
+
+    return (
+      <span
+        ref={ref}
+        role="img"
+        aria-label={label}
+        data-dark={dark}
+        className={cn('inline-flex items-center justify-center select-none overflow-hidden', className)}
+        style={{
+          width: size,
+          height: size,
+          borderRadius: radius,
+          background: bg,
+          backgroundColor: fallbackBg,
+          fontFamily: 'var(--amp-oportunities-font-display, "Geist", "Inter Tight", sans-serif)',
+          fontWeight: 'var(--amp-oportunities-weight-display, 600)',
+          letterSpacing: 'var(--amp-oportunities-letter-spacing-tight, -0.04em)',
+          color: fallbackLetter,
+          fontSize,
+          lineHeight: 1,
+          // Match the iOS app-icon subtle outline so cards on cream/white
+          // backgrounds don't disappear into the surface.
+          boxShadow: dark
+            ? '0 1px 0 rgba(255,255,255,0.04) inset'
+            : '0 0 0 1px rgba(28,22,17,0.06) inset',
+          ...style,
+        }}
+        {...rest}
+      >
+        <span aria-hidden="true" style={{ color: letterColor }}>
+          op
+        </span>
+        <span
+          aria-hidden="true"
+          data-testid="app-icon-period"
+          style={{ color: periodColor, marginLeft: Math.max(1, Math.round(size * 0.01)) }}
+        >
+          .
+        </span>
+      </span>
+    );
+  },
+);
+
+AppIconOportunities.displayName = 'AppIconOportunities';

--- a/packages/ui/src/components/AppIconOportunities/index.ts
+++ b/packages/ui/src/components/AppIconOportunities/index.ts
@@ -1,0 +1,2 @@
+export { AppIconOportunities } from './AppIconOportunities';
+export type { AppIconOportunitiesProps } from './AppIconOportunities';

--- a/packages/ui/src/components/BrandInterestCard/BrandInterestCard.tsx
+++ b/packages/ui/src/components/BrandInterestCard/BrandInterestCard.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+import { Card } from '../Card';
+import { Badge } from '../Badge';
+
+/**
+ * BrandInterestCard — creator-side equivalent of CreatorIntentCard.
+ *
+ * Rendered inside the creator app inbox to surface a brand that has
+ * expressed interest in partnering with the creator. Composes Card and
+ * Badge from the design system; introduces no new visual primitives.
+ *
+ * Theme tokens consumed:
+ *   --amp-oportunities-theme-color-accent       (Reply CTA)
+ *   --amp-oportunities-theme-color-text-primary
+ *   --amp-oportunities-theme-color-text-secondary
+ *   --amp-oportunities-theme-color-ai-purple    (AI fit pill)
+ *   --amp-oportunities-theme-color-ai-soft      (AI fit pill bg)
+ *   --amp-oportunities-theme-color-border       (Decline outline)
+ */
+
+export interface BrandInterestCardBrand {
+  name: string;
+  /** Logo URL — when omitted, renders an initial-based square fallback. */
+  logo?: string;
+  category: string;
+}
+
+export interface BrandInterestCardInterest {
+  /** Short headline (e.g. "Wants you for spring launch"). */
+  headline: string;
+  /** Personalised message from the brand. */
+  message: string;
+  /** 0–100 AI fit score for this interest. Optional. */
+  aiFitScore?: number;
+}
+
+export interface BrandInterestCardProps {
+  brand: BrandInterestCardBrand;
+  interest: BrandInterestCardInterest;
+  onReply?: () => void;
+  onDecline?: () => void;
+  /** Override the Reply CTA label. Default: 'Reply'. */
+  replyLabel?: string;
+  /** Override the Decline CTA label. Default: 'Decline'. */
+  declineLabel?: string;
+  className?: string;
+}
+
+function initialsFor(name: string): string {
+  return name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((p) => p.charAt(0))
+    .join('')
+    .toUpperCase();
+}
+
+export const BrandInterestCard = React.forwardRef<HTMLDivElement, BrandInterestCardProps>(
+  (
+    {
+      brand,
+      interest,
+      onReply,
+      onDecline,
+      replyLabel = 'Reply',
+      declineLabel = 'Decline',
+      className,
+    },
+    ref,
+  ) => {
+    return (
+      <Card
+        ref={ref as React.Ref<HTMLElement>}
+        variant="elevated"
+        padding="comfortable"
+        className={cn('flex flex-col gap-4', className)}
+      >
+        {/* Header — brand logo + name/category + AI fit pill */}
+        <div className="flex items-start gap-3">
+          <div
+            data-testid="brand-logo"
+            aria-hidden="true"
+            className="flex h-12 w-12 flex-shrink-0 items-center justify-center overflow-hidden rounded-[10px] text-[14px] font-semibold"
+            style={{
+              background: 'var(--amp-oportunities-theme-color-bg-soft)',
+              color: 'var(--amp-oportunities-theme-color-text-primary)',
+              border: '1px solid var(--amp-oportunities-theme-color-border)',
+            }}
+          >
+            {brand.logo ? (
+              <img src={brand.logo} alt={brand.name} className="h-full w-full object-cover" />
+            ) : (
+              <span>{initialsFor(brand.name)}</span>
+            )}
+          </div>
+
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span
+              className="truncate text-[15px] font-semibold"
+              style={{ color: 'var(--amp-oportunities-theme-color-text-primary)' }}
+            >
+              {brand.name}
+            </span>
+            <span
+              className="truncate text-[13px]"
+              style={{ color: 'var(--amp-oportunities-theme-color-text-secondary)' }}
+            >
+              {brand.category}
+            </span>
+          </div>
+
+          {typeof interest.aiFitScore === 'number' && (
+            <span
+              data-testid="ai-fit-pill"
+              className="flex-shrink-0 inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[12px] font-semibold"
+              style={{
+                background: 'var(--amp-oportunities-theme-color-ai-soft)',
+                color: 'var(--amp-oportunities-theme-color-ai-purple)',
+              }}
+            >
+              <span aria-hidden="true">●</span>
+              AI fit {Math.round(interest.aiFitScore)}
+            </span>
+          )}
+        </div>
+
+        {/* Interest block */}
+        <div className="flex flex-col gap-2">
+          <Badge variant="brand" size="sm">
+            {interest.headline}
+          </Badge>
+          <p
+            className="text-[14px] leading-snug"
+            style={{ color: 'var(--amp-oportunities-theme-color-text-primary)' }}
+          >
+            {interest.message}
+          </p>
+        </div>
+
+        {/* Footer — Reply (primary apricot) + Decline (ghost) */}
+        <div className="flex items-center justify-end gap-2 pt-1">
+          {onDecline && (
+            <button
+              type="button"
+              data-testid="decline-cta"
+              onClick={onDecline}
+              className={cn(
+                'inline-flex items-center justify-center rounded-full px-4 py-2 text-[13px] font-medium transition-colors duration-150',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+              )}
+              style={{
+                background: 'transparent',
+                color: 'var(--amp-oportunities-theme-color-text-secondary)',
+                border: '1px solid var(--amp-oportunities-theme-color-border)',
+              }}
+            >
+              {declineLabel}
+            </button>
+          )}
+          <button
+            type="button"
+            data-testid="reply-cta"
+            onClick={onReply}
+            className={cn(
+              'inline-flex items-center justify-center rounded-full px-4 py-2 text-[13px] font-semibold transition-colors duration-150',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+            )}
+            style={{
+              background: 'var(--amp-oportunities-theme-color-accent)',
+              color: '#FFFFFF',
+            }}
+          >
+            {replyLabel}
+          </button>
+        </div>
+      </Card>
+    );
+  },
+);
+
+BrandInterestCard.displayName = 'BrandInterestCard';

--- a/packages/ui/src/components/BrandInterestCard/index.ts
+++ b/packages/ui/src/components/BrandInterestCard/index.ts
@@ -1,0 +1,6 @@
+export { BrandInterestCard } from './BrandInterestCard';
+export type {
+  BrandInterestCardProps,
+  BrandInterestCardBrand,
+  BrandInterestCardInterest,
+} from './BrandInterestCard';

--- a/packages/ui/src/components/CreatorIntentCard/CreatorIntentCard.tsx
+++ b/packages/ui/src/components/CreatorIntentCard/CreatorIntentCard.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+import { Card } from '../Card';
+import { Avatar } from '../Avatar';
+import { Badge } from '../Badge';
+
+/**
+ * CreatorIntentCard — the signature Oportunities product card.
+ *
+ * Surfaces a creator's *declared intent* to a brand: who they are, what
+ * they want to partner on, the AI fit score, and an unlock CTA. Used in
+ * the brand-side "Intent Feed" (the core Oportunities discovery surface).
+ *
+ * This is a composed primitive — it stacks Card + Avatar + Badge from
+ * the design system. It does NOT introduce any new visual primitive.
+ *
+ * Theme tokens consumed:
+ *   --amp-oportunities-theme-color-accent       (apricot — unlock CTA)
+ *   --amp-oportunities-theme-color-ai-purple    (AI fit pill)
+ *   --amp-oportunities-theme-color-ai-soft      (AI fit pill bg)
+ *   --amp-oportunities-theme-color-text-primary
+ *   --amp-oportunities-theme-color-text-secondary
+ */
+
+export interface CreatorIntentCardCreator {
+  name: string;
+  handle: string;
+  niche: string;
+  /** Follower count — either a formatted string ("128K") or a raw number. */
+  followers: string | number;
+  /**
+   * Optional CSS gradient applied to the Avatar background when no `src`
+   * is supplied (e.g. `'linear-gradient(135deg, #E68F47, #7B5BFF)'`).
+   */
+  avatarGradient?: string;
+  /** Optional avatar image URL (wins over `avatarGradient`). */
+  avatarSrc?: string;
+}
+
+export interface CreatorIntentCardIntent {
+  /** Short summary line — the "I want to…" phrase. */
+  headline: string;
+  /** Human-readable date range. */
+  dateRange: string;
+  /** Tone descriptor (e.g. 'editorial · slow-luxe · brand-led'). */
+  vibe: string;
+  /** Optional list of partnership shapes the creator is open to. */
+  openTo?: string[];
+}
+
+export interface CreatorIntentCardProps {
+  creator: CreatorIntentCardCreator;
+  intent: CreatorIntentCardIntent;
+  /** 0–100 AI fit score. When set, shows the purple AI fit pill. */
+  aiFitScore?: number;
+  /** Click handler for the apricot "Unlock" CTA. */
+  onUnlock?: () => void;
+  /** Override the CTA label. Default: 'Unlock intent'. */
+  unlockLabel?: string;
+  /** Disable the CTA. */
+  disabled?: boolean;
+  className?: string;
+}
+
+function formatFollowers(value: string | number): string {
+  if (typeof value === 'string') return value;
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(value % 1000 === 0 ? 0 : 1)}K`;
+  return String(value);
+}
+
+function initialsFor(name: string): string {
+  return name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((p) => p.charAt(0))
+    .join('')
+    .toUpperCase();
+}
+
+export const CreatorIntentCard = React.forwardRef<HTMLDivElement, CreatorIntentCardProps>(
+  ({ creator, intent, aiFitScore, onUnlock, unlockLabel = 'Unlock intent', disabled = false, className }, ref) => {
+    const initials = initialsFor(creator.name);
+    const followers = formatFollowers(creator.followers);
+
+    return (
+      <Card
+        ref={ref as React.Ref<HTMLElement>}
+        variant="elevated"
+        padding="comfortable"
+        className={cn('flex flex-col gap-4', className)}
+      >
+        {/* Header — avatar + creator info + AI fit pill */}
+        <div className="flex items-start gap-3">
+          <div
+            className="flex-shrink-0"
+            style={
+              !creator.avatarSrc && creator.avatarGradient
+                ? ({
+                    // Inline-style wrapper lets us paint the gradient behind Avatar's initials
+                    borderRadius: '9999px',
+                    background: creator.avatarGradient,
+                    padding: 0,
+                    display: 'inline-flex',
+                  } as React.CSSProperties)
+                : undefined
+            }
+          >
+            <Avatar
+              src={creator.avatarSrc}
+              initials={initials}
+              size="lg"
+              alt={creator.name}
+              className={!creator.avatarSrc && creator.avatarGradient ? 'bg-transparent' : undefined}
+            />
+          </div>
+
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span
+              className="truncate text-[15px] font-semibold"
+              style={{ color: 'var(--amp-oportunities-theme-color-text-primary)' }}
+            >
+              {creator.name}
+            </span>
+            <span
+              className="truncate text-[13px]"
+              style={{ color: 'var(--amp-oportunities-theme-color-text-secondary)' }}
+            >
+              {creator.handle} · {creator.niche} · {followers}
+            </span>
+          </div>
+
+          {typeof aiFitScore === 'number' && (
+            <span
+              data-testid="ai-fit-pill"
+              className="flex-shrink-0 inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[12px] font-semibold"
+              style={{
+                background: 'var(--amp-oportunities-theme-color-ai-soft)',
+                color: 'var(--amp-oportunities-theme-color-ai-purple)',
+              }}
+            >
+              <span aria-hidden="true">●</span>
+              AI fit {Math.round(aiFitScore)}
+            </span>
+          )}
+        </div>
+
+        {/* Intent block */}
+        <div className="flex flex-col gap-2">
+          <p
+            className="text-[15px] leading-snug"
+            style={{ color: 'var(--amp-oportunities-theme-color-text-primary)' }}
+          >
+            {intent.headline}
+          </p>
+          <div
+            className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[12px]"
+            style={{ color: 'var(--amp-oportunities-theme-color-text-secondary)' }}
+          >
+            <span>{intent.dateRange}</span>
+            <span aria-hidden="true">·</span>
+            <span>{intent.vibe}</span>
+          </div>
+          {intent.openTo && intent.openTo.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 pt-1">
+              {intent.openTo.map((tag) => (
+                <Badge key={tag} variant="neutral" size="sm">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Footer — unlock CTA */}
+        <div className="flex items-center justify-end pt-1">
+          <button
+            type="button"
+            data-testid="unlock-cta"
+            onClick={onUnlock}
+            disabled={disabled}
+            className={cn(
+              'inline-flex items-center justify-center rounded-full px-4 py-2 text-[13px] font-semibold transition-all duration-150',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+            style={{
+              background: 'var(--amp-oportunities-theme-color-accent)',
+              color: '#FFFFFF',
+            }}
+          >
+            {unlockLabel}
+          </button>
+        </div>
+      </Card>
+    );
+  },
+);
+
+CreatorIntentCard.displayName = 'CreatorIntentCard';

--- a/packages/ui/src/components/CreatorIntentCard/index.ts
+++ b/packages/ui/src/components/CreatorIntentCard/index.ts
@@ -1,0 +1,6 @@
+export { CreatorIntentCard } from './CreatorIntentCard';
+export type {
+  CreatorIntentCardProps,
+  CreatorIntentCardCreator,
+  CreatorIntentCardIntent,
+} from './CreatorIntentCard';

--- a/packages/ui/src/components/IntentFeed/IntentFeed.tsx
+++ b/packages/ui/src/components/IntentFeed/IntentFeed.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+import { CreatorIntentCard, type CreatorIntentCardProps } from '../CreatorIntentCard';
+
+/**
+ * IntentFeed — container that renders a filter strip + a responsive grid
+ * of CreatorIntentCards. The brand-side discovery surface for
+ * Oportunities.
+ *
+ * Composition only — no new visual primitives are introduced. The filter
+ * strip is rendered as a row of pill buttons; selection state is
+ * controlled via `activeFilters`.
+ *
+ * Theme tokens consumed:
+ *   --amp-oportunities-theme-color-text-primary
+ *   --amp-oportunities-theme-color-text-secondary
+ *   --amp-oportunities-theme-color-accent       (active filter chip)
+ *   --amp-oportunities-theme-color-accent-soft  (active filter bg)
+ *   --amp-oportunities-theme-color-border
+ *   --amp-oportunities-theme-color-bg-elev
+ */
+
+export interface IntentFeedFilters {
+  category?: string[];
+  effort?: string[];
+  freshness?: string[];
+}
+
+export interface IntentFeedFilterChange {
+  group: keyof IntentFeedFilters;
+  value: string;
+  /** True if newly selected, false if deselected. */
+  selected: boolean;
+}
+
+export interface IntentFeedProps {
+  cards: CreatorIntentCardProps[];
+  /** Filter options surfaced as pill rows. Each group is rendered as a labelled row. */
+  filters?: IntentFeedFilters;
+  /** Currently active filter selections per group. */
+  activeFilters?: IntentFeedFilters;
+  /** Called whenever the user toggles a filter chip. */
+  onFilter?: (change: IntentFeedFilterChange) => void;
+  /** Forwarded to every card's `onUnlock`. The card index is passed so consumers can route. */
+  onUnlock?: (cardIndex: number) => void;
+  /** Optional heading rendered above the filter strip. */
+  heading?: React.ReactNode;
+  /** Empty-state node rendered when `cards.length === 0`. */
+  emptyState?: React.ReactNode;
+  className?: string;
+}
+
+const FILTER_GROUP_LABELS: Record<keyof IntentFeedFilters, string> = {
+  category: 'Category',
+  effort: 'Effort',
+  freshness: 'Freshness',
+};
+
+function isActive(active: IntentFeedFilters | undefined, group: keyof IntentFeedFilters, value: string): boolean {
+  return Boolean(active?.[group]?.includes(value));
+}
+
+export const IntentFeed = React.forwardRef<HTMLDivElement, IntentFeedProps>(
+  ({ cards, filters, activeFilters, onFilter, onUnlock, heading, emptyState, className }, ref) => {
+    const filterGroups = (Object.keys(FILTER_GROUP_LABELS) as Array<keyof IntentFeedFilters>).filter(
+      (group) => (filters?.[group]?.length ?? 0) > 0,
+    );
+
+    return (
+      <div ref={ref} className={cn('flex flex-col gap-6', className)}>
+        {heading && (
+          <div
+            className="text-[20px] font-semibold"
+            style={{
+              color: 'var(--amp-oportunities-theme-color-text-primary)',
+              fontFamily: 'var(--amp-oportunities-font-display)',
+              letterSpacing: 'var(--amp-oportunities-letter-spacing-tight, -0.04em)',
+            }}
+          >
+            {heading}
+          </div>
+        )}
+
+        {/* Filter strip */}
+        {filterGroups.length > 0 && (
+          <div
+            data-testid="intent-feed-filters"
+            className="flex flex-col gap-2 rounded-[12px] p-3"
+            style={{
+              background: 'var(--amp-oportunities-theme-color-bg-elev)',
+              border: '1px solid var(--amp-oportunities-theme-color-border)',
+            }}
+          >
+            {filterGroups.map((group) => (
+              <div key={group} className="flex flex-wrap items-center gap-2">
+                <span
+                  className="text-[12px] font-semibold uppercase tracking-wide"
+                  style={{ color: 'var(--amp-oportunities-theme-color-text-secondary)' }}
+                >
+                  {FILTER_GROUP_LABELS[group]}
+                </span>
+                {filters?.[group]?.map((value) => {
+                  const active = isActive(activeFilters, group, value);
+                  return (
+                    <button
+                      key={value}
+                      type="button"
+                      data-testid={`filter-${group}-${value}`}
+                      data-active={active}
+                      onClick={() => onFilter?.({ group, value, selected: !active })}
+                      className={cn(
+                        'inline-flex items-center rounded-full px-3 py-1 text-[12px] font-medium transition-colors duration-150',
+                        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+                      )}
+                      style={
+                        active
+                          ? {
+                              background: 'var(--amp-oportunities-theme-color-accent-soft)',
+                              color: 'var(--amp-oportunities-theme-color-accent)',
+                              border: '1px solid var(--amp-oportunities-theme-color-accent)',
+                            }
+                          : {
+                              background: 'transparent',
+                              color: 'var(--amp-oportunities-theme-color-text-secondary)',
+                              border: '1px solid var(--amp-oportunities-theme-color-border)',
+                            }
+                      }
+                    >
+                      {value}
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Card grid */}
+        {cards.length === 0 ? (
+          <div data-testid="intent-feed-empty">{emptyState}</div>
+        ) : (
+          <div
+            data-testid="intent-feed-grid"
+            className="grid gap-4"
+            style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))' }}
+          >
+            {cards.map((card, idx) => (
+              <CreatorIntentCard
+                key={`${card.creator.handle}-${idx}`}
+                {...card}
+                onUnlock={() => {
+                  card.onUnlock?.();
+                  onUnlock?.(idx);
+                }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+IntentFeed.displayName = 'IntentFeed';

--- a/packages/ui/src/components/IntentFeed/index.ts
+++ b/packages/ui/src/components/IntentFeed/index.ts
@@ -1,0 +1,2 @@
+export { IntentFeed } from './IntentFeed';
+export type { IntentFeedProps, IntentFeedFilters, IntentFeedFilterChange } from './IntentFeed';

--- a/packages/ui/src/components/SignalDot/SignalDot.tsx
+++ b/packages/ui/src/components/SignalDot/SignalDot.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+/**
+ * SignalDot — the Oportunities apricot period as a standalone animated mark.
+ *
+ * This is the "moment" of the brand: the wordmark's period lifted out as
+ * a reusable signal. Use it as:
+ *   - a brand bullet/avatar accent
+ *   - a "live" indicator (with pulse rings)
+ *   - a section divider mark
+ *
+ * Props:
+ *   - `size`     — pixel diameter (default 16)
+ *   - `pulse`    — subtle scale-pulse animation
+ *   - `gradient` — apricot→purple conic fill instead of solid apricot
+ *   - `live`     — emit two expanding pulse rings (presence indicator)
+ *
+ * Tokens consumed:
+ *   --amp-oportunities-theme-color-accent     (apricot fill)
+ *   --amp-oportunities-theme-color-ai-purple  (gradient endpoint)
+ *
+ * All motion (pulse + live rings) is gated by `prefers-reduced-motion`.
+ */
+
+export interface SignalDotProps extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'children'> {
+  /** Pixel diameter of the dot. Default 16. */
+  size?: number;
+  /** Apply a subtle scale pulse to the dot itself. */
+  pulse?: boolean;
+  /** Use an apricot→purple conic gradient instead of solid apricot fill. */
+  gradient?: boolean;
+  /** Render two expanding pulse rings around the dot (live/presence indicator). */
+  live?: boolean;
+  /** Accessible label. Default 'signal'. Live mode forces 'live' suffix. */
+  label?: string;
+  className?: string;
+}
+
+const STYLE_ID = 'amp-signal-dot-keyframes';
+const styleSheet = `
+@keyframes amp-signal-dot-pulse {
+  0%   { transform: scale(1);    opacity: 1; }
+  50%  { transform: scale(1.12); opacity: 0.85; }
+  100% { transform: scale(1);    opacity: 1; }
+}
+@keyframes amp-signal-dot-ring {
+  0%   { transform: scale(0.6); opacity: 0.55; }
+  100% { transform: scale(2.4); opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .amp-signal-dot-pulse,
+  .amp-signal-dot-ring { animation: none !important; }
+  .amp-signal-dot-ring { opacity: 0 !important; }
+}
+`;
+
+function useInjectedKeyframes() {
+  React.useEffect(() => {
+    if (typeof document === 'undefined') return;
+    if (document.getElementById(STYLE_ID)) return;
+    const el = document.createElement('style');
+    el.id = STYLE_ID;
+    el.textContent = styleSheet;
+    document.head.appendChild(el);
+  }, []);
+}
+
+export const SignalDot = React.forwardRef<HTMLSpanElement, SignalDotProps>(
+  ({ size = 16, pulse = false, gradient = false, live = false, label, className, style, ...rest }, ref) => {
+    useInjectedKeyframes();
+
+    const fillStyle: React.CSSProperties = gradient
+      ? {
+          background:
+            'conic-gradient(from 210deg, var(--amp-oportunities-theme-color-accent) 0%, var(--amp-oportunities-theme-color-ai-purple) 60%, var(--amp-oportunities-theme-color-accent) 100%)',
+        }
+      : { background: 'var(--amp-oportunities-theme-color-accent)' };
+
+    const ariaLabel = label ?? (live ? 'live signal' : 'signal');
+
+    return (
+      <span
+        ref={ref}
+        role="img"
+        aria-label={ariaLabel}
+        className={cn('relative inline-flex items-center justify-center', className)}
+        style={{
+          width: size,
+          height: size,
+          ...style,
+        }}
+        {...rest}
+      >
+        {live && (
+          <>
+            <span
+              aria-hidden="true"
+              data-testid="signal-dot-ring-1"
+              className="amp-signal-dot-ring absolute inset-0 rounded-full [animation:amp-signal-dot-ring_1.8s_ease-out_infinite]"
+              style={{ background: 'var(--amp-oportunities-theme-color-accent)' }}
+            />
+            <span
+              aria-hidden="true"
+              data-testid="signal-dot-ring-2"
+              className="amp-signal-dot-ring absolute inset-0 rounded-full [animation:amp-signal-dot-ring_1.8s_ease-out_0.9s_infinite]"
+              style={{ background: 'var(--amp-oportunities-theme-color-accent)' }}
+            />
+          </>
+        )}
+        <span
+          aria-hidden="true"
+          data-testid="signal-dot-core"
+          className={cn(
+            'relative inline-block rounded-full',
+            pulse && 'amp-signal-dot-pulse [animation:amp-signal-dot-pulse_1.6s_ease-in-out_infinite]',
+          )}
+          style={{
+            width: size,
+            height: size,
+            ...fillStyle,
+          }}
+        />
+      </span>
+    );
+  },
+);
+
+SignalDot.displayName = 'SignalDot';

--- a/packages/ui/src/components/SignalDot/index.ts
+++ b/packages/ui/src/components/SignalDot/index.ts
@@ -1,0 +1,2 @@
+export { SignalDot } from './SignalDot';
+export type { SignalDotProps } from './SignalDot';

--- a/packages/ui/src/components/Wordmark/Wordmark.tsx
+++ b/packages/ui/src/components/Wordmark/Wordmark.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../lib/cn';
+
+/**
+ * Wordmark — the Oportunities wordmark ("oportunities.") rendered as a
+ * brand-grade typographic mark.
+ *
+ * - Geist 600 with -0.04em tracking (the locked Oportunities signature)
+ * - The trailing period is always apricot — the brand's defining moment
+ * - `animated` enables a slow gradient sweep across the letters using
+ *   `-webkit-background-clip: text` + animated background-position. The
+ *   apricot period remains solid (it's the focal point of the brand).
+ * - `monochrome` collapses the sweep to solid text-primary — useful for
+ *   small-screen / print / footer renders
+ * - All motion is gated by `prefers-reduced-motion`
+ *
+ * Tokens consumed from `tokens-oportunities`:
+ *   --amp-oportunities-font-display
+ *   --amp-oportunities-letter-spacing-tight
+ *   --amp-oportunities-weight-display
+ *   --amp-oportunities-theme-color-accent          (apricot period)
+ *   --amp-oportunities-theme-color-text-primary    (monochrome fill)
+ *   --amp-oportunities-gradient-ai-sweep-anim      (sweep)
+ */
+
+export type WordmarkSize = 'sm' | 'md' | 'lg' | 'xl';
+
+export interface WordmarkProps extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'children'> {
+  /** Visual size. Default `md`. */
+  size?: WordmarkSize;
+  /**
+   * When true, animates a slow apricot→purple→apricot sweep across the
+   * letters via `background-clip: text`. The apricot period remains
+   * solid. Disabled automatically under `prefers-reduced-motion`.
+   */
+  animated?: boolean;
+  /**
+   * When true, render the letters in solid `text-primary` and drop the
+   * gradient (the apricot period remains). Wins over `animated` if both
+   * are set.
+   */
+  monochrome?: boolean;
+  className?: string;
+}
+
+const sizeClasses: Record<WordmarkSize, string> = {
+  sm: 'text-[18px] leading-none',
+  md: 'text-[28px] leading-none',
+  lg: 'text-[44px] leading-[1.05]',
+  xl: 'text-[72px] leading-[1.02]',
+};
+
+const STYLE_ID = 'amp-wordmark-keyframes';
+const styleSheet = `
+@keyframes amp-wordmark-sweep {
+  0%   { background-position: 0% 50%; }
+  100% { background-position: 200% 50%; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .amp-wordmark-animated {
+    animation: none !important;
+    background-position: 0% 50% !important;
+  }
+}
+`;
+
+function useInjectedKeyframes() {
+  React.useEffect(() => {
+    if (typeof document === 'undefined') return;
+    if (document.getElementById(STYLE_ID)) return;
+    const el = document.createElement('style');
+    el.id = STYLE_ID;
+    el.textContent = styleSheet;
+    document.head.appendChild(el);
+  }, []);
+}
+
+export const Wordmark = React.forwardRef<HTMLSpanElement, WordmarkProps>(
+  ({ size = 'md', animated = false, monochrome = false, className, ...rest }, ref) => {
+    useInjectedKeyframes();
+
+    const useGradient = animated && !monochrome;
+
+    const lettersStyle: React.CSSProperties = useGradient
+      ? {
+          backgroundImage: 'var(--amp-oportunities-gradient-ai-sweep-anim)',
+          backgroundSize: '200% 100%',
+          backgroundClip: 'text',
+          WebkitBackgroundClip: 'text',
+          WebkitTextFillColor: 'transparent',
+          color: 'transparent',
+        }
+      : {
+          color: 'var(--amp-oportunities-theme-color-text-primary)',
+        };
+
+    return (
+      <span
+        ref={ref}
+        aria-label="oportunities"
+        className={cn('op-wordmark inline-flex items-baseline', sizeClasses[size], className)}
+        style={{
+          fontFamily: 'var(--amp-oportunities-font-display)',
+          fontWeight: 'var(--amp-oportunities-weight-display, 600)',
+          letterSpacing: 'var(--amp-oportunities-letter-spacing-tight, -0.04em)',
+        }}
+        {...rest}
+      >
+        <span
+          aria-hidden="true"
+          data-testid="wordmark-letters"
+          className={cn(useGradient && 'amp-wordmark-animated [animation:amp-wordmark-sweep_6s_linear_infinite]')}
+          style={lettersStyle}
+        >
+          oportunities
+        </span>
+        <span
+          aria-hidden="true"
+          data-testid="wordmark-period"
+          className="op-period"
+          style={{ color: 'var(--amp-oportunities-theme-color-accent)' }}
+        >
+          .
+        </span>
+      </span>
+    );
+  },
+);
+
+Wordmark.displayName = 'Wordmark';

--- a/packages/ui/src/components/Wordmark/index.ts
+++ b/packages/ui/src/components/Wordmark/index.ts
@@ -1,0 +1,2 @@
+export { Wordmark } from './Wordmark';
+export type { WordmarkProps, WordmarkSize } from './Wordmark';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -654,3 +654,45 @@ export type {
   ReplyAffordanceProps,
   VariantRef,
 } from './components/ReplyAffordance';
+
+// ─── Oportunities product primitives (2.14.0) ────────────────────────
+// Six composed components specific to the Oportunities (creator-intent)
+// product line. All compose existing primitives (Card, Avatar, Badge);
+// none introduce new visual primitives. Consume the `tokens-oportunities`
+// theme surface via `--amp-oportunities-*` CSS vars.
+
+// Wordmark — the "oportunities." wordmark with optional gradient sweep
+export { Wordmark } from './components/Wordmark';
+export type { WordmarkProps, WordmarkSize } from './components/Wordmark';
+
+// SignalDot — the apricot period as a standalone animated mark
+export { SignalDot } from './components/SignalDot';
+export type { SignalDotProps } from './components/SignalDot';
+
+// CreatorIntentCard — signature product card (brand-side intent feed)
+export { CreatorIntentCard } from './components/CreatorIntentCard';
+export type {
+  CreatorIntentCardProps,
+  CreatorIntentCardCreator,
+  CreatorIntentCardIntent,
+} from './components/CreatorIntentCard';
+
+// BrandInterestCard — creator-side inbox card
+export { BrandInterestCard } from './components/BrandInterestCard';
+export type {
+  BrandInterestCardProps,
+  BrandInterestCardBrand,
+  BrandInterestCardInterest,
+} from './components/BrandInterestCard';
+
+// IntentFeed — filter strip + grid of CreatorIntentCards
+export { IntentFeed } from './components/IntentFeed';
+export type {
+  IntentFeedProps,
+  IntentFeedFilters,
+  IntentFeedFilterChange,
+} from './components/IntentFeed';
+
+// AppIconOportunities — the locked "op." app icon as a React component
+export { AppIconOportunities } from './components/AppIconOportunities';
+export type { AppIconOportunitiesProps } from './components/AppIconOportunities';

--- a/scripts/build-tokens.js
+++ b/scripts/build-tokens.js
@@ -23,7 +23,7 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
 
-const VALID_PACKAGES = ['foundation', 'brand', 'atmosphere', 'creator', 'studio'];
+const VALID_PACKAGES = ['foundation', 'brand', 'atmosphere', 'creator', 'studio', 'oportunities'];
 const pkg = process.argv[2];
 if (!pkg || !VALID_PACKAGES.includes(pkg)) {
   console.error(`Usage: node scripts/build-tokens.js <${VALID_PACKAGES.join('|')}>`);


### PR DESCRIPTION
# feat: add Oportunities theme + Studio brand to design system

This PR introduces the **Oportunities** product theme (Studio direction) to the federated design system, alongside the existing brand/creator/atmosphere/studio/marketing themes.

## What's added

### 4 new packages
- **`@amplify-ai/tokens-oportunities@1.0.0`** — Studio-direction tokens (apricot palette, Geist + Inter + JBM, light + dark)
- **`@amplify-ai/brand-oportunities@1.0.0`** — brand asset library (logo SVGs, app icons, favicons, social templates, business cards, email signature, full `BRAND-DECISIONS.md`)

### 6 new components in `@amplify-ai/ui` (will release as 2.12.0)
- `Wordmark` — Oportunities wordmark with optional gradient-sweep animation
- `SignalDot` — the apricot period as a standalone animated mark
- `CreatorIntentCard` — signature product card (composes `Card` + `Avatar` + `Badge`)
- `BrandInterestCard` — creator-side inbox card
- `IntentFeed` — filterable container
- `AppIconOportunities` — the locked "op." app icon as a React component

All composed from existing primitives — no new primitives introduced.

### Storybook
- Oportunities theme registered in theme switcher
- 8 brand guidelines docs: Brand overview, Logo, Color, Typography, Components, Voice, AppIcon, Favicon

## What's NOT in this PR (Phase 2)
Marketing site templates, email transactional/marketing templates, push notif spec, WhatsApp message templates, full social templates, slide deck cover, Slack notification format. These ship in a follow-up PR (`feat/oportunities-templates`).

## Locked brand decisions (founder-approved)
Documented in `packages/brand-oportunities/BRAND-DECISIONS.md` — full record of:
- Wordmark spec
- Signature animation
- App icon + favicon (light + dark)
- Voice register
- Application contexts
- Sizing scale

## Test plan
- [ ] `npm install` from clean state
- [ ] `npm run build` succeeds for all workspaces
- [ ] `npm run storybook` launches; Oportunities theme selectable; all 8 docs render
- [ ] `npm run test -w packages/ui` passes
- [ ] Pixel drift detection picks up the new package within 6 hours of merge
- [ ] Engineer can import + use components in a sample product

## Migration / breaking changes
None. All additions are net-new. No existing API changed.

Generated with Claude Code
