### PR TITLE
feat(tokens-creator): implement palette semantic alias module

### DIFF
--- a/packages/tokens-creator/build.js
+++ b/packages/tokens-creator/build.js
@@ -1,7 +1,13 @@
-// Delegates to shared build script
+// Delegates to shared build script.
+// Runs the palette-validator first so a missing-token reference fails
+// the build early with a clear pointer (instead of failing later in
+// downstream consumer apps with a runtime missing-color).
 import { execSync } from 'child_process';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-const root = join(dirname(fileURLToPath(import.meta.url)), '../..');
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '../..');
+
+execSync(`node ${join(__dirname, 'scripts/validate-palette.js')}`, { stdio: 'inherit' });
 execSync(`node ${join(root, 'scripts/build-tokens.js')} creator`, { stdio: 'inherit' });

--- a/packages/tokens-creator/package.json
+++ b/packages/tokens-creator/package.json
@@ -10,6 +10,10 @@
     "./json": "./dist/tokens.json",
     "./js": "./dist/tokens.js",
     "./react-native": "./dist/tokens.native.js",
+    "./palette": {
+      "types": "./palette.d.ts",
+      "default": "./palette.js"
+    },
     "./icons": "./dist/icons/manifest.json",
     "./icons/essentials": "./dist/icons/essentials.json",
     "./icons/types": "./dist/icons/manifest.d.ts",
@@ -18,6 +22,8 @@
   "scripts": {
     "build": "node build.js && npx tsx scripts/build-icons.ts",
     "build:icons": "npx tsx scripts/build-icons.ts",
+    "validate:palette": "node scripts/validate-palette.js",
+    "test": "vitest run",
     "sync-check": "node scripts/sync-check.js"
   },
   "dependencies": {
@@ -30,6 +36,8 @@
     "dist/",
     "tokens/",
     "scripts/",
-    "icons/"
+    "icons/",
+    "palette.js",
+    "palette.d.ts"
   ]
 }

--- a/packages/tokens-creator/palette.d.ts
+++ b/packages/tokens-creator/palette.d.ts
@@ -1,0 +1,105 @@
+/**
+ * Type declarations for the palette module.
+ *
+ * Provides autocomplete + structural typing for consumers (BFF handlers).
+ * The branded `SduiToken` type marks string values that are valid SDUI
+ * token names — preventing accidental concatenation with arbitrary strings.
+ */
+
+/** Branded string type — valid SDUI token name. */
+export type SduiToken = string & { readonly __brand: "SduiToken" };
+
+export interface PaletteText {
+  readonly strong: SduiToken;
+  readonly medium: SduiToken;
+  readonly weak: SduiToken;
+  readonly subtle: SduiToken;
+  readonly inverse: SduiToken;
+}
+
+export interface PaletteSurface {
+  readonly base: SduiToken;
+  readonly raised: SduiToken;
+  readonly border: SduiToken;
+  readonly transparent: SduiToken;
+}
+
+export interface PaletteBrand {
+  readonly primary: SduiToken;
+  readonly primaryWeak: SduiToken;
+}
+
+export interface PaletteStatus {
+  readonly positive: SduiToken;
+  readonly positiveWeak: SduiToken;
+  readonly notice: SduiToken;
+  readonly noticeWeak: SduiToken;
+  readonly negative: SduiToken;
+  readonly negativeWeak: SduiToken;
+}
+
+export interface PaletteFont {
+  readonly xs: SduiToken;
+  readonly sm: SduiToken;
+  readonly md: SduiToken;
+  readonly lg: SduiToken;
+  readonly xl: SduiToken;
+  readonly xxl: SduiToken;
+  readonly xxxl: SduiToken;
+}
+
+export interface PaletteWeight {
+  readonly regular: SduiToken;
+  readonly medium: SduiToken;
+  readonly semibold: SduiToken;
+  readonly bold: SduiToken;
+}
+
+export interface PaletteSpacing {
+  readonly xs: SduiToken;
+  readonly sm: SduiToken;
+  readonly md: SduiToken;
+  readonly lg: SduiToken;
+  readonly xl: SduiToken;
+  readonly xxl: SduiToken;
+  readonly xxxl: SduiToken;
+}
+
+export interface PaletteRadius {
+  readonly none: SduiToken;
+  readonly xs: SduiToken;
+  readonly sm: SduiToken;
+  readonly md: SduiToken;
+  readonly lg: SduiToken;
+  readonly xl: SduiToken;
+  readonly full: SduiToken;
+}
+
+export interface PaletteIcon {
+  readonly sm: SduiToken;
+  readonly md: SduiToken;
+  readonly lg: SduiToken;
+  readonly xl: SduiToken;
+}
+
+export interface PaletteBorderWidth {
+  readonly none: SduiToken;
+  readonly thin: SduiToken;
+  readonly medium: SduiToken;
+  readonly thick: SduiToken;
+}
+
+export interface Palette {
+  readonly text: PaletteText;
+  readonly surface: PaletteSurface;
+  readonly brand: PaletteBrand;
+  readonly status: PaletteStatus;
+  readonly font: PaletteFont;
+  readonly weight: PaletteWeight;
+  readonly spacing: PaletteSpacing;
+  readonly radius: PaletteRadius;
+  readonly icon: PaletteIcon;
+  readonly borderWidth: PaletteBorderWidth;
+}
+
+export declare const palette: Palette;

--- a/packages/tokens-creator/palette.js
+++ b/packages/tokens-creator/palette.js
@@ -1,0 +1,104 @@
+/**
+ * Palette — semantic token alias module.
+ *
+ * Maps engineer-friendly semantic names (e.g. `palette.text.strong`) to
+ * canonical SDUI token names (e.g. `"sdui.color.neutral-strong"`). The
+ * token NAME is theme-invariant; only its VALUE differs per theme, and
+ * theme resolution happens client-side in the renderer at paint time.
+ *
+ * Consumers (BFF handlers, server-driven UI emitters):
+ *   import { palette } from "@amplify-ai/tokens-creator/palette";
+ *   sdui.pageHeader({ title: { text: "Explore", color: palette.text.strong } });
+ *
+ * Maintenance:
+ *   - Every value here MUST resolve to a token defined in EVERY theme JSON
+ *     (tokens/theme-light.json + tokens/theme-dark.json). The build-time
+ *     invariant in scripts/validate-palette.js enforces this; the build
+ *     fails if any palette entry references a non-existent token.
+ *   - When adding a new alias, first add the underlying token to the theme
+ *     JSONs (in BOTH light and dark), then add the alias here.
+ *
+ * Design rationale: see PALETTE-DESIGN.md in this package.
+ */
+
+export const palette = Object.freeze({
+  text: Object.freeze({
+    strong: "sdui.color.neutral-strong",
+    medium: "sdui.color.neutral-medium",
+    weak: "sdui.color.neutral-weak",
+    subtle: "sdui.color.neutral-subtle",
+    inverse: "sdui.color.neutral-inverse",
+  }),
+
+  surface: Object.freeze({
+    base: "sdui.color.offset-weak",
+    raised: "sdui.color.offset-medium",
+    border: "sdui.color.offset-strong",
+    transparent: "sdui.color.transparent",
+  }),
+
+  brand: Object.freeze({
+    primary: "sdui.color.primary",
+    primaryWeak: "sdui.color.primary-weak",
+  }),
+
+  status: Object.freeze({
+    positive: "sdui.color.positive",
+    positiveWeak: "sdui.color.positive-weak",
+    notice: "sdui.color.notice",
+    noticeWeak: "sdui.color.notice-weak",
+    negative: "sdui.color.negative",
+    negativeWeak: "sdui.color.negative-weak",
+  }),
+
+  font: Object.freeze({
+    xs: "sdui.font-size.xs",
+    sm: "sdui.font-size.sm",
+    md: "sdui.font-size.md",
+    lg: "sdui.font-size.lg",
+    xl: "sdui.font-size.xl",
+    xxl: "sdui.font-size.xxl",
+    xxxl: "sdui.font-size.xxxl",
+  }),
+
+  weight: Object.freeze({
+    regular: "sdui.font-weight.regular",
+    medium: "sdui.font-weight.medium",
+    semibold: "sdui.font-weight.semibold",
+    bold: "sdui.font-weight.bold",
+  }),
+
+  spacing: Object.freeze({
+    xs: "sdui.spacing.xs",
+    sm: "sdui.spacing.sm",
+    md: "sdui.spacing.md",
+    lg: "sdui.spacing.lg",
+    xl: "sdui.spacing.xl",
+    xxl: "sdui.spacing.xxl",
+    xxxl: "sdui.spacing.xxxl",
+  }),
+
+  radius: Object.freeze({
+    none: "sdui.radius.none",
+    xs: "sdui.radius.xs",
+    sm: "sdui.radius.sm",
+    md: "sdui.radius.md",
+    lg: "sdui.radius.lg",
+    xl: "sdui.radius.xl",
+    full: "sdui.radius.full",
+  }),
+
+  icon: Object.freeze({
+    sm: "sdui.icon-size.sm",
+    md: "sdui.icon-size.md",
+    lg: "sdui.icon-size.lg",
+    xl: "sdui.icon-size.xl",
+  }),
+
+  borderWidth: Object.freeze({
+    none: "sdui.border-width.none",
+    thin: "sdui.border-width.thin",
+    medium: "sdui.border-width.medium",
+    thick: "sdui.border-width.thick",
+  }),
+});

--- a/packages/tokens-creator/palette.test.js
+++ b/packages/tokens-creator/palette.test.js
@@ -1,0 +1,108 @@
+/**
+ * Tests for the palette module.
+ *
+ * The build-time validator (scripts/validate-palette.js) is the
+ * authoritative check that every palette entry resolves in every theme.
+ * These tests catch shape + format regressions separately:
+ *   - Every leaf value matches the canonical SDUI token regex
+ *   - Snapshot of the palette object shape (prevents accidental
+ *     rename / removal of a public entry — a breaking change for
+ *     downstream BFF consumers)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { palette } from './palette.js';
+
+const SDUI_TOKEN_REGEX = /^sdui\.[a-z-]+\.[a-z0-9-]+$/;
+
+describe('palette — format', () => {
+  function collectLeaves(obj, path = []) {
+    const leaves = [];
+    for (const [key, value] of Object.entries(obj)) {
+      const p = [...path, key];
+      if (typeof value === 'string') {
+        leaves.push({ path: p.join('.'), value });
+      } else if (value && typeof value === 'object') {
+        leaves.push(...collectLeaves(value, p));
+      }
+    }
+    return leaves;
+  }
+
+  it('every leaf value matches the canonical SDUI token regex', () => {
+    const leaves = collectLeaves(palette);
+    expect(leaves.length).toBeGreaterThan(0);
+    for (const { path, value } of leaves) {
+      expect(value, `palette.${path}`).toMatch(SDUI_TOKEN_REGEX);
+    }
+  });
+
+  it('all six SDUI token families are represented', () => {
+    const leaves = collectLeaves(palette);
+    const families = new Set(leaves.map((l) => l.value.split('.')[1]));
+    expect(families).toContain('color');
+    expect(families).toContain('font-size');
+    expect(families).toContain('font-weight');
+    expect(families).toContain('spacing');
+    expect(families).toContain('radius');
+    expect(families).toContain('icon-size');
+    expect(families).toContain('border-width');
+  });
+});
+
+describe('palette — shape stability (snapshot)', () => {
+  it('top-level keys are stable', () => {
+    expect(Object.keys(palette).sort()).toEqual(
+      [
+        'borderWidth',
+        'brand',
+        'font',
+        'icon',
+        'radius',
+        'spacing',
+        'status',
+        'surface',
+        'text',
+        'weight',
+      ].sort(),
+    );
+  });
+
+  it('text group has expected keys', () => {
+    expect(Object.keys(palette.text).sort()).toEqual(
+      ['inverse', 'medium', 'strong', 'subtle', 'weak'].sort(),
+    );
+  });
+
+  it('font + spacing + radius + icon + borderWidth have expected size shorthand', () => {
+    // Smoke-check that the shorthand scales are intact
+    expect(palette.font.md).toBeDefined();
+    expect(palette.spacing.md).toBeDefined();
+    expect(palette.radius.md).toBeDefined();
+    expect(palette.icon.md).toBeDefined();
+    expect(palette.borderWidth.thin).toBeDefined();
+  });
+
+  it('status group covers positive / notice / negative + weak variants', () => {
+    expect(palette.status.positive).toBeDefined();
+    expect(palette.status.positiveWeak).toBeDefined();
+    expect(palette.status.notice).toBeDefined();
+    expect(palette.status.noticeWeak).toBeDefined();
+    expect(palette.status.negative).toBeDefined();
+    expect(palette.status.negativeWeak).toBeDefined();
+  });
+});
+
+describe('palette — immutability', () => {
+  it('top-level object is frozen', () => {
+    expect(Object.isFrozen(palette)).toBe(true);
+  });
+
+  it('nested groups are frozen', () => {
+    expect(Object.isFrozen(palette.text)).toBe(true);
+    expect(Object.isFrozen(palette.surface)).toBe(true);
+    expect(Object.isFrozen(palette.status)).toBe(true);
+    expect(Object.isFrozen(palette.font)).toBe(true);
+    expect(Object.isFrozen(palette.spacing)).toBe(true);
+  });
+});

--- a/packages/tokens-creator/scripts/validate-palette.js
+++ b/packages/tokens-creator/scripts/validate-palette.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Build-time invariant: every palette entry must resolve to a real
+ * token in EVERY theme JSON. Build fails on any missing reference.
+ *
+ * Catches the failure mode of a runtime missing-color on the creator's
+ * phone by surfacing it at design-system build time instead — the
+ * BFF emits palette.text.strong, the renderer resolves it against the
+ * active theme's `sdui.color.neutral-strong` value, and BOTH halves
+ * must agree about that path existing.
+ *
+ * Run: node packages/tokens-creator/scripts/validate-palette.js
+ * Wired into: packages/tokens-creator/build.js (runs before the
+ * style-dictionary build step).
+ */
+
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = join(__dirname, '..');
+
+const THEME_FILES = ['theme-light.json', 'theme-dark.json'];
+
+// ── Load palette from sibling palette.js ──────────────────────────────────
+async function loadPalette() {
+  const palettePath = join(PACKAGE_ROOT, 'palette.js');
+  const module = await import(palettePath);
+  return module.palette;
+}
+
+// ── Load theme JSON ───────────────────────────────────────────────────────
+function loadTheme(filename) {
+  const path = join(PACKAGE_ROOT, 'tokens', filename);
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+// ── Walk a token string path (e.g. "sdui.color.neutral-strong") against
+//    the theme JSON and confirm it leads to a valid `$value`. ──────────────
+function lookupToken(themeRoot, tokenPath) {
+  const segments = tokenPath.split('.');
+  let current = themeRoot;
+  for (const seg of segments) {
+    if (current && typeof current === 'object' && seg in current) {
+      current = current[seg];
+    } else {
+      return undefined;
+    }
+  }
+  // Final node must have $value (DTCG token shape)
+  if (current && typeof current === 'object' && '$value' in current) {
+    return current.$value;
+  }
+  return undefined;
+}
+
+// ── Collect all leaf token strings from the nested palette object ─────────
+function collectPaletteLeaves(palette, pathPrefix = []) {
+  const leaves = [];
+  for (const [key, value] of Object.entries(palette)) {
+    const currentPath = [...pathPrefix, key];
+    if (typeof value === 'string') {
+      leaves.push({ alias: currentPath.join('.'), token: value });
+    } else if (value && typeof value === 'object') {
+      leaves.push(...collectPaletteLeaves(value, currentPath));
+    }
+  }
+  return leaves;
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+async function main() {
+  const palette = await loadPalette();
+  const leaves = collectPaletteLeaves(palette);
+  const themes = THEME_FILES.map((filename) => ({
+    name: filename.replace('.json', ''),
+    data: loadTheme(filename),
+  }));
+
+  const failures = [];
+  for (const theme of themes) {
+    for (const { alias, token } of leaves) {
+      const resolved = lookupToken(theme.data, token);
+      if (resolved === undefined) {
+        failures.push({ theme: theme.name, alias, token });
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error('');
+    console.error('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+    console.error(`PALETTE VALIDATION FAILED — ${failures.length} unresolved alias(es)`);
+    console.error('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+    for (const f of failures) {
+      console.error(`  ✗ palette.${f.alias} → "${f.token}"  not found in ${f.theme}.json`);
+    }
+    console.error('');
+    console.error('Fix order:');
+    console.error('  1. Add the missing token to BOTH tokens/theme-light.json AND theme-dark.json');
+    console.error('  2. Re-run build');
+    console.error('  3. (Optional) Update PALETTE-DESIGN.md if the alias name changed');
+    console.error('');
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ palette: ${leaves.length} aliases × ${themes.length} themes — all resolve`
+  );
+}
+
+main().catch((err) => {
+  console.error('Palette validation script error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Implements the palette module designed in `packages/tokens-creator/PALETTE-DESIGN.md` (landed in main as commit 06c5363 via #130). Adds the actual `palette.js` export + types + validator + tests that BFF handlers will consume.

**Locally smoke-tested**: validator confirms `50 aliases × 2 themes — all resolve`.

## What's in this PR

| File | Purpose | LOC |
|---|---|---|
| `packages/tokens-creator/palette.js` | Frozen semantic alias map — `palette.text.strong → \"sdui.color.neutral-strong\"` etc. across 7 token families (color, font-size, font-weight, spacing, radius, icon-size, border-width) | 104 |
| `packages/tokens-creator/palette.d.ts` | TS types with branded `SduiToken` + per-group interfaces (`PaletteText`, `PaletteSurface`, etc.) | 105 |
| `packages/tokens-creator/palette.test.js` | Vitest tests for token regex + shape stability + immutability | 108 |
| `packages/tokens-creator/scripts/validate-palette.js` | Build-time invariant — every alias resolves in EVERY theme JSON; build fails on missing | 116 |
| `packages/tokens-creator/build.js` | Wired validator to run before style-dictionary build | +5 |
| `packages/tokens-creator/package.json` | Added `./palette` export path + `validate:palette` + `test` scripts; included `palette.{js,d.ts}` in `files` | +10 |

## Default decisions applied

The design doc surfaced 6 decisions and said \"Defaults apply if not overridden.\" None were overridden via comments on the merged #130, so I implemented per recommendations:

1. **Location**: top-level `palette.js` (not `dist/`) — hand-maintained
2. **Per-product palettes**: lives only in `@amplify-ai/tokens-creator` for this initial implementation; other packages get their own when consumers need one
3. **Naming**: multi-level dotted (`palette.text.strong`) — better autocomplete
4. **Type-union of all theme token names**: deferred (out of scope this PR)
5. **Versioning**: palette shape is part of the package's public API; snapshot tests prevent accidental rename
6. **Ordering**: theme JSON gets the value FIRST, palette alias SECOND — the validator enforces

If you'd like any of these reversed, just say so and I'll rework.

## Discrepancy flagged (worth your attention)

Existing amplify-gateway BFF code uses token names that **don't exist** in the theme JSONs:

| Used by BFF | Real token name |
|---|---|
| `sdui.color.text-neutral-strong` | `sdui.color.neutral-strong` |
| `sdui.color.text-neutral-medium` | `sdui.color.neutral-medium` |
| `sdui.color.text-neutral-weak` | `sdui.color.neutral-weak` |
| `sdui.color.text-neutral-faint` | (no equivalent — closest is `neutral-subtle`) |
| `sdui.color.surface` | `sdui.color.offset-weak` (or `offset-medium`) |
| `sdui.color.border-neutral` | `sdui.color.offset-strong` |

This palette uses the REAL names. The Brief #264 Phase 2 BFF refactor replaces local `const color = {...}` maps with `palette.text.strong` etc., which naturally fixes BFF's broken refs as a side-effect of the migration.

Alternative would have been to introduce ALIAS tokens in the theme JSONs (e.g. add `text-neutral-strong` aliased to `neutral-strong`) to preserve BFF's current names — happy to do that instead if you prefer no BFF-side rename.

## Test plan

- [x] `node scripts/validate-palette.js` passes locally — `50 aliases × 2 themes — all resolve`
- [ ] CI runs `vitest` if configured for this package (engineer-verify)
- [ ] After merge: any consumer can `import { palette } from \"@amplify-ai/tokens-creator/palette\"` and get autocomplete on the typed surface
- [ ] First Brief #264 Phase 2 BFF refactor PR (home-tabs.ts) confirms end-to-end import works

## Sibling PRs

- One-Impression/zenith-coding-agent#366 — Phase 2 reviewer-rules prereq (one of which is `bff-palette-tokens-only` which blocks raw `\"sdui.*\"` strings, encouraging palette use). Awaiting merge.
- One-Impression/amplify-design-system#130 — palette design doc (already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)