### PR TITLE
chore(changeset): tokens-creator palette minor bump

### DIFF
--- a/.changeset/tokens-creator-palette.md
+++ b/.changeset/tokens-creator-palette.md
@@ -1,0 +1,17 @@
+---
+"@amplify-ai/tokens-creator": minor
+---
+
+feat(tokens-creator): add palette semantic alias module
+
+Adds the `palette` export — a hand-curated semantic alias map for BFF and app
+consumers. Maps engineer-friendly names (`palette.text.strong`) to canonical
+SDUI token names (`"sdui.color.neutral-strong"`) across all 7 token families
+(color, font-size, font-weight, spacing, radius, icon-size, border-width).
+Build-time validator ensures every alias resolves in every theme JSON.
+
+New export path: `@amplify-ai/tokens-creator/palette`. Consumers replace
+inline token strings and local `const color = {...}` duplication with
+`import { palette } from "@amplify-ai/tokens-creator/palette"`. Theme
+resolution stays entirely client-side; the BFF emits palette names and the
+renderer paints the theme-correct value at paint time.


### PR DESCRIPTION
## Summary

Adds the changeset for the palette module that landed in PR #131 (commit `370fdd4`). Queues `@amplify-ai/tokens-creator` for the next minor release so consumers (amplify-gateway BFF, amplify-creator-app) can pull the new `./palette` export.

## Why this is a separate PR

The implementation PR (#131) was merged before the changeset was added. Filing a follow-up PR with just the changeset is the cleanest path — joins the queue of pending changesets in `.changeset/` waiting for the next release-coordinator PR.

## What ships in the bump

- New export path `@amplify-ai/tokens-creator/palette` exposing `palette` const + branded TS types
- Build-time invariant validator (already wired in build.js — no consumer-facing change there)

## Test plan

- [ ] Next release-coordinator PR (changesets version) picks this up
- [ ] After release, consumers `import { palette } from "@amplify-ai/tokens-creator/palette"` works at the published version

🤖 Generated with [Claude Code](https://claude.com/claude-code)