### PR TITLE
chore: migrate @amplify-ai/* → @one-impression/* on GitHub Packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
+  "changelog": [
+    "@changesets/changelog-github",
+    { "repo": "One-Impression/amplify-design-system" }
+  ],
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "restricted",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": [
+    "storybook",
+    "@one-impression/templates",
+    "brand-oportunities",
+    "feature-flags",
+    "@amplify/tokens-marketing",
+    "tokens-oportunities",
+    "tokens-studio"
+  ]
+}

--- a/.changeset/migrate-to-github-packages.md
+++ b/.changeset/migrate-to-github-packages.md
@@ -1,0 +1,21 @@
+---
+"@one-impression/tokens-foundation": major
+"@one-impression/tokens-brand": major
+"@one-impression/tokens-atmosphere": major
+"@one-impression/tokens-creator": major
+"@one-impression/ui": major
+"@one-impression/ui-native": major
+"@one-impression/sdui-runtime": major
+"@one-impression/mcp-server": major
+"@one-impression/eslint-config": major
+---
+
+Migrate from `@amplify-ai/*` (npmjs.org, owner-locked) to `@one-impression/*` (GitHub Packages, org-owned).
+
+**Why:** The previous publish pipeline was bottlenecked on a single npm account, causing silent publish failures since 2026-05-22 (commits landed on `main` but never reached the registry). Moving to GitHub Packages under the `@one-impression` scope removes the single-owner dependency — every merge to `main` now publishes via the auto-injected `GITHUB_TOKEN`, with no human in the loop.
+
+**What changes for consumers:** Package scope changed from `@amplify-ai/*` to `@one-impression/*`. Install requires a GitHub PAT with `read:packages` scope (same auth model as the existing `@one-impression/sdk-*` packages from `amplify-schemas`). Update imports and `package.json` dependencies accordingly.
+
+**Versioning:** Major bump on every package because the scope change is a breaking name change — old `@amplify-ai/*` imports will not resolve after consumers update.
+
+**Pipeline:** Publishes now run via `changesets` (see `.changeset/` and `.github/workflows/publish.yml`) — every PR that ships a code change must include a `changeset` file declaring `patch`/`minor`/`major`. Merge to `main` opens a Version PR; merging that publishes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          registry-url: https://registry.npmjs.org
-          scope: '@amplify-ai'
 
       - name: Install dependencies
         run: npm ci
@@ -38,16 +36,16 @@ jobs:
           npm run build -w packages/tokens-atmosphere
           npm run build -w packages/tokens-marketing
 
-      - name: Build @amplify-ai/ui
+      - name: Build @one-impression/ui
         run: npm run build -w packages/ui
 
-      - name: Build @amplify-ai/ui-native
+      - name: Build @one-impression/ui-native
         run: npm run build -w packages/ui-native
 
-      - name: Build @amplify-ai/sdui-runtime
+      - name: Build @one-impression/sdui-runtime
         run: npm run build -w packages/sdui-runtime
 
-      - name: Build @amplify-ai/mcp-server
+      - name: Build @one-impression/mcp-server
         run: npm run build -w packages/mcp-server
 
       - name: Validate cross-package consistency
@@ -79,37 +77,6 @@ jobs:
 
       - name: Build Storybook
         run: npm run build -w packages/storybook
-
-      - name: Publish packages
-        if: github.ref == 'refs/heads/main' && env.NPM_TOKEN_SET == 'true'
-        env:
-          NPM_TOKEN_SET: ${{ secrets.NPM_TOKEN != '' }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          set -e
-          for pkg in tokens-foundation tokens-brand tokens-atmosphere tokens-creator ui ui-native sdui-runtime mcp-server eslint-config; do
-            echo "Publishing @amplify-ai/$pkg..."
-            (
-              cd packages/$pkg
-              OUTPUT=$(npm publish --access public 2>&1) && echo "$OUTPUT" || {
-                EXIT_CODE=$?
-                echo "$OUTPUT"
-                if echo "$OUTPUT" | grep -qE 'EPUBLISHCONFLICT|already been published|You cannot publish over the previously published versions|cannot publish over the previously published'; then
-                  echo "Package already published at this version — skipping"
-                else
-                  echo "::error::Publish failed for $pkg"
-                  exit $EXIT_CODE
-                fi
-              }
-            )
-          done
-
-      - name: Publish skipped (NPM_TOKEN not set)
-        if: github.ref == 'refs/heads/main' && env.NPM_TOKEN_SET != 'true'
-        env:
-          NPM_TOKEN_SET: ${{ secrets.NPM_TOKEN != '' }}
-        run: |
-          echo "::notice title=Publish skipped::NPM_TOKEN secret is not set on this repo. Build + tests passed but @amplify-ai/* was NOT published. To enable publishing: (1) create npm org 'amplify-ai' at npmjs.com/org/create, (2) generate an automation token with publish scope, (3) gh secret set NPM_TOKEN -R One-Impression/amplify-design-system. Then re-run this workflow."
 
   secret-scan:
     name: Secret Scan

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,102 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+
+concurrency:
+  group: publish-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release (Changesets)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://npm.pkg.github.com
+          scope: "@one-impression"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build packages
+        run: |
+          npm run build -w packages/tokens-foundation
+          npm run build -w packages/tokens-brand
+          npm run build -w packages/tokens-creator
+          npm run build -w packages/tokens-atmosphere
+          npm run build -w packages/tokens-marketing
+          npm run build -w packages/ui
+          npm run build -w packages/ui-native
+          npm run build -w packages/sdui-runtime
+          npm run build -w packages/mcp-server
+
+      - name: Version or publish
+        id: version_or_publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          CHANGESETS=$(find .changeset -maxdepth 1 -name "*.md" ! -name "README.md" 2>/dev/null | wc -l | tr -d ' ')
+
+          if [ "$CHANGESETS" -gt 0 ]; then
+            echo "Found $CHANGESETS changeset(s) — bumping versions and opening Version PR"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            npx changeset version
+            git checkout -b changesets-release
+            git add -A
+            git diff --staged --quiet || git commit -m "chore: release packages"
+            git push origin changesets-release --force
+
+            EXISTING=$(gh pr list --head changesets-release --base main \
+              --state open --json number -q '.[0].number' 2>/dev/null || true)
+            if [ -z "$EXISTING" ]; then
+              gh pr create --base main --head changesets-release \
+                --title "chore: release packages" \
+                --body "Automated version bump from Changesets. Merge to publish to GitHub Packages." \
+                || echo "PR creation skipped — org policy blocks Actions from creating PRs. Open manually from changesets-release branch."
+            else
+              echo "Version PR #$EXISTING already open — branch updated"
+            fi
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No unconsumed changesets — publishing packages"
+            npx changeset publish
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify packages published
+        if: steps.version_or_publish.outputs.published == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          echo "@one-impression:registry=https://npm.pkg.github.com" > ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" >> ~/.npmrc
+          for pkg in tokens-foundation tokens-brand tokens-atmosphere tokens-creator ui ui-native sdui-runtime mcp-server eslint-config; do
+            EXPECTED=$(jq -r .version packages/$pkg/package.json)
+            ACTUAL=$(npm view @one-impression/$pkg version 2>/dev/null || echo "MISSING")
+            if [ "$EXPECTED" != "$ACTUAL" ]; then
+              echo "::warning::@one-impression/$pkg expected $EXPECTED but registry has $ACTUAL"
+            else
+              echo "OK @one-impression/$pkg@$EXPECTED published"
+            fi
+          done

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
-@amplify-ai:registry=https://registry.npmjs.org
+@one-impression:registry=https://npm.pkg.github.com
+@one-impression:always-auth=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,12 +94,12 @@ Studio-direction brand for One Impression's creator-intent platform.
 - **Brand assets**: `packages/brand-oportunities/` — logos, app icons, favicons, social templates, business cards, email signature
 - **Brand decisions**: `packages/brand-oportunities/BRAND-DECISIONS.md` — founder-approved, do not change without sign-off
 - **Engineer hand-off**: `packages/brand-oportunities/ENGINEER-HANDOFF.md` — how to consume in a product app
-- **Components**: 6 new composed components in `@amplify-ai/ui` (`Wordmark`, `SignalDot`, `CreatorIntentCard`, `BrandInterestCard`, `IntentFeed`, `AppIconOportunities`)
+- **Components**: 6 new composed components in `@one-impression/ui` (`Wordmark`, `SignalDot`, `CreatorIntentCard`, `BrandInterestCard`, `IntentFeed`, `AppIconOportunities`)
 
 **Composition rule**: Oportunities components compose from `tokens-foundation`
-primitives + existing `@amplify-ai/ui` primitives (Card, Avatar, Badge, etc.).
+primitives + existing `@one-impression/ui` primitives (Card, Avatar, Badge, etc.).
 **Never invent new primitives for Oportunities** — add a composed component
 that wraps existing primitives instead. If a true primitive is missing, raise
-it in `@amplify-ai/ui` first so all themes benefit.
+it in `@one-impression/ui` first so all themes benefit.
 
 **Spelling**: single-P "Oportunities" everywhere. Not "Opportunities".

--- a/PR-DESCRIPTION.md
+++ b/PR-DESCRIPTION.md
@@ -5,10 +5,10 @@ This PR introduces the **Oportunities** product theme (Studio direction) to the 
 ## What's added
 
 ### 4 new packages
-- **`@amplify-ai/tokens-oportunities@1.0.0`** — Studio-direction tokens (apricot palette, Geist + Inter + JBM, light + dark)
-- **`@amplify-ai/brand-oportunities@1.0.0`** — brand asset library (logo SVGs, app icons, favicons, social templates, business cards, email signature, full `BRAND-DECISIONS.md`)
+- **`@one-impression/tokens-oportunities@1.0.0`** — Studio-direction tokens (apricot palette, Geist + Inter + JBM, light + dark)
+- **`@one-impression/brand-oportunities@1.0.0`** — brand asset library (logo SVGs, app icons, favicons, social templates, business cards, email signature, full `BRAND-DECISIONS.md`)
 
-### 6 new components in `@amplify-ai/ui` (will release as 2.12.0)
+### 6 new components in `@one-impression/ui` (will release as 2.12.0)
 - `Wordmark` — Oportunities wordmark with optional gradient-sweep animation
 - `SignalDot` — the apricot period as a standalone animated mark
 - `CreatorIntentCard` — signature product card (composes `Card` + `Avatar` + `Badge`)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Federated design tokens and shared UI components for all One Impression products
                     |  - Figma sync          |
                     +----------+-------------+
                                |
-                    npm install @amplify-ai/tokens-*
+                    npm install @one-impression/tokens-*
                                |
           +---------+----------+----------+----------+
           |         |          |          |          |
@@ -57,7 +57,7 @@ product's tokens.
 |----------------|------------|
 | Stores token JSON source files | Governs token changes (approval workflows) |
 | Builds CSS/JS/RN output via Style Dictionary | Detects token drift (Pixel vs code) |
-| Publishes npm packages (@amplify-ai/*) | Cascades brand changes across products |
+| Publishes npm packages (@one-impression/*) | Cascades brand changes across products |
 | Houses React UI components | Reviews PR design compliance |
 | Runs Storybook for component docs | Audits accessibility (WCAG 2.1 AA) |
 | Provides ESLint rules | Generates design mockups & handoff specs |
@@ -69,15 +69,15 @@ product's tokens.
 
 | Package | Purpose | Consumer |
 |---------|---------|----------|
-| `@amplify-ai/tokens-foundation` | Shared primitives (spacing, radii, shadows, typography) | All products |
-| `@amplify-ai/tokens-brand` | Brand platform colors & theme | one-dashboard-web |
-| `@amplify-ai/tokens-atmosphere` | Atmosphere dashboard colors & theme | odin-agent/web |
-| `@amplify-ai/tokens-creator` | Creator app colors & SDUI mapping | one_club_app |
-| `@amplify-ai/tokens-oportunities` | Oportunities theme tokens (Studio direction, apricot palette) | oportunities apps (TBD) |
-| `@amplify-ai/brand-oportunities` | Oportunities brand asset library (logos, app icons, favicons, social, decisions doc) | oportunities apps (TBD) |
-| `@amplify-ai/ui` | Shared React UI components | Web products |
-| `@amplify-ai/eslint-config` | Design system lint rules | All products |
-| `@amplify-ai/feature-flags` | Feature flag utilities | All products |
+| `@one-impression/tokens-foundation` | Shared primitives (spacing, radii, shadows, typography) | All products |
+| `@one-impression/tokens-brand` | Brand platform colors & theme | one-dashboard-web |
+| `@one-impression/tokens-atmosphere` | Atmosphere dashboard colors & theme | odin-agent/web |
+| `@one-impression/tokens-creator` | Creator app colors & SDUI mapping | one_club_app |
+| `@one-impression/tokens-oportunities` | Oportunities theme tokens (Studio direction, apricot palette) | oportunities apps (TBD) |
+| `@one-impression/brand-oportunities` | Oportunities brand asset library (logos, app icons, favicons, social, decisions doc) | oportunities apps (TBD) |
+| `@one-impression/ui` | Shared React UI components | Web products |
+| `@one-impression/eslint-config` | Design system lint rules | All products |
+| `@one-impression/feature-flags` | Feature flag utilities | All products |
 
 ## Token Flow
 
@@ -86,7 +86,7 @@ product's tokens.
 3. **GitHub Actions** builds all packages, validates, creates PR
 4. On merge: npm publish + **Pixel** detects update via scheduled drift check
 5. Pixel runs brand cascade → identifies affected products → generates fix PRs
-6. Products `npm update @amplify-ai/tokens-*` to adopt changes
+6. Products `npm update @one-impression/tokens-*` to adopt changes
 
 ## Pixel Integration Points
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,10 @@
       "workspaces": [
         "packages/*"
       ],
+      "devDependencies": {
+        "@changesets/changelog-github": "^0.7.0",
+        "@changesets/cli": "^2.31.0"
+      },
       "engines": {
         "node": ">=18.0.0"
       }
@@ -20,66 +24,6 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@amplify-ai/brand-oportunities": {
-      "resolved": "packages/brand-oportunities",
-      "link": true
-    },
-    "node_modules/@amplify-ai/eslint-config": {
-      "resolved": "packages/eslint-config",
-      "link": true
-    },
-    "node_modules/@amplify-ai/feature-flags": {
-      "resolved": "packages/feature-flags",
-      "link": true
-    },
-    "node_modules/@amplify-ai/mcp-server": {
-      "resolved": "packages/mcp-server",
-      "link": true
-    },
-    "node_modules/@amplify-ai/sdui-runtime": {
-      "resolved": "packages/sdui-runtime",
-      "link": true
-    },
-    "node_modules/@amplify-ai/storybook": {
-      "resolved": "packages/storybook",
-      "link": true
-    },
-    "node_modules/@amplify-ai/templates": {
-      "resolved": "packages/templates",
-      "link": true
-    },
-    "node_modules/@amplify-ai/tokens-atmosphere": {
-      "resolved": "packages/tokens-atmosphere",
-      "link": true
-    },
-    "node_modules/@amplify-ai/tokens-brand": {
-      "resolved": "packages/tokens-brand",
-      "link": true
-    },
-    "node_modules/@amplify-ai/tokens-creator": {
-      "resolved": "packages/tokens-creator",
-      "link": true
-    },
-    "node_modules/@amplify-ai/tokens-foundation": {
-      "resolved": "packages/tokens-foundation",
-      "link": true
-    },
-    "node_modules/@amplify-ai/tokens-oportunities": {
-      "resolved": "packages/tokens-oportunities",
-      "link": true
-    },
-    "node_modules/@amplify-ai/tokens-studio": {
-      "resolved": "packages/tokens-studio",
-      "link": true
-    },
-    "node_modules/@amplify-ai/ui": {
-      "resolved": "packages/ui",
-      "link": true
-    },
-    "node_modules/@amplify-ai/ui-native": {
-      "resolved": "packages/ui-native",
-      "link": true
     },
     "node_modules/@amplify/tokens-marketing": {
       "resolved": "packages/tokens-marketing",
@@ -383,6 +327,585 @@
         "path": "^0.12.7",
         "stream": "^0.0.3",
         "util": "^0.12.5"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.1.tgz",
+      "integrity": "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/config": "^3.1.4",
+        "@changesets/get-version-range-type": "^0.4.0",
+        "@changesets/git": "^3.0.4",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "detect-indent": "^6.0.0",
+        "fs-extra": "^7.0.1",
+        "lodash.startcase": "^4.4.0",
+        "outdent": "^0.5.0",
+        "prettier": "^2.7.1",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@changesets/assemble-release-plan": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.10.tgz",
+      "integrity": "sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.4",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/assemble-release-plan/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@changesets/changelog-git": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz",
+      "integrity": "sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0"
+      }
+    },
+    "node_modules/@changesets/changelog-github": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.7.0.tgz",
+      "integrity": "sha512-rBsbRvc4TVn+FvFnOVM3LxlFJfTXXCp8gfVJ+0BubxWNSVnLuAzowi5j+IEraLLP52w8AAs9QfKbPS3MMiXQJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/get-github-info": "^0.8.0",
+        "@changesets/types": "^6.1.0",
+        "dotenv": "^8.1.0"
+      }
+    },
+    "node_modules/@changesets/cli": {
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.31.0.tgz",
+      "integrity": "sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/apply-release-plan": "^7.1.1",
+        "@changesets/assemble-release-plan": "^6.0.10",
+        "@changesets/changelog-git": "^0.2.1",
+        "@changesets/config": "^3.1.4",
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.4",
+        "@changesets/get-release-plan": "^4.0.16",
+        "@changesets/git": "^3.0.4",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.7",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@changesets/write": "^0.4.0",
+        "@inquirer/external-editor": "^1.0.2",
+        "@manypkg/get-packages": "^1.1.3",
+        "ansi-colors": "^4.1.3",
+        "enquirer": "^2.4.1",
+        "fs-extra": "^7.0.1",
+        "mri": "^1.2.0",
+        "package-manager-detector": "^0.2.0",
+        "picocolors": "^1.1.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.3",
+        "spawndamnit": "^3.0.1",
+        "term-size": "^2.1.0"
+      },
+      "bin": {
+        "changeset": "bin.js"
+      }
+    },
+    "node_modules/@changesets/cli/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@changesets/cli/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@changesets/cli/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@changesets/cli/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@changesets/cli/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@changesets/config": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.4.tgz",
+      "integrity": "sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.4",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "fs-extra": "^7.0.1",
+        "micromatch": "^4.0.8"
+      }
+    },
+    "node_modules/@changesets/config/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@changesets/config/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@changesets/config/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@changesets/errors": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
+      "integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extendable-error": "^0.1.5"
+      }
+    },
+    "node_modules/@changesets/get-dependents-graph": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.4.tgz",
+      "integrity": "sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "picocolors": "^1.1.0",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/get-dependents-graph/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@changesets/get-github-info": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.8.0.tgz",
+      "integrity": "sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dataloader": "^1.4.0",
+        "node-fetch": "^2.5.0"
+      }
+    },
+    "node_modules/@changesets/get-release-plan": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.16.tgz",
+      "integrity": "sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/assemble-release-plan": "^6.0.10",
+        "@changesets/config": "^3.1.4",
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.7",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3"
+      }
+    },
+    "node_modules/@changesets/get-version-range-type": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
+      "integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@changesets/git": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz",
+      "integrity": "sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "is-subdir": "^1.1.1",
+        "micromatch": "^4.0.8",
+        "spawndamnit": "^3.0.1"
+      }
+    },
+    "node_modules/@changesets/logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz",
+      "integrity": "sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.0"
+      }
+    },
+    "node_modules/@changesets/parse": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.3.tgz",
+      "integrity": "sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "js-yaml": "^4.1.1"
+      }
+    },
+    "node_modules/@changesets/pre": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz",
+      "integrity": "sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "fs-extra": "^7.0.1"
+      }
+    },
+    "node_modules/@changesets/pre/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@changesets/pre/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@changesets/pre/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@changesets/read": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.7.tgz",
+      "integrity": "sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/git": "^3.0.4",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/parse": "^0.4.3",
+        "@changesets/types": "^6.1.0",
+        "fs-extra": "^7.0.1",
+        "p-filter": "^2.1.0",
+        "picocolors": "^1.1.0"
+      }
+    },
+    "node_modules/@changesets/read/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@changesets/read/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@changesets/read/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@changesets/should-skip-package": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz",
+      "integrity": "sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3"
+      }
+    },
+    "node_modules/@changesets/types": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@changesets/write": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz",
+      "integrity": "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "fs-extra": "^7.0.1",
+        "human-id": "^4.1.1",
+        "prettier": "^2.7.1"
+      }
+    },
+    "node_modules/@changesets/write/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@changesets/write/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@changesets/write/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/@changesets/write/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1214,6 +1737,28 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1789,6 +2334,174 @@
         "tslib": "2"
       }
     },
+    "node_modules/@manypkg/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "@types/node": "^12.7.1",
+        "find-up": "^4.1.0",
+        "fs-extra": "^8.1.0"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@manypkg/find-root/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@manypkg/get-packages": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
+      "integrity": "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "@changesets/types": "^4.0.1",
+        "@manypkg/find-root": "^1.1.0",
+        "fs-extra": "^8.1.0",
+        "globby": "^11.0.0",
+        "read-yaml-file": "^1.1.0"
+      }
+    },
+    "node_modules/@manypkg/get-packages/node_modules/@changesets/types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@manypkg/get-packages/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@manypkg/get-packages/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@manypkg/get-packages/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/@mdx-js/react": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
@@ -1846,6 +2559,104 @@
           "optional": false
         }
       }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@one-impression/brand-oportunities": {
+      "resolved": "packages/brand-oportunities",
+      "link": true
+    },
+    "node_modules/@one-impression/eslint-config": {
+      "resolved": "packages/eslint-config",
+      "link": true
+    },
+    "node_modules/@one-impression/feature-flags": {
+      "resolved": "packages/feature-flags",
+      "link": true
+    },
+    "node_modules/@one-impression/mcp-server": {
+      "resolved": "packages/mcp-server",
+      "link": true
+    },
+    "node_modules/@one-impression/sdui-runtime": {
+      "resolved": "packages/sdui-runtime",
+      "link": true
+    },
+    "node_modules/@one-impression/storybook": {
+      "resolved": "packages/storybook",
+      "link": true
+    },
+    "node_modules/@one-impression/templates": {
+      "resolved": "packages/templates",
+      "link": true
+    },
+    "node_modules/@one-impression/tokens-atmosphere": {
+      "resolved": "packages/tokens-atmosphere",
+      "link": true
+    },
+    "node_modules/@one-impression/tokens-brand": {
+      "resolved": "packages/tokens-brand",
+      "link": true
+    },
+    "node_modules/@one-impression/tokens-creator": {
+      "resolved": "packages/tokens-creator",
+      "link": true
+    },
+    "node_modules/@one-impression/tokens-foundation": {
+      "resolved": "packages/tokens-foundation",
+      "link": true
+    },
+    "node_modules/@one-impression/tokens-oportunities": {
+      "resolved": "packages/tokens-oportunities",
+      "link": true
+    },
+    "node_modules/@one-impression/tokens-studio": {
+      "resolved": "packages/tokens-studio",
+      "link": true
+    },
+    "node_modules/@one-impression/ui": {
+      "resolved": "packages/ui",
+      "link": true
+    },
+    "node_modules/@one-impression/ui-native": {
+      "resolved": "packages/ui-native",
+      "link": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3657,6 +4468,16 @@
       "integrity": "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==",
       "peer": true
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3703,6 +4524,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/asap": {
@@ -3840,6 +4671,19 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/better-path-resolve": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
+      "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-windows": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/body-parser": {
@@ -4130,6 +4974,13 @@
       "version": "5.4.4",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
       "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4582,6 +5433,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/dataloader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
+      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4718,6 +5576,29 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -4737,6 +5618,16 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4785,6 +5676,33 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/enquirer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/entities": {
@@ -5269,11 +6187,48 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/extendable-error": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
+      "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -5304,6 +6259,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fb-dotslash": {
       "version": "0.5.8",
@@ -5754,6 +6719,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5922,6 +6918,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/human-id": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.1.3.tgz",
+      "integrity": "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "human-id": "dist/cli.js"
       }
     },
     "node_modules/hyperdyperid": {
@@ -6250,6 +7256,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-subdir": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
+      "integrity": "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "better-path-resolve": "1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
@@ -6264,6 +7283,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-wsl": {
@@ -6740,6 +7769,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
@@ -6895,6 +7931,16 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "peer": true
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/metro": {
       "version": "0.84.4",
@@ -7378,6 +8424,16 @@
         "ufo": "^1.6.3"
       }
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7429,6 +8485,52 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-int64": {
@@ -7594,6 +8696,26 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/outdent": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
+      "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/p-filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7626,12 +8748,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/package-manager-detector": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
+      "integrity": "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quansync": "^0.2.7"
+      }
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -7792,6 +8944,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-unified": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/path-unified/-/path-unified-0.2.0.tgz",
@@ -7849,6 +9011,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pirates": {
@@ -8085,6 +9257,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/queue": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
@@ -8093,6 +9282,27 @@
       "dependencies": {
         "inherits": "~2.0.3"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -8343,6 +9553,46 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/read-yaml-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
+      "integrity": "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.5",
+        "js-yaml": "^3.6.1",
+        "pify": "^4.0.1",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/read-yaml-file/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/read-yaml-file/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -8467,6 +9717,17 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -8534,6 +9795,30 @@
       "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -8849,6 +10134,24 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/spawndamnit": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
+      "integrity": "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "cross-spawn": "^7.0.5",
+        "signal-exit": "^4.0.1"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -9194,6 +10497,19 @@
       "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/term-size": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/terser": {
       "version": "5.47.1",
@@ -12467,11 +13783,11 @@
       }
     },
     "packages/brand-oportunities": {
-      "name": "@amplify-ai/brand-oportunities",
+      "name": "@one-impression/brand-oportunities",
       "version": "1.0.0"
     },
     "packages/eslint-config": {
-      "name": "@amplify-ai/eslint-config",
+      "name": "@one-impression/eslint-config",
       "version": "2.1.0",
       "devDependencies": {
         "eslint": "^9.0.0"
@@ -12481,14 +13797,14 @@
       }
     },
     "packages/feature-flags": {
-      "name": "@amplify-ai/feature-flags",
+      "name": "@one-impression/feature-flags",
       "version": "2.0.1",
       "peerDependencies": {
         "react": ">=17.0.0"
       }
     },
     "packages/mcp-server": {
-      "name": "@amplify-ai/mcp-server",
+      "name": "@one-impression/mcp-server",
       "version": "2.0.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
@@ -12506,7 +13822,7 @@
       }
     },
     "packages/sdui-runtime": {
-      "name": "@amplify-ai/sdui-runtime",
+      "name": "@one-impression/sdui-runtime",
       "version": "1.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
@@ -12518,10 +13834,10 @@
         "typescript": "^5.5.0"
       },
       "peerDependencies": {
-        "@amplify-ai/tokens-creator": ">=2.0.3",
-        "@amplify-ai/ui-native": ">=1.0.0",
         "@gorhom/bottom-sheet": "^5.0.0",
         "@one-impression/sdk-native-sdui": ">=1.0.0",
+        "@one-impression/tokens-creator": ">=2.0.3",
+        "@one-impression/ui-native": ">=1.0.0",
         "react": ">=18.0.0",
         "react-native": ">=0.72.0",
         "react-native-webview": ">=13.0.0"
@@ -12539,10 +13855,10 @@
       }
     },
     "packages/storybook": {
-      "name": "@amplify-ai/storybook",
+      "name": "@one-impression/storybook",
       "version": "0.1.0",
       "devDependencies": {
-        "@amplify-ai/ui": "*",
+        "@one-impression/ui": "*",
         "@storybook/addon-a11y": "^8.4.0",
         "@storybook/addon-essentials": "^8.4.0",
         "@storybook/blocks": "^8.4.0",
@@ -12560,11 +13876,11 @@
       }
     },
     "packages/templates": {
-      "name": "@amplify-ai/templates",
+      "name": "@one-impression/templates",
       "version": "2.0.1",
       "dependencies": {
-        "@amplify-ai/tokens-brand": "^3.0.0",
-        "@amplify-ai/ui": "^2.0.1"
+        "@one-impression/tokens-brand": "^3.0.0",
+        "@one-impression/ui": "^2.0.1"
       },
       "devDependencies": {
         "@types/react": "^18.3.0",
@@ -12591,37 +13907,37 @@
       }
     },
     "packages/tokens-atmosphere": {
-      "name": "@amplify-ai/tokens-atmosphere",
+      "name": "@one-impression/tokens-atmosphere",
       "version": "2.0.3",
       "dependencies": {
-        "@amplify-ai/tokens-foundation": "^2.0.1"
+        "@one-impression/tokens-foundation": "^2.0.1"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
     },
     "packages/tokens-brand": {
-      "name": "@amplify-ai/tokens-brand",
+      "name": "@one-impression/tokens-brand",
       "version": "3.1.0",
       "dependencies": {
-        "@amplify-ai/tokens-foundation": "^2.0.1"
+        "@one-impression/tokens-foundation": "^2.0.1"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
     },
     "packages/tokens-creator": {
-      "name": "@amplify-ai/tokens-creator",
+      "name": "@one-impression/tokens-creator",
       "version": "2.0.3",
       "dependencies": {
-        "@amplify-ai/tokens-foundation": "^2.0.1"
+        "@one-impression/tokens-foundation": "^2.0.1"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
     },
     "packages/tokens-foundation": {
-      "name": "@amplify-ai/tokens-foundation",
+      "name": "@one-impression/tokens-foundation",
       "version": "2.1.3",
       "devDependencies": {
         "style-dictionary": "^4.3.0"
@@ -12631,31 +13947,31 @@
       "name": "@amplify/tokens-marketing",
       "version": "1.0.0",
       "peerDependencies": {
-        "@amplify-ai/tokens-foundation": "^2.1.0"
+        "@one-impression/tokens-foundation": "^2.1.0"
       }
     },
     "packages/tokens-oportunities": {
-      "name": "@amplify-ai/tokens-oportunities",
+      "name": "@one-impression/tokens-oportunities",
       "version": "1.0.0",
       "dependencies": {
-        "@amplify-ai/tokens-foundation": "^2.1.0"
+        "@one-impression/tokens-foundation": "^2.1.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
     },
     "packages/tokens-studio": {
-      "name": "@amplify-ai/tokens-studio",
+      "name": "@one-impression/tokens-studio",
       "version": "1.0.4",
       "dependencies": {
-        "@amplify-ai/tokens-foundation": "^2.1.0"
+        "@one-impression/tokens-foundation": "^2.1.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
     },
     "packages/ui": {
-      "name": "@amplify-ai/ui",
+      "name": "@one-impression/ui",
       "version": "2.13.0",
       "dependencies": {
         "clsx": "^2.1.0",
@@ -12679,7 +13995,7 @@
       }
     },
     "packages/ui-native": {
-      "name": "@amplify-ai/ui-native",
+      "name": "@one-impression/ui-native",
       "version": "1.0.0",
       "devDependencies": {
         "@types/react": "^18.2.0",
@@ -12687,7 +14003,7 @@
         "typescript": "^5.5.0"
       },
       "peerDependencies": {
-        "@amplify-ai/tokens-creator": ">=2.0.3",
+        "@one-impression/tokens-creator": ">=2.0.3",
         "react": ">=18.0.0",
         "react-native": ">=0.72.0"
       }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,9 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "devDependencies": {
+    "@changesets/changelog-github": "^0.7.0",
+    "@changesets/cli": "^2.31.0"
   }
 }

--- a/packages/brand-oportunities/BRAND-DECISIONS.md
+++ b/packages/brand-oportunities/BRAND-DECISIONS.md
@@ -2,7 +2,7 @@
 
 Final record of every brand decision for **Oportunities** as of 2026-05-19.
 This file is the source-of-truth for the asset package. Token values live in
-`@amplify-ai/tokens-oportunities`.
+`@one-impression/tokens-oportunities`.
 
 ---
 
@@ -153,5 +153,5 @@ but for the **brand assets** specifically:
 
 Pending decisions (NOT in this asset package):
 - Long-form brand voice doc (separate concern, lives in marketing wiki)
-- Motion grammar for in-product transitions (handled by `@amplify-ai/tokens-foundation/motion`)
+- Motion grammar for in-product transitions (handled by `@one-impression/tokens-foundation/motion`)
 - Sound / haptics (deferred until mobile app GA)

--- a/packages/brand-oportunities/ENGINEER-HANDOFF.md
+++ b/packages/brand-oportunities/ENGINEER-HANDOFF.md
@@ -1,35 +1,35 @@
 # Oportunities — Engineer hand-off guide
 
 ## What's been built (all in this PR)
-- `@amplify-ai/tokens-oportunities@1.0.0`
-- `@amplify-ai/brand-oportunities@1.0.0`
-- New components in `@amplify-ai/ui` (`Wordmark`, `SignalDot`, `CreatorIntentCard`, `BrandInterestCard`, `IntentFeed`, `AppIconOportunities`)
+- `@one-impression/tokens-oportunities@1.0.0`
+- `@one-impression/brand-oportunities@1.0.0`
+- New components in `@one-impression/ui` (`Wordmark`, `SignalDot`, `CreatorIntentCard`, `BrandInterestCard`, `IntentFeed`, `AppIconOportunities`)
 - Storybook theme + 8 brand guidelines docs
 
 ## How to consume in a product app
 
 ### Step 1: install tokens + UI
 ```bash
-npm install @amplify-ai/tokens-oportunities @amplify-ai/ui @amplify-ai/brand-oportunities
+npm install @one-impression/tokens-oportunities @one-impression/ui @one-impression/brand-oportunities
 ```
 
 ### Step 2: load CSS or Tailwind
 
 Option A (CSS vars):
 ```ts
-import '@amplify-ai/tokens-oportunities/css';
+import '@one-impression/tokens-oportunities/css';
 ```
 
 Option B (Tailwind preset):
 ```ts
 // tailwind.config.ts
-import oportunitiesPreset from '@amplify-ai/tokens-oportunities/tailwind';
+import oportunitiesPreset from '@one-impression/tokens-oportunities/tailwind';
 export default { presets: [oportunitiesPreset], ... };
 ```
 
 ### Step 3: use components
 ```tsx
-import { Wordmark, SignalDot, CreatorIntentCard } from '@amplify-ai/ui';
+import { Wordmark, SignalDot, CreatorIntentCard } from '@one-impression/ui';
 
 <Wordmark size="xl" animated />
 <SignalDot size={24} live />
@@ -38,9 +38,9 @@ import { Wordmark, SignalDot, CreatorIntentCard } from '@amplify-ai/ui';
 
 ### Step 4: brand assets
 ```ts
-import { wordmark, appIcon } from '@amplify-ai/brand-oportunities';
+import { wordmark, appIcon } from '@one-impression/brand-oportunities';
 // Or reference directly:
-<img src="/node_modules/@amplify-ai/brand-oportunities/assets/logo/wordmark-default.svg" />
+<img src="/node_modules/@one-impression/brand-oportunities/assets/logo/wordmark-default.svg" />
 ```
 
 ## What you still need to build (product code, not design system)

--- a/packages/brand-oportunities/README.md
+++ b/packages/brand-oportunities/README.md
@@ -1,10 +1,10 @@
-# @amplify-ai/brand-oportunities
+# @one-impression/brand-oportunities
 
 Locked brand assets for **Oportunities** — the creator-intent intelligence platform.
 Theme direction: **Studio** (Geist + apricot period).
 
 This package ships ready-to-use SVG/HTML assets — no build step, no token wiring.
-For runtime tokens (colors, type, spacing), use `@amplify-ai/tokens-oportunities`.
+For runtime tokens (colors, type, spacing), use `@one-impression/tokens-oportunities`.
 
 ---
 
@@ -91,7 +91,7 @@ locked.
 ## Programmatic access
 
 ```js
-import { wordmark, appIcon, favicon, brandColors } from '@amplify-ai/brand-oportunities';
+import { wordmark, appIcon, favicon, brandColors } from '@one-impression/brand-oportunities';
 
 // Returns asset paths relative to the package root.
 console.log(wordmark.default); // 'assets/logo/wordmark-default.svg'
@@ -102,5 +102,5 @@ console.log(brandColors.apricot); // '#E89252'
 
 ## Related packages
 
-- **`@amplify-ai/tokens-oportunities`** — runtime tokens (colors, type, spacing) as CSS / SCSS / JS
-- **`@amplify-ai/ui`** — shared components themed via tokens-oportunities
+- **`@one-impression/tokens-oportunities`** — runtime tokens (colors, type, spacing) as CSS / SCSS / JS
+- **`@one-impression/ui`** — shared components themed via tokens-oportunities

--- a/packages/brand-oportunities/index.js
+++ b/packages/brand-oportunities/index.js
@@ -1,5 +1,5 @@
 /**
- * @amplify-ai/brand-oportunities
+ * @one-impression/brand-oportunities
  * Asset path exports — resolve from package root.
  */
 

--- a/packages/brand-oportunities/package.json
+++ b/packages/brand-oportunities/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify-ai/brand-oportunities",
+  "name": "@one-impression/brand-oportunities",
   "version": "1.0.0",
   "type": "module",
   "description": "Oportunities brand assets — wordmark SVGs, app icons, favicons, social templates, business cards, email signature",

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,18 +1,18 @@
 /**
- * @amplify-ai/eslint-config — Shared ESLint flat config (recommended preset)
+ * @one-impression/eslint-config — Shared ESLint flat config (recommended preset)
  *
  * Enforces Amplify design token usage across consuming projects.
  *
  * Usage (eslint.config.js):
- *   import amplifyConfig from '@amplify-ai/eslint-config';
+ *   import amplifyConfig from '@one-impression/eslint-config';
  *   export default [...amplifyConfig];
  *
  * Or CommonJS:
- *   const amplifyConfig = require('@amplify-ai/eslint-config');
+ *   const amplifyConfig = require('@one-impression/eslint-config');
  *   module.exports = [...amplifyConfig];
  *
  * For hard CI enforcement (every violation = error), use the strict preset:
- *   import amplifyStrict from '@amplify-ai/eslint-config/strict';
+ *   import amplifyStrict from '@one-impression/eslint-config/strict';
  *   export default [...amplifyStrict];
  */
 'use strict';
@@ -27,7 +27,7 @@ const noHardcodedTypography = require('./rules/no-hardcoded-typography');
 
 const plugin = {
   meta: {
-    name: '@amplify-ai/eslint-plugin',
+    name: '@one-impression/eslint-plugin',
     version: '2.1.0',
   },
   rules: {
@@ -48,13 +48,13 @@ module.exports = [
       '@amplify-ai': plugin,
     },
     rules: {
-      '@amplify-ai/no-hardcoded-colors': 'warn',
-      '@amplify-ai/no-raw-spacing': 'warn',
-      '@amplify-ai/prefer-token-import': 'warn',
-      '@amplify-ai/no-inline-styles': 'warn',
-      '@amplify-ai/no-raw-surface': 'warn',
-      '@amplify-ai/no-hardcoded-radius': 'warn',
-      '@amplify-ai/no-hardcoded-typography': 'warn',
+      '@one-impression/no-hardcoded-colors': 'warn',
+      '@one-impression/no-raw-spacing': 'warn',
+      '@one-impression/prefer-token-import': 'warn',
+      '@one-impression/no-inline-styles': 'warn',
+      '@one-impression/no-raw-surface': 'warn',
+      '@one-impression/no-hardcoded-radius': 'warn',
+      '@one-impression/no-hardcoded-typography': 'warn',
     },
   },
 ];

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify-ai/eslint-config",
+  "name": "@one-impression/eslint-config",
   "version": "2.1.0",
   "description": "Shared ESLint flat config enforcing Amplify design token usage (no-hardcoded-colors, no-raw-spacing, prefer-token-import, no-inline-styles, no-raw-surface, no-hardcoded-radius, no-hardcoded-typography)",
   "main": "index.js",
@@ -21,5 +21,8 @@
     "index.js",
     "strict.js",
     "rules/"
-  ]
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
 }

--- a/packages/eslint-config/rules/no-hardcoded-colors.js
+++ b/packages/eslint-config/rules/no-hardcoded-colors.js
@@ -1,5 +1,5 @@
 /**
- * @amplify-ai/eslint-config — no-hardcoded-colors
+ * @one-impression/eslint-config — no-hardcoded-colors
  *
  * Flags hex colour literals (#fff, #ff0000, #FF000080) in:
  *   - JSX style props: style={{ color: '#FF0000' }}
@@ -31,7 +31,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description:
-        'Disallow hardcoded hex colour literals; require Amplify design tokens (CSS vars or @amplify-ai/tokens-* imports)',
+        'Disallow hardcoded hex colour literals; require Amplify design tokens (CSS vars or @one-impression/tokens-* imports)',
       recommended: true,
     },
     schema: [],

--- a/packages/eslint-config/rules/no-hardcoded-radius.js
+++ b/packages/eslint-config/rules/no-hardcoded-radius.js
@@ -1,5 +1,5 @@
 /**
- * @amplify-ai/no-hardcoded-radius
+ * @one-impression/no-hardcoded-radius
  *
  * Flags Tailwind hardcoded border-radius classes. Use design token radii instead:
  *   rounded-[var(--radius-card)]  — 16px, for cards and containers

--- a/packages/eslint-config/rules/no-hardcoded-typography.js
+++ b/packages/eslint-config/rules/no-hardcoded-typography.js
@@ -1,5 +1,5 @@
 /**
- * @amplify-ai/no-hardcoded-typography
+ * @one-impression/no-hardcoded-typography
  *
  * Flags arbitrary pixel font sizes in Tailwind classes like text-[13px], text-[11px].
  * Use Tailwind's built-in scale instead:

--- a/packages/eslint-config/rules/no-inline-styles.js
+++ b/packages/eslint-config/rules/no-inline-styles.js
@@ -1,5 +1,5 @@
 /**
- * @amplify-ai/no-inline-styles
+ * @one-impression/no-inline-styles
  *
  * Flags inline style={{}} objects in JSX. These bypass the design token system
  * and can't be themed, audited, or updated globally.

--- a/packages/eslint-config/rules/no-raw-spacing.js
+++ b/packages/eslint-config/rules/no-raw-spacing.js
@@ -1,5 +1,5 @@
 /**
- * @amplify-ai/eslint-config — no-raw-spacing
+ * @one-impression/eslint-config — no-raw-spacing
  *
  * Flags raw pixel/em/rem literals used as spacing in JSX style props or
  * style objects, e.g.:
@@ -57,7 +57,7 @@ module.exports = {
     schema: [],
     messages: {
       noRawSpacing:
-        'Raw spacing value `{{value}}` for `{{prop}}` — use a token like var(--amp-spacing-md) or @amplify-ai/tokens-foundation/js.',
+        'Raw spacing value `{{value}}` for `{{prop}}` — use a token like var(--amp-spacing-md) or @one-impression/tokens-foundation/js.',
     },
   },
   create(context) {

--- a/packages/eslint-config/rules/no-raw-surface.js
+++ b/packages/eslint-config/rules/no-raw-surface.js
@@ -1,5 +1,5 @@
 /**
- * @amplify-ai/no-raw-surface
+ * @one-impression/no-raw-surface
  *
  * Flags bg-[var(--surface-elevated/secondary/tertiary/overlay)] without a visible
  * boundary (ring, border, or shadow). In light mode, elevated surfaces are white

--- a/packages/eslint-config/rules/prefer-token-import.js
+++ b/packages/eslint-config/rules/prefer-token-import.js
@@ -1,5 +1,5 @@
 /**
- * @amplify-ai/eslint-config — prefer-token-import
+ * @one-impression/eslint-config — prefer-token-import
  *
  * Flags direct color/token imports from product-local or legacy modules that
  * should be Amplify token imports instead.
@@ -12,9 +12,9 @@
  *   import x from '../design-tokens';
  *
  * Acceptable:
- *   import tokens from '@amplify-ai/tokens-foundation/js';
- *   import { colors } from '@amplify-ai/tokens-creator';
- *   @import "@amplify-ai/tokens-foundation/css";
+ *   import tokens from '@one-impression/tokens-foundation/js';
+ *   import { colors } from '@one-impression/tokens-creator';
+ *   @import "@one-impression/tokens-foundation/css";
  */
 'use strict';
 
@@ -31,13 +31,13 @@ const SUSPECT_PATTERNS = [
 
 // Legacy patterns with explicit replacement suggestions
 const LEGACY_PATTERNS = [
-  { pattern: /^@oneimpression\/tokens/, suggested: '@amplify-ai/tokens-brand' },
-  { pattern: /\.\.\/.*styles\/colors/, suggested: '@amplify-ai/tokens-creator or @amplify-ai/tokens-brand' },
-  { pattern: /\.\.\/.*design-tokens/, suggested: '@amplify-ai/tokens-brand' },
+  { pattern: /^@oneimpression\/tokens/, suggested: '@one-impression/tokens-brand' },
+  { pattern: /\.\.\/.*styles\/colors/, suggested: '@one-impression/tokens-creator or @one-impression/tokens-brand' },
+  { pattern: /\.\.\/.*design-tokens/, suggested: '@one-impression/tokens-brand' },
 ];
 
 const ALLOWED_PREFIXES = [
-  '@amplify-ai/',
+  '@one-impression/',
   '@amplify/',
 ];
 
@@ -54,13 +54,13 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description:
-        'Prefer @amplify-ai/tokens-* imports over product-local or legacy color/palette/token modules',
+        'Prefer @one-impression/tokens-* imports over product-local or legacy color/palette/token modules',
       recommended: true,
     },
     schema: [],
     messages: {
       preferTokenImport:
-        'Local color import "{{source}}" — prefer @amplify-ai/tokens-foundation (or product token package).',
+        'Local color import "{{source}}" — prefer @one-impression/tokens-foundation (or product token package).',
       preferAmplifyTokens:
         'Import from "{{suggested}}" instead of legacy path "{{source}}".',
     },

--- a/packages/eslint-config/strict.js
+++ b/packages/eslint-config/strict.js
@@ -1,12 +1,12 @@
 /**
- * @amplify-ai/eslint-config/strict — strict (error-level) flat config
+ * @one-impression/eslint-config/strict — strict (error-level) flat config
  *
  * Same rules as the recommended preset, but every violation is an `error`
  * instead of `warn`. Use this preset in CI gates and when you want hard
  * enforcement for design-system compliance.
  *
  * Usage:
- *   import amplifyStrict from '@amplify-ai/eslint-config/strict';
+ *   import amplifyStrict from '@one-impression/eslint-config/strict';
  *   export default [...amplifyStrict];
  */
 'use strict';
@@ -21,13 +21,13 @@ module.exports = [
       '@amplify-ai': plugin,
     },
     rules: {
-      '@amplify-ai/no-hardcoded-colors': 'error',
-      '@amplify-ai/no-raw-spacing': 'error',
-      '@amplify-ai/prefer-token-import': 'error',
-      '@amplify-ai/no-inline-styles': 'error',
-      '@amplify-ai/no-raw-surface': 'error',
-      '@amplify-ai/no-hardcoded-radius': 'error',
-      '@amplify-ai/no-hardcoded-typography': 'error',
+      '@one-impression/no-hardcoded-colors': 'error',
+      '@one-impression/no-raw-spacing': 'error',
+      '@one-impression/prefer-token-import': 'error',
+      '@one-impression/no-inline-styles': 'error',
+      '@one-impression/no-raw-surface': 'error',
+      '@one-impression/no-hardcoded-radius': 'error',
+      '@one-impression/no-hardcoded-typography': 'error',
     },
   },
 ];

--- a/packages/eslint-config/test/rules.test.js
+++ b/packages/eslint-config/test/rules.test.js
@@ -61,7 +61,7 @@ test('no-raw-spacing', () => {
 test('prefer-token-import', () => {
   tester.run('prefer-token-import', preferTokenImport, {
     valid: [
-      { code: "import x from '@amplify-ai/tokens-foundation';" },
+      { code: "import x from '@one-impression/tokens-foundation';" },
       { code: "import x from 'react';" },
     ],
     invalid: [

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify-ai/feature-flags",
+  "name": "@one-impression/feature-flags",
   "version": "2.0.1",
   "description": "Feature flag client and React hooks for Amplify platform",
   "main": "src/index.ts",

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,4 +1,4 @@
-# @amplify-ai/mcp-server
+# @one-impression/mcp-server
 
 MCP server exposing the Amplify Canvas design system to AI agents (Pixel, Claude Code, etc.).
 
@@ -6,7 +6,7 @@ MCP server exposing the Amplify Canvas design system to AI agents (Pixel, Claude
 
 | Tool | Purpose |
 |------|---------|
-| `list_components` | All components in `@amplify-ai/ui` with one-line descriptions and tags. |
+| `list_components` | All components in `@one-impression/ui` with one-line descriptions and tags. |
 | `get_props` | Full prop signature for a component (variants, sizes, states, required props). |
 | `find_block` | Search the templates package for blocks matching a use case (e.g. "checkout", "stepper"). |
 | `validate_usage` | Validate a JSX snippet against component contracts — reports invalid props/values. |
@@ -37,7 +37,7 @@ Add to `~/.claude/.mcp.json`:
   "mcpServers": {
     "canvas": {
       "command": "npx",
-      "args": ["-y", "@amplify-ai/mcp-server"]
+      "args": ["-y", "@one-impression/mcp-server"]
     }
   }
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify-ai/mcp-server",
+  "name": "@one-impression/mcp-server",
   "version": "2.0.1",
   "description": "MCP server exposing the Amplify Canvas design system to AI agents (Pixel, Claude Code).",
   "type": "module",
@@ -42,5 +42,8 @@
     "tsup": "^8.0.0",
     "tsx": "^4.16.0",
     "typescript": "^5.4.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
   }
 }

--- a/packages/mcp-server/src/data/components.ts
+++ b/packages/mcp-server/src/data/components.ts
@@ -38,7 +38,7 @@ const candidateContractsManifests = [
   resolve(here, '../../../ui/dist/contracts.json'),
   resolve(here, '../../../../ui/dist/contracts.json'),
   resolve(process.cwd(), 'packages/ui/dist/contracts.json'),
-  resolve(process.cwd(), 'node_modules/@amplify-ai/ui/dist/contracts.json'),
+  resolve(process.cwd(), 'node_modules/@one-impression/ui/dist/contracts.json'),
 ];
 
 const candidateComponentRoots = [

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -13,7 +13,7 @@ const main = async (): Promise<void> => {
   const http = createServer(async (req, res) => {
     if (req.url === '/health') {
       res.writeHead(200, { 'content-type': 'application/json' });
-      res.end(JSON.stringify({ status: 'ok', server: '@amplify-ai/mcp-server' }));
+      res.end(JSON.stringify({ status: 'ok', server: '@one-impression/mcp-server' }));
       return;
     }
     await transport.handleRequest(req, res);

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 const tools = [
   {
     name: 'list_components',
-    description: 'List components in @amplify-ai/ui with their variants, sizes, and forwardRef status.',
+    description: 'List components in @one-impression/ui with their variants, sizes, and forwardRef status.',
     schema: listComponentsSchema,
     handler: listComponents,
   },
@@ -60,7 +60,7 @@ const zodToInputSchema = (schema: z.ZodTypeAny): Record<string, unknown> => {
 
 export const createCanvasServer = (): Server => {
   const server = new Server(
-    { name: '@amplify-ai/mcp-server', version: '0.1.0' },
+    { name: '@one-impression/mcp-server', version: '0.1.0' },
     { capabilities: { tools: {} } }
   );
 

--- a/packages/mcp-server/src/tools/validate-usage.ts
+++ b/packages/mcp-server/src/tools/validate-usage.ts
@@ -27,7 +27,7 @@ export const validateUsage = (input: ValidateUsageInput) => {
     return {
       valid: false,
       tag,
-      issues: [{ level: 'error' as const, message: `Component "${tag}" not in @amplify-ai/ui.` }],
+      issues: [{ level: 'error' as const, message: `Component "${tag}" not in @one-impression/ui.` }],
     };
   }
 

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@amplify-ai/sdui-runtime",
+  "name": "@one-impression/sdui-runtime",
   "version": "1.0.0",
-  "description": "SDUI runtime for Amplify Creator App \u2014 interpreter, action engine, bottom-sheet manager, loaders, providers",
+  "description": "SDUI runtime for Amplify Creator App — interpreter, action engine, bottom-sheet manager, loaders, providers",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -40,8 +40,8 @@
     "react": ">=18.0.0",
     "react-native": ">=0.72.0",
     "@one-impression/sdk-native-sdui": ">=1.0.0",
-    "@amplify-ai/ui-native": ">=1.0.0",
-    "@amplify-ai/tokens-creator": ">=2.0.3",
+    "@one-impression/ui-native": ">=1.0.0",
+    "@one-impression/tokens-creator": ">=2.0.3",
     "@gorhom/bottom-sheet": "^5.0.0",
     "react-native-webview": ">=13.0.0"
   },
@@ -64,5 +64,8 @@
   "devDependencies": {
     "tsup": "^8.0.0",
     "typescript": "^5.5.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
   }
 }

--- a/packages/sdui-runtime/src/index.ts
+++ b/packages/sdui-runtime/src/index.ts
@@ -1,4 +1,4 @@
-// @amplify-ai/sdui-runtime — SDUI runtime for Amplify Creator App
+// @one-impression/sdui-runtime — SDUI runtime for Amplify Creator App
 // Renderers + runtime + state + action engine + bottom-sheet manager + loaders.
 // React Native code — NOT Node-safe. Backend consumers use @one-impression/sdk-native-sdui instead.
 

--- a/packages/sdui-runtime/src/snippets/Aerobar/Aerobar.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/Aerobar/Aerobar.renderer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { AerobarSchema } from "@one-impression/sdk-native-sdui";
-import { ScrollView, Box } from "@amplify-ai/ui-native";
+import { ScrollView, Box } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/snippets/BannerImage/BannerImage.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/BannerImage/BannerImage.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { BannerImageSchema } from "@one-impression/sdk-native-sdui";
-import { Image as DSImage } from "@amplify-ai/ui-native";
+import { Image as DSImage } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function BannerImageRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/snippets/BottomSheetFooter/BottomSheetFooter.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/BottomSheetFooter/BottomSheetFooter.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { BottomSheetFooterSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack } from "@amplify-ai/ui-native";
+import { Box, Stack } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/snippets/BottomSheetHeader/BottomSheetHeader.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/BottomSheetHeader/BottomSheetHeader.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { BottomSheetHeaderSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack, Text, Icon as DSIcon } from "@amplify-ai/ui-native";
+import { Box, Stack, Text, Icon as DSIcon } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function BottomSheetHeaderRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/snippets/BottomSheetHeaderWithSearch/BottomSheetHeaderWithSearch.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/BottomSheetHeaderWithSearch/BottomSheetHeaderWithSearch.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { BottomSheetHeaderWithSearchSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack, Text, Icon as DSIcon } from "@amplify-ai/ui-native";
+import { Box, Stack, Text, Icon as DSIcon } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/snippets/BottomSheetInput/BottomSheetInput.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/BottomSheetInput/BottomSheetInput.renderer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { BottomSheetInputSchema } from "@one-impression/sdk-native-sdui";
-import { Input as DSInput, Box, Text } from "@amplify-ai/ui-native";
+import { Input as DSInput, Box, Text } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";
 

--- a/packages/sdui-runtime/src/snippets/BottomSheetInputSection/BottomSheetInputSection.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/BottomSheetInputSection/BottomSheetInputSection.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { BottomSheetInputSectionSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack, Text, Icon as DSIcon } from "@amplify-ai/ui-native";
+import { Box, Stack, Text, Icon as DSIcon } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function BottomSheetInputSectionRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/snippets/Card/Card.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/Card/Card.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { CardSnippetSchema } from "@one-impression/sdk-native-sdui";
-import { Card as DSCard } from "@amplify-ai/ui-native";
+import { Card as DSCard } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/snippets/Chip/Chip.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/Chip/Chip.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { ChipSnippetSchema } from "@one-impression/sdk-native-sdui";
-import { Chip as DSChip, Icon as DSIcon } from "@amplify-ai/ui-native";
+import { Chip as DSChip, Icon as DSIcon } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function ChipRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/snippets/EmptySpace/EmptySpace.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/EmptySpace/EmptySpace.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { EmptySpaceSchema } from "@one-impression/sdk-native-sdui";
-import { Box } from "@amplify-ai/ui-native";
+import { Box } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function EmptySpaceRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/snippets/EmptyState/EmptyState.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/EmptyState/EmptyState.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { EmptyStateSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack, Text, Icon as DSIcon, Image as DSImage } from "@amplify-ai/ui-native";
+import { Box, Stack, Text, Icon as DSIcon, Image as DSImage } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/snippets/Form/Form.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/Form/Form.renderer.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useRef, useCallback } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { FormSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack } from "@amplify-ai/ui-native";
+import { Box, Stack } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";

--- a/packages/sdui-runtime/src/snippets/GroupChips/GroupChips.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/GroupChips/GroupChips.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { GroupChipsSchema } from "@one-impression/sdk-native-sdui";
-import { ScrollView } from "@amplify-ai/ui-native";
+import { ScrollView } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/snippets/GroupConfig/GroupConfig.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/GroupConfig/GroupConfig.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { GroupConfigSchema } from "@one-impression/sdk-native-sdui";
-import { Stack } from "@amplify-ai/ui-native";
+import { Stack } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/snippets/GroupSnippets/GroupSnippets.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/GroupSnippets/GroupSnippets.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { GroupSnippetsSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack } from "@amplify-ai/ui-native";
+import { Box, Stack } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/snippets/GroupSteps/GroupSteps.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/GroupSteps/GroupSteps.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { GroupStepsSchema } from "@one-impression/sdk-native-sdui";
-import { Stack } from "@amplify-ai/ui-native";
+import { Stack } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/snippets/ImageCarousel/ImageCarousel.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/ImageCarousel/ImageCarousel.renderer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { ImageCarouselSchema } from "@one-impression/sdk-native-sdui";
-import { ScrollView, Box, Image as DSImage } from "@amplify-ai/ui-native";
+import { ScrollView, Box, Image as DSImage } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function ImageCarouselRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/snippets/ImageStack/ImageStack.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/ImageStack/ImageStack.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { ImageStackSnippetSchema } from "@one-impression/sdk-native-sdui";
-import { ImageStack as DSImageStack } from "@amplify-ai/ui-native";
+import { ImageStack as DSImageStack } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function ImageStackRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/snippets/InfoBreakdownRow/InfoBreakdownRow.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/InfoBreakdownRow/InfoBreakdownRow.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { InfoBreakdownRowSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack, Text } from "@amplify-ai/ui-native";
+import { Box, Stack, Text } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function InfoBreakdownRowRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/snippets/InfoIconRow/InfoIconRow.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/InfoIconRow/InfoIconRow.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { InfoIconRowSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack, Text, Icon as DSIcon, Card as DSCard } from "@amplify-ai/ui-native";
+import { Box, Stack, Text, Icon as DSIcon, Card as DSCard } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function InfoIconRowRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/snippets/InfoMediaRow/InfoMediaRow.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/InfoMediaRow/InfoMediaRow.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { InfoMediaRowSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack, Text } from "@amplify-ai/ui-native";
+import { Box, Stack, Text } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { renderMedia } from "../_shared/render-media.js";
 

--- a/packages/sdui-runtime/src/snippets/InfoProgressRow/InfoProgressRow.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/InfoProgressRow/InfoProgressRow.renderer.tsx
@@ -6,7 +6,7 @@ import {
   Stack,
   Text,
   ProgressIndicator as DSProgressIndicator,
-} from "@amplify-ai/ui-native";
+} from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function InfoProgressRowRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/snippets/InfoRow/InfoRow.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/InfoRow/InfoRow.renderer.tsx
@@ -9,7 +9,7 @@ import {
   Card as DSCard,
   Tag as DSTag,
   ProgressIndicator as DSProgressIndicator,
-} from "@amplify-ai/ui-native";
+} from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { renderMedia } from "../_shared/render-media.js";
 

--- a/packages/sdui-runtime/src/snippets/Input/Input.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/Input/Input.renderer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { InputSnippetSchema } from "@one-impression/sdk-native-sdui";
-import { Input as DSInput, Box, Text } from "@amplify-ai/ui-native";
+import { Input as DSInput, Box, Text } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";
 

--- a/packages/sdui-runtime/src/snippets/List/List.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/List/List.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { ListSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack } from "@amplify-ai/ui-native";
+import { Box, Stack } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/snippets/Loader/Loader.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/Loader/Loader.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { LoaderSchema } from "@one-impression/sdk-native-sdui";
-import { Box } from "@amplify-ai/ui-native";
+import { Box } from "@one-impression/ui-native";
 import { ActivityIndicator, View, StyleSheet } from "react-native";
 import { SduiNode } from "../../sdui-node/index.js";
 

--- a/packages/sdui-runtime/src/snippets/MultiSelectInput/MultiSelectInput.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/MultiSelectInput/MultiSelectInput.renderer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { MultiSelectInputSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack, Text } from "@amplify-ai/ui-native";
+import { Box, Stack, Text } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";

--- a/packages/sdui-runtime/src/snippets/OverlappingImage/OverlappingImage.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/OverlappingImage/OverlappingImage.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { OverlappingImageSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Image as DSImage } from "@amplify-ai/ui-native";
+import { Box, Image as DSImage } from "@one-impression/ui-native";
 import { View, StyleSheet } from "react-native";
 import { SduiNode } from "../../sdui-node/index.js";
 

--- a/packages/sdui-runtime/src/snippets/PageFloaterHeader/PageFloaterHeader.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/PageFloaterHeader/PageFloaterHeader.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { PageFloaterHeaderSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack, Text, Icon as DSIcon } from "@amplify-ai/ui-native";
+import { Box, Stack, Text, Icon as DSIcon } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function PageFloaterHeaderRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/snippets/PageFooter/PageFooter.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/PageFooter/PageFooter.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { PageFooterSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack } from "@amplify-ai/ui-native";
+import { Box, Stack } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/snippets/PageFooterWithCheckbox/PageFooterWithCheckbox.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/PageFooterWithCheckbox/PageFooterWithCheckbox.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { PageFooterWithCheckboxSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack } from "@amplify-ai/ui-native";
+import { Box, Stack } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/snippets/PageHeader/PageHeader.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/PageHeader/PageHeader.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { PageHeaderSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack, Text, Icon as DSIcon } from "@amplify-ai/ui-native";
+import { Box, Stack, Text, Icon as DSIcon } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/snippets/PageHeaderImageStack/PageHeaderImageStack.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/PageHeaderImageStack/PageHeaderImageStack.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { PageHeaderImageStackSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack, Text, ImageStack as DSImageStack } from "@amplify-ai/ui-native";
+import { Box, Stack, Text, ImageStack as DSImageStack } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function PageHeaderImageStackRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/snippets/PhoneNumberInput/PhoneNumberInput.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/PhoneNumberInput/PhoneNumberInput.renderer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { PhoneNumberInputSchema } from "@one-impression/sdk-native-sdui";
-import { Input as DSInput, Box, Stack, Text } from "@amplify-ai/ui-native";
+import { Input as DSInput, Box, Stack, Text } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";
 

--- a/packages/sdui-runtime/src/snippets/SectionHeader/SectionHeader.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/SectionHeader/SectionHeader.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { SectionHeaderSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack, Text } from "@amplify-ai/ui-native";
+import { Box, Stack, Text } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/snippets/Separator/Separator.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/Separator/Separator.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { SeparatorSnippetSchema } from "@one-impression/sdk-native-sdui";
-import { Separator as DSSeparator } from "@amplify-ai/ui-native";
+import { Separator as DSSeparator } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function SeparatorRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/snippets/SingleSelectInput/SingleSelectInput.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/SingleSelectInput/SingleSelectInput.renderer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { SingleSelectInputSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack, Text } from "@amplify-ai/ui-native";
+import { Box, Stack, Text } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";

--- a/packages/sdui-runtime/src/snippets/Steps/Steps.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/Steps/Steps.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { StepsSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack, Text } from "@amplify-ai/ui-native";
+import { Box, Stack, Text } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function StepsRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/snippets/Tabs/Tabs.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/Tabs/Tabs.renderer.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { TabsSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack } from "@amplify-ai/ui-native";
+import { Box, Stack } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/snippets/TabsFooter/TabsFooter.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/TabsFooter/TabsFooter.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { TabsFooterSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack } from "@amplify-ai/ui-native";
+import { Box, Stack } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/snippets/ToggleInput/ToggleInput.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/ToggleInput/ToggleInput.renderer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { ToggleInputSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack, Text } from "@amplify-ai/ui-native";
+import { Box, Stack, Text } from "@one-impression/ui-native";
 import { Switch } from "react-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";

--- a/packages/sdui-runtime/src/snippets/UploadFile/UploadFile.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/UploadFile/UploadFile.renderer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { UploadFileSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack, Text, Icon as DSIcon, Button as DSButton } from "@amplify-ai/ui-native";
+import { Box, Stack, Text, Icon as DSIcon, Button as DSButton } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";
 

--- a/packages/sdui-runtime/src/snippets/_shared/render-media.tsx
+++ b/packages/sdui-runtime/src/snippets/_shared/render-media.tsx
@@ -4,7 +4,7 @@ import {
   Icon as DSIcon,
   ImageStack as DSImageStack,
   ProgressIndicator as DSProgressIndicator,
-} from "@amplify-ai/ui-native";
+} from "@one-impression/ui-native";
 
 interface MediaImage {
   type: "image";

--- a/packages/sdui-runtime/src/theme/tokens.ts
+++ b/packages/sdui-runtime/src/theme/tokens.ts
@@ -1,15 +1,15 @@
 /**
- * tokens — maps @amplify-ai/tokens-creator values to React Native
+ * tokens — maps @one-impression/tokens-creator values to React Native
  * compatible values for runtime resolution.
  *
  * Reads the sdui namespace from tokens-creator and re-exports as
  * flat lookup maps usable by the style resolver and useToken hook.
  */
-import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import { sdui } from '@one-impression/tokens-creator/react-native';
 
 /**
  * Token category types matching the sdui namespace structure.
- * These mirror the types in @amplify-ai/ui-native/src/tokens.ts
+ * These mirror the types in @one-impression/ui-native/src/tokens.ts
  * but are defined here to avoid a hard dependency on that package.
  */
 export type TokenCategory =

--- a/packages/sdui-runtime/src/theme/useToken.ts
+++ b/packages/sdui-runtime/src/theme/useToken.ts
@@ -2,7 +2,7 @@
  * useToken — hook to resolve token strings at render time.
  *
  * Accepts a dot-notation token path and returns the resolved value.
- * Uses the token map built from @amplify-ai/tokens-creator.
+ * Uses the token map built from @one-impression/tokens-creator.
  *
  * @example
  * ```tsx

--- a/packages/sdui-runtime/src/ui_components/Button/Button.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Button/Button.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { ButtonComponentSchema } from "@one-impression/sdk-native-sdui";
-import { Button as DSButton } from "@amplify-ai/ui-native";
+import { Button as DSButton } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/ui_components/Card/Card.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Card/Card.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { CardComponentSchema } from "@one-impression/sdk-native-sdui";
-import { Card as DSCard } from "@amplify-ai/ui-native";
+import { Card as DSCard } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/ui_components/Checkbox/Checkbox.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Checkbox/Checkbox.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { CheckboxComponentSchema } from "@one-impression/sdk-native-sdui";
-import { Checkbox as DSCheckbox } from "@amplify-ai/ui-native";
+import { Checkbox as DSCheckbox } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/ui_components/Chip/Chip.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Chip/Chip.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { ChipComponentSchema } from "@one-impression/sdk-native-sdui";
-import { Chip as DSChip } from "@amplify-ai/ui-native";
+import { Chip as DSChip } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/ui_components/Icon/Icon.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Icon/Icon.renderer.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { IconComponentSchema } from "@one-impression/sdk-native-sdui";
-import { Icon as DSIcon } from "@amplify-ai/ui-native";
+import { Icon as DSIcon } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { useIconStore } from "../../icon-store/index.js";
 import { parseSvg } from "../../icon-store/parseSvg.js";

--- a/packages/sdui-runtime/src/ui_components/Image/Image.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Image/Image.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { ImageComponentSchema } from "@one-impression/sdk-native-sdui";
-import { Image as DSImage } from "@amplify-ai/ui-native";
+import { Image as DSImage } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function ImageRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/ui_components/ImageStack/ImageStack.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/ImageStack/ImageStack.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { ImageStackComponentSchema } from "@one-impression/sdk-native-sdui";
-import { ImageStack as DSImageStack } from "@amplify-ai/ui-native";
+import { ImageStack as DSImageStack } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function ImageStackRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/ui_components/Input/Input.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Input/Input.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { InputComponentSchema } from "@one-impression/sdk-native-sdui";
-import { Input as DSInput } from "@amplify-ai/ui-native";
+import { Input as DSInput } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function InputRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/ui_components/ProgressIndicator/ProgressIndicator.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/ProgressIndicator/ProgressIndicator.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { ProgressIndicatorComponentSchema } from "@one-impression/sdk-native-sdui";
-import { ProgressIndicator as DSProgressIndicator } from "@amplify-ai/ui-native";
+import { ProgressIndicator as DSProgressIndicator } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function ProgressIndicatorRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/ui_components/Radio/Radio.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Radio/Radio.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { RadioComponentSchema } from "@one-impression/sdk-native-sdui";
-import { Radio as DSRadio } from "@amplify-ai/ui-native";
+import { Radio as DSRadio } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/ui_components/ScrollView/ScrollView.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/ScrollView/ScrollView.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { ScrollViewComponentSchema } from "@one-impression/sdk-native-sdui";
-import { ScrollView as DSScrollView } from "@amplify-ai/ui-native";
+import { ScrollView as DSScrollView } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/ui_components/SearchBar/SearchBar.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/SearchBar/SearchBar.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { SearchBarComponentSchema } from "@one-impression/sdk-native-sdui";
-import { SearchBar as DSSearchBar } from "@amplify-ai/ui-native";
+import { SearchBar as DSSearchBar } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function SearchBarRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/ui_components/Section/Section.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Section/Section.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { SectionComponentSchema } from "@one-impression/sdk-native-sdui";
-import { Section as DSSection } from "@amplify-ai/ui-native";
+import { Section as DSSection } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/ui_components/SelectableItem/SelectableItem.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/SelectableItem/SelectableItem.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { SelectableItemComponentSchema } from "@one-impression/sdk-native-sdui";
-import { SelectableItem as DSSelectableItem } from "@amplify-ai/ui-native";
+import { SelectableItem as DSSelectableItem } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/ui_components/Separator/Separator.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Separator/Separator.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { SeparatorComponentSchema } from "@one-impression/sdk-native-sdui";
-import { Separator as DSSeparator } from "@amplify-ai/ui-native";
+import { Separator as DSSeparator } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function SeparatorRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/src/ui_components/Tab/Tab.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Tab/Tab.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { TabComponentSchema } from "@one-impression/sdk-native-sdui";
-import { Tab as DSTab } from "@amplify-ai/ui-native";
+import { Tab as DSTab } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/ui_components/Tag/Tag.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Tag/Tag.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { TagComponentSchema } from "@one-impression/sdk-native-sdui";
-import { Tag as DSTag } from "@amplify-ai/ui-native";
+import { Tag as DSTag } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 

--- a/packages/sdui-runtime/src/ui_components/Text/Text.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Text/Text.renderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { TextComponentSchema } from "@one-impression/sdk-native-sdui";
-import { Text as DSText } from "@amplify-ai/ui-native";
+import { Text as DSText } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 
 export function TextRenderer(node: Node): React.ReactElement {

--- a/packages/sdui-runtime/tsup.config.ts
+++ b/packages/sdui-runtime/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   // Multi-entry: emit a standalone bundle at each subpath the package
   // advertises in its `exports` map. This lets consumers do
-  // `import { x } from "@amplify-ai/sdui-runtime/bff"` without falling
+  // `import { x } from "@one-impression/sdui-runtime/bff"` without falling
   // through to `dist/index.js` (which would pull the entire bundle into
   // every consumer chunk that only needs the bff client).
   //
@@ -23,8 +23,8 @@ export default defineConfig({
     "react",
     "react-native",
     "@one-impression/sdk-native-sdui",
-    "@amplify-ai/ui-native",
-    "@amplify-ai/tokens-creator",
+    "@one-impression/ui-native",
+    "@one-impression/tokens-creator",
     "@gorhom/bottom-sheet",
     // Expo / React Native packages used via dynamic imports in capabilities/
     "expo-clipboard",

--- a/packages/storybook/.storybook/preview.ts
+++ b/packages/storybook/.storybook/preview.ts
@@ -4,7 +4,7 @@ import type { Preview } from '@storybook/react';
  * Theme switcher.
  *
  * Each entry maps a theme id to the published CSS module of its
- * @amplify-ai/tokens-* package. The CSS is loaded lazily via a
+ * @one-impression/tokens-* package. The CSS is loaded lazily via a
  * <link rel="stylesheet"> tag pointing at the package's exported
  * /css entry — so Vite does NOT need to resolve it at build time.
  *

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify-ai/storybook",
+  "name": "@one-impression/storybook",
   "version": "0.1.0",
   "private": true,
   "description": "Storybook for Amplify Design System — component documentation and visual testing",
@@ -22,7 +22,7 @@
     "vite": "^6.0.0",
     "typescript": "^5.5.0",
     "tailwindcss": "^4.0.0",
-    "@amplify-ai/ui": "*",
+    "@one-impression/ui": "*",
     "chromatic": "^11.0.0"
   }
 }

--- a/packages/storybook/public/_themes/oportunities.css
+++ b/packages/storybook/public/_themes/oportunities.css
@@ -1,7 +1,7 @@
 /* ──────────────────────────────────────────────────────────────────
  * Oportunities theme — Storybook stub.
  *
- * Mirrors the CSS variables that @amplify-ai/tokens-oportunities/css
+ * Mirrors the CSS variables that @one-impression/tokens-oportunities/css
  * publishes from tokens/theme-light.json + tokens/theme-dark.json.
  *
  * This stub exists so the Storybook theme switcher renders the

--- a/packages/storybook/stories/ActionCard.stories.tsx
+++ b/packages/storybook/stories/ActionCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ActionCard } from '@amplify-ai/ui';
+import { ActionCard } from '@one-impression/ui';
 
 const meta = {
   title: 'Recipes/ActionCard',

--- a/packages/storybook/stories/AlertBanner.stories.tsx
+++ b/packages/storybook/stories/AlertBanner.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { AlertBanner } from '@amplify-ai/ui';
+import { AlertBanner } from '@one-impression/ui';
 
 const meta = {
   title: 'Recipes/AlertBanner',

--- a/packages/storybook/stories/AnimatedNumber.stories.tsx
+++ b/packages/storybook/stories/AnimatedNumber.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-import { AnimatedNumber, Button } from '@amplify-ai/ui';
+import { AnimatedNumber, Button } from '@one-impression/ui';
 
 const meta = {
   title: 'Motion/AnimatedNumber',

--- a/packages/storybook/stories/AnnouncementBar.stories.tsx
+++ b/packages/storybook/stories/AnnouncementBar.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { AnnouncementBar } from '@amplify-ai/ui';
+import { AnnouncementBar } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/AnnouncementBar',

--- a/packages/storybook/stories/Badge.stories.tsx
+++ b/packages/storybook/stories/Badge.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Badge } from '@amplify-ai/ui';
+import { Badge } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Badge',

--- a/packages/storybook/stories/BarChart.stories.tsx
+++ b/packages/storybook/stories/BarChart.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { BarChart } from '@amplify-ai/ui';
+import { BarChart } from '@one-impression/ui';
 
 const meta = {
   title: 'Data Viz/BarChart',

--- a/packages/storybook/stories/BentoGrid.stories.tsx
+++ b/packages/storybook/stories/BentoGrid.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { BentoGrid, BentoItem } from '@amplify-ai/ui';
+import { BentoGrid, BentoItem } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Layout/BentoGrid',

--- a/packages/storybook/stories/Button.stories.tsx
+++ b/packages/storybook/stories/Button.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Button } from '@amplify-ai/ui';
+import { Button } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Button',

--- a/packages/storybook/stories/CTABand.stories.tsx
+++ b/packages/storybook/stories/CTABand.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { CTABand, Button } from '@amplify-ai/ui';
+import { CTABand, Button } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/CTABand',

--- a/packages/storybook/stories/Card.stories.tsx
+++ b/packages/storybook/stories/Card.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Card, Button, Badge } from '@amplify-ai/ui';
+import { Card, Button, Badge } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Card',

--- a/packages/storybook/stories/CardPresets.stories.tsx
+++ b/packages/storybook/stories/CardPresets.stories.tsx
@@ -7,7 +7,7 @@ import {
   MetricCard,
   WalletCard,
   CollapsibleCard,
-} from '@amplify-ai/ui';
+} from '@one-impression/ui';
 
 /**
  * One story per Card preset wrapper proving the public API still renders

--- a/packages/storybook/stories/CaseStudyCard.stories.tsx
+++ b/packages/storybook/stories/CaseStudyCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { CaseStudyCard, Button } from '@amplify-ai/ui';
+import { CaseStudyCard, Button } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/CaseStudyCard',

--- a/packages/storybook/stories/ChatInput.stories.tsx
+++ b/packages/storybook/stories/ChatInput.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-import { ChatInput, IconButton } from '@amplify-ai/ui';
+import { ChatInput, IconButton } from '@one-impression/ui';
 
 const meta = {
   title: 'Conversational/ChatInput',

--- a/packages/storybook/stories/CommandPalette.stories.tsx
+++ b/packages/storybook/stories/CommandPalette.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-import { CommandPalette, Button } from '@amplify-ai/ui';
-import type { CommandItem } from '@amplify-ai/ui';
+import { CommandPalette, Button } from '@one-impression/ui';
+import type { CommandItem } from '@one-impression/ui';
 
 const baseItems: CommandItem[] = [
   { id: 'new-campaign', label: 'New campaign', group: 'Create', shortcut: ['⌘', 'N'], onSelect: () => alert('New campaign') },

--- a/packages/storybook/stories/ComparisonTable.stories.tsx
+++ b/packages/storybook/stories/ComparisonTable.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ComparisonTable, type ComparisonRow, type ComparisonPlan } from '@amplify-ai/ui';
+import { ComparisonTable, type ComparisonRow, type ComparisonPlan } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/ComparisonTable',

--- a/packages/storybook/stories/ContextMenu.stories.tsx
+++ b/packages/storybook/stories/ContextMenu.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ContextMenu } from '@amplify-ai/ui';
-import type { ContextMenuItem } from '@amplify-ai/ui';
+import { ContextMenu } from '@one-impression/ui';
+import type { ContextMenuItem } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/ContextMenu',

--- a/packages/storybook/stories/DateRangePicker.stories.tsx
+++ b/packages/storybook/stories/DateRangePicker.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { DateRangePicker, type DateRange } from '@amplify-ai/ui';
+import { DateRangePicker, type DateRange } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Forms/DateRangePicker',

--- a/packages/storybook/stories/Density.stories.tsx
+++ b/packages/storybook/stories/Density.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Button, DensityProvider, type Density } from '@amplify-ai/ui';
+import { Button, DensityProvider, type Density } from '@one-impression/ui';
 
 const meta = {
   title: 'Foundation/Density',
@@ -14,7 +14,7 @@ Select, Chip, etc. follow) read the ambient density via \`useDensity()\`
 and select the density-appropriate row from their size table.
 
 \`\`\`tsx
-import { DensityProvider, Button } from '@amplify-ai/ui';
+import { DensityProvider, Button } from '@one-impression/ui';
 
 <DensityProvider density="compact">
   <Button size="sm">Save</Button>     {/* renders h-7 */}

--- a/packages/storybook/stories/Drawer.stories.tsx
+++ b/packages/storybook/stories/Drawer.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-import { Drawer, Button } from '@amplify-ai/ui';
+import { Drawer, Button } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Drawer',

--- a/packages/storybook/stories/EmptyState.stories.tsx
+++ b/packages/storybook/stories/EmptyState.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { EmptyState } from '@amplify-ai/ui';
+import { EmptyState } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/EmptyState',

--- a/packages/storybook/stories/EmptyStateVariants.stories.tsx
+++ b/packages/storybook/stories/EmptyStateVariants.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { EmptyState, Button } from '@amplify-ai/ui';
+import { EmptyState, Button } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/EmptyState/Variants',

--- a/packages/storybook/stories/ErrorState.stories.tsx
+++ b/packages/storybook/stories/ErrorState.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ErrorState, Button } from '@amplify-ai/ui';
+import { ErrorState, Button } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/ErrorState',

--- a/packages/storybook/stories/FAQ.stories.tsx
+++ b/packages/storybook/stories/FAQ.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { FAQ } from '@amplify-ai/ui';
+import { FAQ } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/FAQ',

--- a/packages/storybook/stories/FeatureGrid.stories.tsx
+++ b/packages/storybook/stories/FeatureGrid.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { FeatureGrid } from '@amplify-ai/ui';
+import { FeatureGrid } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/FeatureGrid',

--- a/packages/storybook/stories/FilePicker.stories.tsx
+++ b/packages/storybook/stories/FilePicker.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { FilePicker, type PickedFile } from '@amplify-ai/ui';
+import { FilePicker, type PickedFile } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Forms/FilePicker',

--- a/packages/storybook/stories/Footer.stories.tsx
+++ b/packages/storybook/stories/Footer.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
-import { Footer } from '@amplify-ai/ui';
+import { Footer } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/Footer',

--- a/packages/storybook/stories/Funnel.stories.tsx
+++ b/packages/storybook/stories/Funnel.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Funnel } from '@amplify-ai/ui';
+import { Funnel } from '@one-impression/ui';
 
 const meta = {
   title: 'Data Viz/Funnel',

--- a/packages/storybook/stories/Heatmap.stories.tsx
+++ b/packages/storybook/stories/Heatmap.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Heatmap } from '@amplify-ai/ui';
+import { Heatmap } from '@one-impression/ui';
 
 const meta = {
   title: 'Data Viz/Heatmap',

--- a/packages/storybook/stories/Hero.stories.tsx
+++ b/packages/storybook/stories/Hero.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Hero, Button } from '@amplify-ai/ui';
+import { Hero, Button } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/Hero',

--- a/packages/storybook/stories/HoverCard.stories.tsx
+++ b/packages/storybook/stories/HoverCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { HoverCard, Avatar, Button } from '@amplify-ai/ui';
+import { HoverCard, Avatar, Button } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/HoverCard',

--- a/packages/storybook/stories/IconGrid.stories.tsx
+++ b/packages/storybook/stories/IconGrid.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
-import { IconGrid, IconCallout } from '@amplify-ai/ui';
+import { IconGrid, IconCallout } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/IconGrid',

--- a/packages/storybook/stories/KPI.stories.tsx
+++ b/packages/storybook/stories/KPI.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { KPI } from '@amplify-ai/ui';
+import { KPI } from '@one-impression/ui';
 
 const meta = {
   title: 'Data Viz/KPI',

--- a/packages/storybook/stories/LineChart.stories.tsx
+++ b/packages/storybook/stories/LineChart.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { LineChart } from '@amplify-ai/ui';
+import { LineChart } from '@one-impression/ui';
 
 const meta = {
   title: 'Data Viz/LineChart',

--- a/packages/storybook/stories/LoadingState.stories.tsx
+++ b/packages/storybook/stories/LoadingState.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { LoadingState } from '@amplify-ai/ui';
+import { LoadingState } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/LoadingState',

--- a/packages/storybook/stories/LogoCloud.stories.tsx
+++ b/packages/storybook/stories/LogoCloud.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { LogoCloud } from '@amplify-ai/ui';
+import { LogoCloud } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/LogoCloud',

--- a/packages/storybook/stories/MarkdownEditor.stories.tsx
+++ b/packages/storybook/stories/MarkdownEditor.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { MarkdownEditor } from '@amplify-ai/ui';
+import { MarkdownEditor } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Forms/MarkdownEditor',

--- a/packages/storybook/stories/MarketingPage.stories.tsx
+++ b/packages/storybook/stories/MarketingPage.stories.tsx
@@ -11,7 +11,7 @@ import {
   MediaShowcase,
   Section,
   Button,
-} from '@amplify-ai/ui';
+} from '@one-impression/ui';
 
 /**
  * Marketing-page composition — shows how the new primitives plug together

--- a/packages/storybook/stories/Marquee.stories.tsx
+++ b/packages/storybook/stories/Marquee.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Marquee } from '@amplify-ai/ui';
+import { Marquee } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/Marquee',

--- a/packages/storybook/stories/MasonryGrid.stories.tsx
+++ b/packages/storybook/stories/MasonryGrid.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { MasonryGrid } from '@amplify-ai/ui';
+import { MasonryGrid } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Layout/MasonryGrid',

--- a/packages/storybook/stories/MediaShowcase.stories.tsx
+++ b/packages/storybook/stories/MediaShowcase.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { MediaShowcase, Button } from '@amplify-ai/ui';
+import { MediaShowcase, Button } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/MediaShowcase',

--- a/packages/storybook/stories/MessageBubble.stories.tsx
+++ b/packages/storybook/stories/MessageBubble.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { MessageBubble, Avatar } from '@amplify-ai/ui';
+import { MessageBubble, Avatar } from '@one-impression/ui';
 
 const meta = {
   title: 'Conversational/MessageBubble',

--- a/packages/storybook/stories/MetricGrid.stories.tsx
+++ b/packages/storybook/stories/MetricGrid.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { MetricGrid } from '@amplify-ai/ui';
+import { MetricGrid } from '@one-impression/ui';
 
 const meta = {
   title: 'Recipes/MetricGrid',

--- a/packages/storybook/stories/Parallax.stories.tsx
+++ b/packages/storybook/stories/Parallax.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Parallax, Card, CardContent } from '@amplify-ai/ui';
+import { Parallax, Card, CardContent } from '@one-impression/ui';
 
 const meta = {
   title: 'Motion/Parallax',

--- a/packages/storybook/stories/PieChart.stories.tsx
+++ b/packages/storybook/stories/PieChart.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { PieChart } from '@amplify-ai/ui';
+import { PieChart } from '@one-impression/ui';
 
 const meta = {
   title: 'Data Viz/PieChart',

--- a/packages/storybook/stories/PricingTable.stories.tsx
+++ b/packages/storybook/stories/PricingTable.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { PricingTable, Button, type PricingTier } from '@amplify-ai/ui';
+import { PricingTable, Button, type PricingTier } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/PricingTable',

--- a/packages/storybook/stories/ProgressRing.stories.tsx
+++ b/packages/storybook/stories/ProgressRing.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ProgressRing } from '@amplify-ai/ui';
+import { ProgressRing } from '@one-impression/ui';
 
 const meta = {
   title: 'Data Viz/ProgressRing',

--- a/packages/storybook/stories/Quote.stories.tsx
+++ b/packages/storybook/stories/Quote.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Quote } from '@amplify-ai/ui';
+import { Quote } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/Quote',

--- a/packages/storybook/stories/Reveal.stories.tsx
+++ b/packages/storybook/stories/Reveal.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-import { Reveal, Card, CardContent, Button } from '@amplify-ai/ui';
+import { Reveal, Card, CardContent, Button } from '@one-impression/ui';
 
 const meta = {
   title: 'Motion/Reveal',

--- a/packages/storybook/stories/ScrollProgress.stories.tsx
+++ b/packages/storybook/stories/ScrollProgress.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ScrollProgress } from '@amplify-ai/ui';
+import { ScrollProgress } from '@one-impression/ui';
 
 const meta = {
   title: 'Motion/ScrollProgress',

--- a/packages/storybook/stories/SearchCombobox.stories.tsx
+++ b/packages/storybook/stories/SearchCombobox.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { SearchCombobox } from '@amplify-ai/ui';
+import { SearchCombobox } from '@one-impression/ui';
 
 const SAMPLE = [
   { id: '1', label: 'Riya Mehta', hint: '@riyacreates' },

--- a/packages/storybook/stories/Section.stories.tsx
+++ b/packages/storybook/stories/Section.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Section, Button } from '@amplify-ai/ui';
+import { Section, Button } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/Section',

--- a/packages/storybook/stories/Sheet.stories.tsx
+++ b/packages/storybook/stories/Sheet.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-import { Sheet, Button } from '@amplify-ai/ui';
+import { Sheet, Button } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Sheet',

--- a/packages/storybook/stories/Skeleton.stories.tsx
+++ b/packages/storybook/stories/Skeleton.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Skeleton } from '@amplify-ai/ui';
+import { Skeleton } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Skeleton',

--- a/packages/storybook/stories/Sparkline.stories.tsx
+++ b/packages/storybook/stories/Sparkline.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Sparkline } from '@amplify-ai/ui';
+import { Sparkline } from '@one-impression/ui';
 
 const meta = {
   title: 'Data Viz/Sparkline',

--- a/packages/storybook/stories/SplitPane.stories.tsx
+++ b/packages/storybook/stories/SplitPane.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { SplitPane } from '@amplify-ai/ui';
+import { SplitPane } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Layout/SplitPane',

--- a/packages/storybook/stories/Stagger.stories.tsx
+++ b/packages/storybook/stories/Stagger.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-import { Stagger, Card, CardContent, Button } from '@amplify-ai/ui';
+import { Stagger, Card, CardContent, Button } from '@one-impression/ui';
 
 const meta = {
   title: 'Motion/Stagger',

--- a/packages/storybook/stories/StatLarge.stories.tsx
+++ b/packages/storybook/stories/StatLarge.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { StatLarge } from '@amplify-ai/ui';
+import { StatLarge } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/StatLarge',

--- a/packages/storybook/stories/StepHeader.stories.tsx
+++ b/packages/storybook/stories/StepHeader.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { StepHeader, Button } from '@amplify-ai/ui';
+import { StepHeader, Button } from '@one-impression/ui';
 
 const meta = {
   title: 'Recipes/StepHeader',

--- a/packages/storybook/stories/Testimonial.stories.tsx
+++ b/packages/storybook/stories/Testimonial.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Testimonial, Avatar } from '@amplify-ai/ui';
+import { Testimonial, Avatar } from '@one-impression/ui';
 
 const meta = {
   title: 'Marketing/Testimonial',

--- a/packages/storybook/stories/TypingIndicator.stories.tsx
+++ b/packages/storybook/stories/TypingIndicator.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { TypingIndicator, MessageBubble, Avatar } from '@amplify-ai/ui';
+import { TypingIndicator, MessageBubble, Avatar } from '@one-impression/ui';
 
 const meta = {
   title: 'Conversational/TypingIndicator',

--- a/packages/storybook/stories/Wizard.stories.tsx
+++ b/packages/storybook/stories/Wizard.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Wizard, type WizardStep } from '@amplify-ai/ui';
+import { Wizard, type WizardStep } from '@one-impression/ui';
 
 const meta = {
   title: 'Components/Forms/Wizard',

--- a/packages/storybook/stories/oportunities/AppIcon.mdx
+++ b/packages/storybook/stories/oportunities/AppIcon.mdx
@@ -117,17 +117,17 @@ The dot is geometric, not optical:
 ## React Usage
 
 ```tsx
-import { AppIconOportunities } from '@amplify-ai/ui';
+import { AppIconOportunities } from '@one-impression/ui';
 
 <AppIconOportunities size={180} mode="light" platform="ios" />
 <AppIconOportunities size={512} mode="dark" platform="pwa" maskable />
 <AppIconOportunities size={64} mode="light" platform="android" adaptive />
 ```
 
-Static asset paths (from `@amplify-ai/brand-oportunities`):
+Static asset paths (from `@one-impression/brand-oportunities`):
 
 ```js
-import { appIcon } from '@amplify-ai/brand-oportunities';
+import { appIcon } from '@one-impression/brand-oportunities';
 // appIcon.light1024 | light180 | dark1024 | dark180 | spec | pwaMaskable512
 ```
 

--- a/packages/storybook/stories/oportunities/AppIconOportunities.stories.tsx
+++ b/packages/storybook/stories/oportunities/AppIconOportunities.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { AppIconOportunities } from '@amplify-ai/ui';
+import { AppIconOportunities } from '@one-impression/ui';
 
 const meta = {
   title: 'Oportunities/AppIconOportunities',

--- a/packages/storybook/stories/oportunities/BrandInterestCard.stories.tsx
+++ b/packages/storybook/stories/oportunities/BrandInterestCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { BrandInterestCard } from '@amplify-ai/ui';
+import { BrandInterestCard } from '@one-impression/ui';
 
 const meta = {
   title: 'Oportunities/BrandInterestCard',

--- a/packages/storybook/stories/oportunities/Color.mdx
+++ b/packages/storybook/stories/oportunities/Color.mdx
@@ -8,7 +8,7 @@ Warm, intellectual, AI-native. **Apricot** is the brand color, **AI purple** is 
 paired accent for AI-generated surfaces, and the **effort palette** classifies
 creator content by intent (organic / sample / sponsor / paid).
 
-All values authoritative from `@amplify-ai/tokens-oportunities` (`theme-light.json`, `theme-dark.json`).
+All values authoritative from `@one-impression/tokens-oportunities` (`theme-light.json`, `theme-dark.json`).
 
 ---
 

--- a/packages/storybook/stories/oportunities/Components.mdx
+++ b/packages/storybook/stories/oportunities/Components.mdx
@@ -40,7 +40,7 @@ Surfaces a creator's recent signals toward a brand. Used in the IntentFeed and M
 </div>
 
 ```tsx
-import { CreatorIntentCard } from '@amplify-ai/ui';
+import { CreatorIntentCard } from '@one-impression/ui';
 
 <CreatorIntentCard
   creator={{ name: 'Aanya Mehra', handle: 'aanyam', avatarUrl }}

--- a/packages/storybook/stories/oportunities/CreatorIntentCard.stories.tsx
+++ b/packages/storybook/stories/oportunities/CreatorIntentCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { CreatorIntentCard } from '@amplify-ai/ui';
+import { CreatorIntentCard } from '@one-impression/ui';
 
 const meta = {
   title: 'Oportunities/CreatorIntentCard',

--- a/packages/storybook/stories/oportunities/Favicon.mdx
+++ b/packages/storybook/stories/oportunities/Favicon.mdx
@@ -86,7 +86,7 @@ No wordmark, no letters, no gradient: just a clean apricot circle on a warm-surf
 
 ## File Inventory
 
-From `@amplify-ai/brand-oportunities/assets/favicons/`:
+From `@one-impression/brand-oportunities/assets/favicons/`:
 
 | File | Use |
 |---|---|

--- a/packages/storybook/stories/oportunities/IntentFeed.stories.tsx
+++ b/packages/storybook/stories/oportunities/IntentFeed.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { IntentFeed, type CreatorIntentCardProps, type IntentFeedFilters } from '@amplify-ai/ui';
+import { IntentFeed, type CreatorIntentCardProps, type IntentFeedFilters } from '@one-impression/ui';
 
 const meta = {
   title: 'Oportunities/IntentFeed',

--- a/packages/storybook/stories/oportunities/Logo.mdx
+++ b/packages/storybook/stories/oportunities/Logo.mdx
@@ -111,7 +111,7 @@ needs room to breathe.
 ## Implementation
 
 ```tsx
-import { Wordmark } from '@amplify-ai/ui';
+import { Wordmark } from '@one-impression/ui';
 
 // Default — picks light/dark from theme
 <Wordmark />
@@ -122,9 +122,9 @@ import { Wordmark } from '@amplify-ai/ui';
 <Wordmark variant="monochrome" color="#1C1611" />
 ```
 
-Raw SVG paths (from `@amplify-ai/brand-oportunities`):
+Raw SVG paths (from `@one-impression/brand-oportunities`):
 
 ```js
-import { wordmark } from '@amplify-ai/brand-oportunities';
+import { wordmark } from '@one-impression/brand-oportunities';
 // wordmark.default | onLight | onDark | monochrome | withGradient | spec
 ```

--- a/packages/storybook/stories/oportunities/SignalDot.stories.tsx
+++ b/packages/storybook/stories/oportunities/SignalDot.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { SignalDot } from '@amplify-ai/ui';
+import { SignalDot } from '@one-impression/ui';
 
 const meta = {
   title: 'Oportunities/SignalDot',

--- a/packages/storybook/stories/oportunities/Typography.mdx
+++ b/packages/storybook/stories/oportunities/Typography.mdx
@@ -123,7 +123,7 @@ Use for any value that is numeric, identifier, code, or system output. **Never**
 ## Implementation (tokens)
 
 ```css
-/* From @amplify-ai/tokens-oportunities/css */
+/* From @one-impression/tokens-oportunities/css */
 :root {
   --font-display: 'Geist', 'Inter Tight', sans-serif;
   --font-body:    'Inter', system-ui, sans-serif;

--- a/packages/storybook/stories/oportunities/Voice.mdx
+++ b/packages/storybook/stories/oportunities/Voice.mdx
@@ -171,7 +171,7 @@ Three creators agreed today. See them all in the cockpit.
 
 ## Implementation Notes
 
-- All UI strings live in `@amplify-ai/ui` component defaults — override per surface, never invent.
+- All UI strings live in `@one-impression/ui` component defaults — override per surface, never invent.
 - The opener (`Heads up —`) is rendered as a span with `font-weight: 600` to give it a soft visual anchor.
 - Em-dashes (`—`) not hyphens (`-`). Always.
 - No emojis at the **start** of strings. Mid-string emoji is fine if the source is user-generated.

--- a/packages/storybook/stories/oportunities/Wordmark.stories.tsx
+++ b/packages/storybook/stories/oportunities/Wordmark.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Wordmark } from '@amplify-ai/ui';
+import { Wordmark } from '@one-impression/ui';
 
 const meta = {
   title: 'Oportunities/Wordmark',

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify-ai/templates",
+  "name": "@one-impression/templates",
   "version": "2.0.1",
   "description": "React SSR template engine for instant interactive mockups \u2014 100% Canvas design system compliant",
   "type": "module",
@@ -12,8 +12,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@amplify-ai/ui": "^2.0.1",
-    "@amplify-ai/tokens-brand": "^3.0.0"
+    "@one-impression/ui": "^2.0.1",
+    "@one-impression/tokens-brand": "^3.0.0"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/templates/src/base-css.ts
+++ b/packages/templates/src/base-css.ts
@@ -8,7 +8,7 @@ export function getBaseCSS(): string {
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--amp-font);background:var(--amp-bg);color:var(--amp-text);font-size:var(--amp-text-base);line-height:1.5;min-height:100vh;-webkit-font-smoothing:antialiased}
 
-/* ═══ Card — matches @amplify-ai/ui Card component ═══ */
+/* ═══ Card — matches @one-impression/ui Card component ═══ */
 /* Default: rounded-[16px] border border-[border-default] bg-[bg-surface] */
 .amp-card{background:var(--amp-surface);border-radius:var(--amp-radius-xl);border:1px solid var(--amp-border);transition:all var(--amp-transition);overflow:hidden}
 /* Interactive variant: hover:shadow-lg */
@@ -21,7 +21,7 @@ body{font-family:var(--amp-font);background:var(--amp-bg);color:var(--amp-text);
 /* Elevated variant */
 .amp-card.elevated{box-shadow:var(--amp-shadow-lg)}
 
-/* ═══ Button — matches @amplify-ai/ui Button component ═══ */
+/* ═══ Button — matches @one-impression/ui Button component ═══ */
 /* Base: inline-flex items-center justify-center font-medium transition-all duration-150 */
 .amp-btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;height:40px;padding:0 16px;border-radius:6px;font-size:var(--amp-text-base);font-weight:500;border:none;cursor:pointer;transition:all 150ms ease;font-family:var(--amp-font);outline:none}
 .amp-btn:focus-visible{outline:none;box-shadow:0 0 0 2px var(--amp-surface),0 0 0 4px rgba(101,49,255,0.4)}
@@ -52,7 +52,7 @@ body{font-family:var(--amp-font);background:var(--amp-bg);color:var(--amp-text);
 /* Full width */
 .amp-btn-full{width:100%}
 
-/* ═══ Input — matches @amplify-ai/ui Input component ═══ */
+/* ═══ Input — matches @one-impression/ui Input component ═══ */
 /* h-10 px-3 rounded-[16px] text-[14px] border border-[border-default] */
 .amp-input{width:100%;height:40px;padding:0 12px;border:1px solid var(--amp-border);border-radius:var(--amp-radius-xl);font-size:var(--amp-text-base);font-family:var(--amp-font);background:var(--amp-surface);color:var(--amp-text);outline:none;transition:colors 150ms ease}
 .amp-input::placeholder{color:var(--amp-text-muted)}
@@ -60,12 +60,12 @@ body{font-family:var(--amp-font);background:var(--amp-bg);color:var(--amp-text);
 textarea.amp-input{height:auto;min-height:80px;padding:var(--amp-sp-3) 12px;resize:vertical}
 select.amp-input{appearance:none;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 12px center;padding-right:32px}
 
-/* ═══ Chip — matches @amplify-ai/ui chip-like patterns ═══ */
+/* ═══ Chip — matches @one-impression/ui chip-like patterns ═══ */
 .amp-chip{display:inline-flex;align-items:center;gap:6px;padding:var(--amp-sp-1) var(--amp-sp-3);border-radius:var(--amp-radius-full);font-size:var(--amp-text-sm);font-weight:500;border:1px solid var(--amp-border);background:var(--amp-surface);color:var(--amp-text-secondary);cursor:pointer;transition:all 150ms ease;user-select:none}
 .amp-chip:hover{border-color:var(--amp-border-strong);background:var(--amp-surface-overlay)}
 .amp-chip.active{background:var(--amp-accent);border-color:var(--amp-accent);color:#fff}
 
-/* ═══ Badge — matches @amplify-ai/ui Badge component ═══ */
+/* ═══ Badge — matches @one-impression/ui Badge component ═══ */
 /* Base: inline-flex items-center gap-1.5 font-medium whitespace-nowrap */
 .amp-badge{display:inline-flex;align-items:center;gap:6px;padding:2px 10px;border-radius:6px;font-size:var(--amp-text-sm);font-weight:500;white-space:nowrap}
 /* Brand: bg-brand-light text-brand border border-brand/20 */

--- a/packages/templates/src/components/ordering/BudgetSection.tsx
+++ b/packages/templates/src/components/ordering/BudgetSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Badge } from '@amplify-ai/ui';
+import { Card, Badge } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 interface PackageItem {

--- a/packages/templates/src/components/ordering/Checkout.tsx
+++ b/packages/templates/src/components/ordering/Checkout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Button } from '@amplify-ai/ui';
+import { Card, Button } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 export const Checkout: ComponentRenderer = ({ props, context }) => {

--- a/packages/templates/src/components/ordering/ContentType.tsx
+++ b/packages/templates/src/components/ordering/ContentType.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Badge, Button } from '@amplify-ai/ui';
+import { Card, Badge, Button } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 export const ContentType: ComponentRenderer = ({ props }) => {

--- a/packages/templates/src/components/ordering/GoalCards.tsx
+++ b/packages/templates/src/components/ordering/GoalCards.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, CardContent } from '@amplify-ai/ui';
+import { Card, CardContent } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 const defaultGoals = [

--- a/packages/templates/src/components/ordering/Intelligence.tsx
+++ b/packages/templates/src/components/ordering/Intelligence.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Badge } from '@amplify-ai/ui';
+import { Card, Badge } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 export const Intelligence: ComponentRenderer = () => {

--- a/packages/templates/src/components/ordering/ProductScanner.tsx
+++ b/packages/templates/src/components/ordering/ProductScanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card } from '@amplify-ai/ui';
+import { Card } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 const defaultRecentProducts = [

--- a/packages/templates/src/components/ordering/RepeatBanner.tsx
+++ b/packages/templates/src/components/ordering/RepeatBanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@amplify-ai/ui';
+import { Button } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 export const RepeatBanner: ComponentRenderer = ({ props }) => {

--- a/packages/templates/src/components/ordering/ScriptPreview.tsx
+++ b/packages/templates/src/components/ordering/ScriptPreview.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Badge } from '@amplify-ai/ui';
+import { Card, Badge } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 interface Script {

--- a/packages/templates/src/components/ordering/SuccessModal.tsx
+++ b/packages/templates/src/components/ordering/SuccessModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@amplify-ai/ui';
+import { Button } from '@one-impression/ui';
 import type { ComponentRenderer } from '../../registry';
 
 export const SuccessModal: ComponentRenderer = () => {

--- a/packages/templates/src/dev-server.tsx
+++ b/packages/templates/src/dev-server.tsx
@@ -18,7 +18,7 @@ const server = createServer((req, res) => {
 <style>body{font-family:Inter,system-ui,sans-serif;max-width:640px;margin:40px auto;padding:0 20px}
 a{color:#7C3AED;text-decoration:none}a:hover{text-decoration:underline}
 li{margin:8px 0;font-size:16px}h1{color:#1C1917}</style></head>
-<body><h1>@amplify-ai/templates Dev Server</h1><ul>${links}</ul></body></html>`);
+<body><h1>@one-impression/templates Dev Server</h1><ul>${links}</ul></body></html>`);
     return;
   }
 

--- a/packages/templates/src/layouts/ScrollLayout.tsx
+++ b/packages/templates/src/layouts/ScrollLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@amplify-ai/ui';
+import { Button } from '@one-impression/ui';
 import type { TemplateConfig } from '../render';
 import { renderComponent } from '../registry';
 

--- a/packages/templates/src/layouts/StepperLayout.tsx
+++ b/packages/templates/src/layouts/StepperLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@amplify-ai/ui';
+import { Button } from '@one-impression/ui';
 import type { TemplateConfig } from '../render';
 import { renderComponent } from '../registry';
 

--- a/packages/templates/src/tokens.ts
+++ b/packages/templates/src/tokens.ts
@@ -53,7 +53,7 @@ export function getTokensCSS(_product = 'brand'): string {
   --amp-accent-hover: #752AD4;
   --amp-accent-light: #EDEAFC;
 
-  /* Semantic aliases for @amplify-ai/ui components */
+  /* Semantic aliases for @one-impression/ui components */
   --amp-semantic-text-primary: var(--amp-stone-900);
   --amp-semantic-text-secondary: var(--amp-stone-600);
   --amp-semantic-text-muted: var(--amp-stone-500);
@@ -93,7 +93,7 @@ export function getTokensCSS(_product = 'brand'): string {
   /* Transitions */
   --amp-transition: 150ms ease;
 
-  /* Tailwind-mapped tokens for @amplify-ai/ui components */
+  /* Tailwind-mapped tokens for @one-impression/ui components */
   --color-brand: var(--amp-violet-600);
   --color-brand-dark: var(--amp-violet-700);
   --color-brand-light: var(--amp-violet-50);

--- a/packages/tokens-atmosphere/package.json
+++ b/packages/tokens-atmosphere/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify-ai/tokens-atmosphere",
+  "name": "@one-impression/tokens-atmosphere",
   "version": "2.0.3",
   "description": "Amplify Atmosphere (internal tools) design tokens",
   "main": "dist/tokens.js",
@@ -15,7 +15,7 @@
     "build": "node build.js"
   },
   "dependencies": {
-    "@amplify-ai/tokens-foundation": "^2.0.1"
+    "@one-impression/tokens-foundation": "^2.0.1"
   },
   "devDependencies": {
     "style-dictionary": "^4.3.0"
@@ -23,5 +23,8 @@
   "files": [
     "dist/",
     "tokens/"
-  ]
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
 }

--- a/packages/tokens-brand/package.json
+++ b/packages/tokens-brand/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify-ai/tokens-brand",
+  "name": "@one-impression/tokens-brand",
   "version": "3.1.0",
   "description": "Amplify Brand Platform design tokens — colors, typography for brand dashboard",
   "main": "dist/tokens.js",
@@ -18,7 +18,7 @@
     "build": "node build.js"
   },
   "dependencies": {
-    "@amplify-ai/tokens-foundation": "^2.0.1"
+    "@one-impression/tokens-foundation": "^2.0.1"
   },
   "devDependencies": {
     "style-dictionary": "^4.3.0"
@@ -26,5 +26,8 @@
   "files": [
     "dist/",
     "tokens/"
-  ]
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
 }

--- a/packages/tokens-creator/PALETTE-DESIGN.md
+++ b/packages/tokens-creator/PALETTE-DESIGN.md
@@ -35,7 +35,7 @@ Three layers — and only ONE owns the semantic palette:
 |---|---|---|
 | Token values (hex/px/rem) | `amplify-design-system/packages/tokens-creator/tokens/theme-*.json` | Unchanged |
 | Token contract (regex/literal Zod schemas) | `amplify-schemas/packages/sdk-native-sdui/src/schemas/tokens.ts` | Unchanged |
-| **Semantic palette** (`textStrong → "sdui.color.text-neutral-strong"`) | **Duplicated per-handler in amplify-gateway** | **New `palette.js` export in `@amplify-ai/tokens-creator`** |
+| **Semantic palette** (`textStrong → "sdui.color.text-neutral-strong"`) | **Duplicated per-handler in amplify-gateway** | **New `palette.js` export in `@one-impression/tokens-creator`** |
 
 Theme resolution stays entirely client-side. The BFF imports the palette and emits canonical token *names*; the renderer resolves the name → theme-correct *value* at paint time. **The BFF must never know which theme is active and must never branch on theme.**
 
@@ -161,7 +161,7 @@ Add a new export path:
 Consumers import as:
 
 ```ts
-import { palette } from "@amplify-ai/tokens-creator/palette";
+import { palette } from "@one-impression/tokens-creator/palette";
 
 return sdui.pageHeader({
   title: { text: "Explore", color: palette.text.strong },
@@ -225,8 +225,8 @@ Lightweight sanity tests:
 
 2. **Per-product palettes vs single palette?**
    The org has multiple `tokens-*` packages (brand, atmosphere, creator, marketing, etc.). Each has its own theme JSONs. Question:
-   - **(a)** One palette per package — `@amplify-ai/tokens-creator/palette`, `@amplify-ai/tokens-brand/palette`, etc. — each curates the names that product's BFFs use.
-   - **(b)** Shared `@amplify-ai/sdui-palette` package — one universal palette, all themes from all packages must satisfy it.
+   - **(a)** One palette per package — `@one-impression/tokens-creator/palette`, `@one-impression/tokens-brand/palette`, etc. — each curates the names that product's BFFs use.
+   - **(b)** Shared `@one-impression/sdui-palette` package — one universal palette, all themes from all packages must satisfy it.
 
    I lean **(a)** — keeps palette scoped to its product, allows per-product semantic differences (e.g. creator's "energy" color might not exist in brand). Initial implementation adds the palette only to `tokens-creator` since that's the first consumer. Other packages get their own palette module when their consumers need one.
 
@@ -242,7 +242,7 @@ Lightweight sanity tests:
    Open: do we want to expose the token paths in a typed-union form (e.g. `type SduiColorToken = "sdui.color.text-neutral-strong" | "sdui.color.text-neutral-medium" | ...`)? If yes, that's auto-generated from the theme JSONs as a separate build step. Out of scope for the initial palette module but worth flagging as a follow-on.
 
 5. **Where does palette versioning come from?**
-   The palette's shape is part of the public API of `@amplify-ai/tokens-creator`. A breaking change (renaming `palette.text.strong` to `palette.color.text.strong`) needs a major version bump. Test #5.3 (snapshot) catches accidental breakage; intentional breaking changes go through normal package versioning.
+   The palette's shape is part of the public API of `@one-impression/tokens-creator`. A breaking change (renaming `palette.text.strong` to `palette.color.text.strong`) needs a major version bump. Test #5.3 (snapshot) catches accidental breakage; intentional breaking changes go through normal package versioning.
 
 6. **What about palette additions that DON'T resolve in a theme yet?**
    Build-time check fails. The fix order is: theme JSON gets the new token → palette gets the alias → BFFs consume. NOT: palette gets the alias → BFFs consume → theme gets backfilled (BFF ships broken in the meantime).

--- a/packages/tokens-creator/icons/README.md
+++ b/packages/tokens-creator/icons/README.md
@@ -1,6 +1,6 @@
 # Icons Source Directory
 
-This directory holds the SVG source files for the `@amplify-ai/tokens-creator` icon manifest.
+This directory holds the SVG source files for the `@one-impression/tokens-creator` icon manifest.
 
 ## Current state
 

--- a/packages/tokens-creator/package.json
+++ b/packages/tokens-creator/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify-ai/tokens-creator",
+  "name": "@one-impression/tokens-creator",
   "version": "2.0.3",
   "description": "Amplify Creator App design tokens — SDUI theme colors, typography, and component tokens",
   "main": "dist/tokens.js",
@@ -27,7 +27,7 @@
     "sync-check": "node scripts/sync-check.js"
   },
   "dependencies": {
-    "@amplify-ai/tokens-foundation": "^2.0.1"
+    "@one-impression/tokens-foundation": "^2.0.1"
   },
   "devDependencies": {
     "style-dictionary": "^4.3.0"
@@ -39,5 +39,8 @@
     "icons/",
     "palette.js",
     "palette.d.ts"
-  ]
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
 }

--- a/packages/tokens-creator/palette.js
+++ b/packages/tokens-creator/palette.js
@@ -7,7 +7,7 @@
  * theme resolution happens client-side in the renderer at paint time.
  *
  * Consumers (BFF handlers, server-driven UI emitters):
- *   import { palette } from "@amplify-ai/tokens-creator/palette";
+ *   import { palette } from "@one-impression/tokens-creator/palette";
  *   sdui.pageHeader({ title: { text: "Explore", color: palette.text.strong } });
  *
  * Maintenance:

--- a/packages/tokens-creator/scripts/build-icons.ts
+++ b/packages/tokens-creator/scripts/build-icons.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
 /**
- * build-icons.ts — Icon manifest pipeline for @amplify-ai/tokens-creator.
+ * build-icons.ts — Icon manifest pipeline for @one-impression/tokens-creator.
  *
  * Reads SVG files from icons/, sanitises them, and emits:
  *   - dist/icons/manifest.json   — full icon catalog
@@ -173,7 +173,7 @@ function main() {
   writeTypeDefinition(iconNames);
   console.log(`  manifest.d.ts: IconName union of ${iconNames.length} literals`);
 
-  console.log(`\n@amplify-ai/tokens-creator: icon manifest built (${iconNames.length} icons, v${MANIFEST_VERSION})`);
+  console.log(`\n@one-impression/tokens-creator: icon manifest built (${iconNames.length} icons, v${MANIFEST_VERSION})`);
 }
 
 /**

--- a/packages/tokens-foundation/package.json
+++ b/packages/tokens-foundation/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify-ai/tokens-foundation",
+  "name": "@one-impression/tokens-foundation",
   "version": "2.1.3",
   "type": "module",
   "description": "Amplify Design System — shared foundation tokens (spacing, radii, shadows, motion, surfaces, borders, fluid type, breakpoints, z-index)",
@@ -28,5 +28,8 @@
     "dist/",
     "src/",
     "tokens/"
-  ]
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
 }

--- a/packages/tokens-foundation/src/borders.css
+++ b/packages/tokens-foundation/src/borders.css
@@ -1,5 +1,5 @@
 /**
- * @amplify-ai/tokens-foundation — Border tokens
+ * @one-impression/tokens-foundation — Border tokens
  *
  * Semantic border aliases. Reference the `--amp-semantic-border-*` primitives
  * so theming flips automatically when [data-theme] toggles.

--- a/packages/tokens-foundation/src/fluid-type.css
+++ b/packages/tokens-foundation/src/fluid-type.css
@@ -1,5 +1,5 @@
 /**
- * @amplify-ai/tokens-foundation — Fluid type scale
+ * @one-impression/tokens-foundation — Fluid type scale
  *
  * `clamp(min, fluid, max)` based responsive typography. The `fluid` term
  * uses the cqi/vw unit so text scales smoothly between viewport breakpoints

--- a/packages/tokens-foundation/src/index.css
+++ b/packages/tokens-foundation/src/index.css
@@ -1,12 +1,12 @@
 /**
- * @amplify-ai/tokens-foundation — Phase A semantic CSS surface
+ * @one-impression/tokens-foundation — Phase A semantic CSS surface
  *
  * Hand-authored token layer using the canonical `--amplify-*` prefix.
  * Pairs with the auto-generated `--amp-*` primitives in dist/variables.css.
  *
  * Usage:
- *   @import "@amplify-ai/tokens-foundation/css";        // generated primitives
- *   @import "@amplify-ai/tokens-foundation/css/phase-a"; // semantic Phase A layer
+ *   @import "@one-impression/tokens-foundation/css";        // generated primitives
+ *   @import "@one-impression/tokens-foundation/css/phase-a"; // semantic Phase A layer
  */
 @import "./motion.css";
 @import "./shadows.css";

--- a/packages/tokens-foundation/src/motion.css
+++ b/packages/tokens-foundation/src/motion.css
@@ -1,5 +1,5 @@
 /**
- * @amplify-ai/tokens-foundation — Motion tokens
+ * @one-impression/tokens-foundation — Motion tokens
  *
  * Phase A — explicit, hand-authored CSS-variable surface for motion.
  * Mirrors the JSON tokens in tokens/primitives/motion.json (`--amp-motion-*`)

--- a/packages/tokens-foundation/src/shadows.css
+++ b/packages/tokens-foundation/src/shadows.css
@@ -1,5 +1,5 @@
 /**
- * @amplify-ai/tokens-foundation — Shadow tokens
+ * @one-impression/tokens-foundation — Shadow tokens
  *
  * Six-stop elevation scale (0–5) plus coloured accent shadows.
  * Each elevation uses two stacked shadows for realistic light/ambient occlusion.

--- a/packages/tokens-foundation/src/surfaces.css
+++ b/packages/tokens-foundation/src/surfaces.css
@@ -1,5 +1,5 @@
 /**
- * @amplify-ai/tokens-foundation — Surface tokens
+ * @one-impression/tokens-foundation — Surface tokens
  *
  * Semantic surface aliases. Reference the `--amp-semantic-bg-*` primitives
  * generated from tokens/semantic/colors-{light,dark}.json so theming flips

--- a/packages/tokens-marketing/package.json
+++ b/packages/tokens-marketing/package.json
@@ -17,7 +17,7 @@
     "build": "node build.js"
   },
   "peerDependencies": {
-    "@amplify-ai/tokens-foundation": "^2.1.0"
+    "@one-impression/tokens-foundation": "^2.1.0"
   },
   "files": [
     "src/",

--- a/packages/tokens-oportunities/README.md
+++ b/packages/tokens-oportunities/README.md
@@ -1,4 +1,4 @@
-# @amplify-ai/tokens-oportunities
+# @one-impression/tokens-oportunities
 
 Oportunities design tokens — the Studio direction (Geist + apricot period) for the creator-intent intelligence platform.
 
@@ -35,21 +35,21 @@ These are **not negotiable** at the package level:
 Install:
 
 ```bash
-npm install @amplify-ai/tokens-oportunities
+npm install @one-impression/tokens-oportunities
 ```
 
 ### Tailwind v4
 
 ```css
 /* globals.css */
-@import "@amplify-ai/tokens-oportunities/tailwind";
+@import "@one-impression/tokens-oportunities/tailwind";
 ```
 
 ### Plain CSS
 
 ```css
 /* globals.css */
-@import "@amplify-ai/tokens-oportunities/css";
+@import "@one-impression/tokens-oportunities/css";
 
 .button {
   background: var(--amp-oportunities-theme-color-accent);
@@ -63,7 +63,7 @@ npm install @amplify-ai/tokens-oportunities
 ### JS / TS
 
 ```ts
-import * as tokens from '@amplify-ai/tokens-oportunities/js';
+import * as tokens from '@one-impression/tokens-oportunities/js';
 
 console.log(tokens.themeColorAccent); // '#E68F47'
 ```
@@ -71,7 +71,7 @@ console.log(tokens.themeColorAccent); // '#E68F47'
 ### SCSS
 
 ```scss
-@use '@amplify-ai/tokens-oportunities/scss' as oportunities;
+@use '@one-impression/tokens-oportunities/scss' as oportunities;
 
 .button {
   background: oportunities.$amp-oportunities-theme-color-accent;
@@ -81,12 +81,12 @@ console.log(tokens.themeColorAccent); // '#E68F47'
 ### JSON
 
 ```ts
-import tokens from '@amplify-ai/tokens-oportunities/json';
+import tokens from '@one-impression/tokens-oportunities/json';
 ```
 
 ## Foundation dependency
 
-This package depends on `@amplify-ai/tokens-foundation` for the primitive scales (spacing, radius, shadow, typography scale). Foundation primitives are **inherited as-is** — Oportunities only overrides semantic + cockpit layers.
+This package depends on `@one-impression/tokens-foundation` for the primitive scales (spacing, radius, shadow, typography scale). Foundation primitives are **inherited as-is** — Oportunities only overrides semantic + cockpit layers.
 
 ## Build
 

--- a/packages/tokens-oportunities/package.json
+++ b/packages/tokens-oportunities/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify-ai/tokens-oportunities",
+  "name": "@one-impression/tokens-oportunities",
   "version": "1.0.0",
   "type": "module",
   "description": "Oportunities design tokens — Studio direction (Geist + apricot period) for the creator-intent intelligence platform",
@@ -16,7 +16,7 @@
     "build": "node build.js"
   },
   "dependencies": {
-    "@amplify-ai/tokens-foundation": "^2.1.0"
+    "@one-impression/tokens-foundation": "^2.1.0"
   },
   "devDependencies": {
     "style-dictionary": "^4.3.0"

--- a/packages/tokens-studio/README.md
+++ b/packages/tokens-studio/README.md
@@ -1,4 +1,4 @@
-# @amplify-ai/tokens-studio
+# @one-impression/tokens-studio
 
 Studio-specific design tokens — used only by `studio.amplify.club`. Inherits primitives from tokens-foundation; layers Studio cockpit semantics on top.
 
@@ -13,7 +13,7 @@ Studio-specific design tokens — used only by `studio.amplify.club`. Inherits p
 
 ```css
 /* magic-studio/src/app/globals.css */
-@import "@amplify-ai/tokens-studio/css";
+@import "@one-impression/tokens-studio/css";
 
 :root {
   /* Phase-D consumer aliases — keep byte-identical to avoid touching ~282 use sites. */
@@ -55,5 +55,5 @@ Status badges then reference `var(--amp-studio-status-success)` etc. directly �
 
 The 16 lifted variables were sourced verbatim from the Phase-0 token audit
 (`magic-studio/docs/audits/phase-0-tokens.md`). Phase D in `magic-studio` swaps the in-repo
-`:root { --studio-* / --mirror-* }` definitions for an `@import "@amplify-ai/tokens-studio/css"`
+`:root { --studio-* / --mirror-* }` definitions for an `@import "@one-impression/tokens-studio/css"`
 plus the consumer-alias block above.

--- a/packages/tokens-studio/package.json
+++ b/packages/tokens-studio/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify-ai/tokens-studio",
+  "name": "@one-impression/tokens-studio",
   "version": "1.0.4",
   "description": "Amplify Magic Studio design tokens \u2014 Studio cockpit chrome, mirror/Map-mode voices, status scale; consumed only by studio.amplify.club",
   "main": "dist/tokens.js",
@@ -15,7 +15,7 @@
     "build": "node build.js"
   },
   "dependencies": {
-    "@amplify-ai/tokens-foundation": "^2.1.0"
+    "@one-impression/tokens-foundation": "^2.1.0"
   },
   "devDependencies": {
     "style-dictionary": "^4.3.0"

--- a/packages/ui-native/CLAUDE.md
+++ b/packages/ui-native/CLAUDE.md
@@ -1,6 +1,6 @@
-# @amplify-ai/ui-native — Package Context
+# @one-impression/ui-native — Package Context
 
-React Native primitives for the Amplify Creator App. Every component resolves SDUI tokens from `@amplify-ai/tokens-creator/react-native` — no hardcoded colors, spacing, or sizing.
+React Native primitives for the Amplify Creator App. Every component resolves SDUI tokens from `@one-impression/tokens-creator/react-native` — no hardcoded colors, spacing, or sizing.
 
 ## Architecture
 
@@ -26,7 +26,7 @@ packages/ui-native/
 ## Boundaries
 
 - **NO Zod schemas** — those live in `@one-impression/sdk-native-sdui`
-- **NO SDUI renderers** — those live in `@amplify-ai/sdui-runtime`
+- **NO SDUI renderers** — those live in `@one-impression/sdui-runtime`
 - **NO BFF logic, action engine, or creator business logic**
 - **NO `react-dom` imports** — this is React Native only
 - **NO `@one-impression/*` imports** — this package is in the `@amplify-ai` namespace
@@ -75,4 +75,4 @@ npm run lint -w packages/ui-native    # eslint
 
 - `react` >= 18.0.0
 - `react-native` >= 0.72.0
-- `@amplify-ai/tokens-creator` >= 2.1.0
+- `@one-impression/tokens-creator` >= 2.1.0

--- a/packages/ui-native/__mocks__/tokens-creator.ts
+++ b/packages/ui-native/__mocks__/tokens-creator.ts
@@ -1,4 +1,4 @@
-/** Mock tokens for testing — mirrors @amplify-ai/tokens-creator/react-native */
+/** Mock tokens for testing — mirrors @one-impression/tokens-creator/react-native */
 export const sdui = {
   color: {
     neutralStrong: '#1C1917',

--- a/packages/ui-native/jest.config.js
+++ b/packages/ui-native/jest.config.js
@@ -8,6 +8,6 @@ export default {
   testMatch: ['**/*.test.ts', '**/*.test.tsx'],
   setupFilesAfterSetup: [],
   moduleNameMapper: {
-    '^@amplify-ai/tokens-creator/react-native$': '<rootDir>/__mocks__/tokens-creator.ts',
+    '^@one-impression/tokens-creator/react-native$': '<rootDir>/__mocks__/tokens-creator.ts',
   },
 };

--- a/packages/ui-native/package.json
+++ b/packages/ui-native/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@amplify-ai/ui-native",
+  "name": "@one-impression/ui-native",
   "version": "1.0.0",
   "description": "React Native primitives for Amplify Creator App — SDUI-driven, token-resolved components",
   "type": "module",
@@ -24,11 +24,14 @@
   "peerDependencies": {
     "react": ">=18.0.0",
     "react-native": ">=0.72.0",
-    "@amplify-ai/tokens-creator": ">=2.0.3"
+    "@one-impression/tokens-creator": ">=2.0.3"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",
     "tsup": "^8.0.0",
     "typescript": "^5.5.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
   }
 }

--- a/packages/ui-native/src/primitives/Button/Button.styles.ts
+++ b/packages/ui-native/src/primitives/Button/Button.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import { sdui } from '@one-impression/tokens-creator/react-native';
 import type { ButtonVariant, ButtonSize } from './Button.types';
 
 type VariantColors = { bg: string; text: string; border?: string };

--- a/packages/ui-native/src/primitives/Checkbox/Checkbox.styles.ts
+++ b/packages/ui-native/src/primitives/Checkbox/Checkbox.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import { sdui } from '@one-impression/tokens-creator/react-native';
 
 export const styles = StyleSheet.create({
   container: {

--- a/packages/ui-native/src/primitives/Chip/Chip.styles.ts
+++ b/packages/ui-native/src/primitives/Chip/Chip.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import { sdui } from '@one-impression/tokens-creator/react-native';
 
 export const styles = StyleSheet.create({
   base: {

--- a/packages/ui-native/src/primitives/ImageStack/ImageStack.styles.ts
+++ b/packages/ui-native/src/primitives/ImageStack/ImageStack.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import { sdui } from '@one-impression/tokens-creator/react-native';
 
 export const styles = StyleSheet.create({
   container: {

--- a/packages/ui-native/src/primitives/Input/Input.styles.ts
+++ b/packages/ui-native/src/primitives/Input/Input.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import { sdui } from '@one-impression/tokens-creator/react-native';
 
 export const styles = StyleSheet.create({
   container: {

--- a/packages/ui-native/src/primitives/Radio/Radio.styles.ts
+++ b/packages/ui-native/src/primitives/Radio/Radio.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import { sdui } from '@one-impression/tokens-creator/react-native';
 
 export const styles = StyleSheet.create({
   container: {

--- a/packages/ui-native/src/primitives/SearchBar/SearchBar.styles.ts
+++ b/packages/ui-native/src/primitives/SearchBar/SearchBar.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import { sdui } from '@one-impression/tokens-creator/react-native';
 
 export const styles = StyleSheet.create({
   container: {

--- a/packages/ui-native/src/primitives/Section/Section.styles.ts
+++ b/packages/ui-native/src/primitives/Section/Section.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import { sdui } from '@one-impression/tokens-creator/react-native';
 
 export const styles = StyleSheet.create({
   header: {

--- a/packages/ui-native/src/primitives/SelectableItem/SelectableItem.styles.ts
+++ b/packages/ui-native/src/primitives/SelectableItem/SelectableItem.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import { sdui } from '@one-impression/tokens-creator/react-native';
 
 export const styles = StyleSheet.create({
   container: {

--- a/packages/ui-native/src/primitives/Tab/Tab.styles.ts
+++ b/packages/ui-native/src/primitives/Tab/Tab.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import { sdui } from '@one-impression/tokens-creator/react-native';
 
 export const styles = StyleSheet.create({
   base: {

--- a/packages/ui-native/src/primitives/Tag/Tag.styles.ts
+++ b/packages/ui-native/src/primitives/Tag/Tag.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import { sdui } from '@one-impression/tokens-creator/react-native';
 import type { TagVariant } from './Tag.types';
 
 type VariantColors = { bg: string; text: string; border: string };

--- a/packages/ui-native/src/theme/ThemeProvider.tsx
+++ b/packages/ui-native/src/theme/ThemeProvider.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext } from 'react';
-import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import { sdui } from '@one-impression/tokens-creator/react-native';
 
 type SduiTokens = typeof sdui;
 

--- a/packages/ui-native/src/theme/resolvers.ts
+++ b/packages/ui-native/src/theme/resolvers.ts
@@ -1,11 +1,11 @@
 /**
  * Token resolvers — convert token names to concrete values using
- * the sdui namespace from @amplify-ai/tokens-creator/react-native.
+ * the sdui namespace from @one-impression/tokens-creator/react-native.
  *
  * Every resolver accepts either a token name OR a raw value (number/string).
  * This lets components work with both token-driven SDUI props and one-off overrides.
  */
-import { sdui } from '@amplify-ai/tokens-creator/react-native';
+import { sdui } from '@one-impression/tokens-creator/react-native';
 import type {
   ColorToken,
   SpacingToken,

--- a/packages/ui-native/src/tokens.ts
+++ b/packages/ui-native/src/tokens.ts
@@ -1,6 +1,6 @@
 /**
  * Token type definitions — string literal unions matching SDUI token keys
- * from @amplify-ai/tokens-creator/react-native.
+ * from @one-impression/tokens-creator/react-native.
  *
  * Components accept these as props (e.g. <Box bg="primary" p="md" />)
  * and resolve them to concrete values via theme/resolvers.ts.

--- a/packages/ui-native/src/types/tokens-creator.d.ts
+++ b/packages/ui-native/src/types/tokens-creator.d.ts
@@ -1,10 +1,10 @@
 /**
- * Type declarations for @amplify-ai/tokens-creator/react-native
+ * Type declarations for @one-impression/tokens-creator/react-native
  *
  * The tokens-creator package generates tokens.native.js at build time
  * without .d.ts files. This declaration provides type safety for consumers.
  */
-declare module '@amplify-ai/tokens-creator/react-native' {
+declare module '@one-impression/tokens-creator/react-native' {
   export const colors: Record<string, string>;
   export const fontSize: Record<string, number>;
   export const spacing: Record<string, number>;

--- a/packages/ui-native/tsup.config.ts
+++ b/packages/ui-native/tsup.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
   // with @types/react@19 in the monorepo root, and tsup's rollup-plugin-dts
   // doesn't honor skipLibCheck. tsc respects tsconfig.json's skipLibCheck.
   dts: false,
-  external: ['react', 'react-native', '@amplify-ai/tokens-creator'],
+  external: ['react', 'react-native', '@one-impression/tokens-creator'],
   clean: true,
 });

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,6 +1,6 @@
-# `@amplify-ai/ui` Changelog
+# `@one-impression/ui` Changelog
 
-Per-package changelog for `@amplify-ai/ui`. The full cross-package
+Per-package changelog for `@one-impression/ui`. The full cross-package
 changelog lives at the repository root (`CHANGELOG.md`); this file
 mirrors the entries that touch this package only.
 
@@ -31,7 +31,7 @@ no breaking changes to existing primitives.
 ### Token references
 
 - All primitives consume the `--amp-studio-theme-*` + `--amp-semantic-*`
-  token surface already shipping from `@amplify-ai/tokens-studio` 1.0.2.
+  token surface already shipping from `@one-impression/tokens-studio` 1.0.2.
 - `FlowContextSidebar` references three new layout tokens (declared in
   `magic-studio/docs/mockups/OPTION_D_SPEC.md` §7 and in the sibling
   `tokens-studio` PR):
@@ -45,14 +45,14 @@ no breaking changes to existing primitives.
 
 ### Versioned
 
-- `@amplify-ai/ui`: `2.12.0` → `2.13.0`
+- `@one-impression/ui`: `2.12.0` → `2.13.0`
 
 ### Publish gating
 
-This PR does NOT publish `@amplify-ai/ui@2.13.0` to npm. Publish is
+This PR does NOT publish `@one-impression/ui@2.13.0` to npm. Publish is
 gated on the matching `tokens-studio` PR merging first so consumers
-picking up `@amplify-ai/ui` 2.13.0 alongside
-`@amplify-ai/tokens-studio` get a consistent token surface. The
+picking up `@one-impression/ui` 2.13.0 alongside
+`@one-impression/tokens-studio` get a consistent token surface. The
 orchestrating coordinator handles the sequence.
 
 ## Earlier versions

--- a/packages/ui/dist/contracts.json
+++ b/packages/ui/dist/contracts.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-05-09T09:58:05.031Z",
+  "generatedAt": "2026-05-25T08:04:18.528Z",
   "tsVersion": "5.9.3",
-  "componentCount": 120,
+  "componentCount": 126,
   "statusBreakdown": {
     "stable": 46,
-    "alpha": 15,
+    "alpha": 21,
     "beta": 59
   },
   "components": [
@@ -66,6 +66,21 @@
       "lifecycle": {
         "status": "beta",
         "since": "2.1.0"
+      }
+    },
+    {
+      "name": "AppIconOportunities",
+      "contract": "contracts/AppIconOportunities.json",
+      "filePath": "packages/ui/src/components/AppIconOportunities/AppIconOportunities.tsx",
+      "kind": "forwardRef",
+      "variants": null,
+      "sizes": null,
+      "propCount": 4,
+      "subcomponents": [],
+      "lifecycle": {
+        "status": "alpha",
+        "since": "2.14.0",
+        "notes": "Oportunities product primitive — the locked V1 'op.' app icon in an iOS squircle (border-radius 22.37%); light + dark variants."
       }
     },
     {
@@ -157,6 +172,21 @@
       "lifecycle": {
         "status": "alpha",
         "since": "2.4.0"
+      }
+    },
+    {
+      "name": "BrandInterestCard",
+      "contract": "contracts/BrandInterestCard.json",
+      "filePath": "packages/ui/src/components/BrandInterestCard/BrandInterestCard.tsx",
+      "kind": "forwardRef",
+      "variants": null,
+      "sizes": null,
+      "propCount": 7,
+      "subcomponents": [],
+      "lifecycle": {
+        "status": "alpha",
+        "since": "2.14.0",
+        "notes": "Oportunities product primitive — creator-side inbox card surfacing brand interest with reply/decline CTAs. Composes Card + Badge."
       }
     },
     {
@@ -433,6 +463,21 @@
         "status": "beta",
         "since": "2.9.0",
         "notes": "Studio v2 Wave 2 — right-rail per-agent verdicts; supports disagreementsOnly collapse + ask-the-council affordance."
+      }
+    },
+    {
+      "name": "CreatorIntentCard",
+      "contract": "contracts/CreatorIntentCard.json",
+      "filePath": "packages/ui/src/components/CreatorIntentCard/CreatorIntentCard.tsx",
+      "kind": "forwardRef",
+      "variants": null,
+      "sizes": null,
+      "propCount": 7,
+      "subcomponents": [],
+      "lifecycle": {
+        "status": "alpha",
+        "since": "2.14.0",
+        "notes": "Oportunities product primitive — signature brand-side card surfacing a creator's declared intent + AI fit score + unlock CTA. Composes Card + Avatar + Badge."
       }
     },
     {
@@ -884,6 +929,21 @@
       "lifecycle": {
         "status": "stable",
         "since": "1.0.0"
+      }
+    },
+    {
+      "name": "IntentFeed",
+      "contract": "contracts/IntentFeed.json",
+      "filePath": "packages/ui/src/components/IntentFeed/IntentFeed.tsx",
+      "kind": "forwardRef",
+      "variants": null,
+      "sizes": null,
+      "propCount": 8,
+      "subcomponents": [],
+      "lifecycle": {
+        "status": "alpha",
+        "since": "2.14.0",
+        "notes": "Oportunities product primitive — container rendering a filter strip + responsive grid of CreatorIntentCards."
       }
     },
     {
@@ -1541,6 +1601,21 @@
       }
     },
     {
+      "name": "SignalDot",
+      "contract": "contracts/SignalDot.json",
+      "filePath": "packages/ui/src/components/SignalDot/SignalDot.tsx",
+      "kind": "forwardRef",
+      "variants": null,
+      "sizes": null,
+      "propCount": 6,
+      "subcomponents": [],
+      "lifecycle": {
+        "status": "alpha",
+        "since": "2.14.0",
+        "notes": "Oportunities product primitive — the apricot period as a standalone animated mark; supports pulse, conic-gradient fill, and 'live' presence rings; prefers-reduced-motion gated."
+      }
+    },
+    {
       "name": "Skeleton",
       "contract": "contracts/Skeleton.json",
       "filePath": "packages/ui/src/components/Skeleton/Skeleton.tsx",
@@ -1895,6 +1970,26 @@
       "lifecycle": {
         "status": "alpha",
         "since": "2.4.0"
+      }
+    },
+    {
+      "name": "Wordmark",
+      "contract": "contracts/Wordmark.json",
+      "filePath": "packages/ui/src/components/Wordmark/Wordmark.tsx",
+      "kind": "forwardRef",
+      "variants": null,
+      "sizes": [
+        "sm",
+        "md",
+        "lg",
+        "xl"
+      ],
+      "propCount": 4,
+      "subcomponents": [],
+      "lifecycle": {
+        "status": "alpha",
+        "since": "2.14.0",
+        "notes": "Oportunities product primitive — the 'oportunities.' wordmark in Geist 600 with optional apricot→purple gradient-sweep animation; prefers-reduced-motion gated."
       }
     }
   ]

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@amplify-ai/ui",
+  "name": "@one-impression/ui",
   "version": "2.13.0",
-  "description": "Shared UI components for Amplify products \u2014 Brand, Creator, and Atmosphere",
+  "description": "Shared UI components for Amplify products — Brand, Creator, and Atmosphere",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -57,5 +57,8 @@
   "dependencies": {
     "clsx": "^2.1.0",
     "tailwind-merge": "^2.3.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
   }
 }

--- a/packages/ui/scripts/generate-contracts.mjs
+++ b/packages/ui/scripts/generate-contracts.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Generate JSON component contracts from @amplify-ai/ui source.
+ * Generate JSON component contracts from @one-impression/ui source.
  *
  * Uses the real TypeScript compiler API (vs. the regex extractors in
  * scripts/generate-llms-docs.mjs and packages/mcp-server) so resolved

--- a/packages/ui/src/components/Card/Card.tsx
+++ b/packages/ui/src/components/Card/Card.tsx
@@ -344,7 +344,7 @@ Card.Actions = CardActionsImpl;
 // ─── Backward-compat top-level exports ───────────────────────────────────────
 //
 // v1 of this file exported these as separate top-level symbols. Products import
-// them as `import { CardHeader, CardTitle, ... } from '@amplify-ai/ui'`. Keep
+// them as `import { CardHeader, CardTitle, ... } from '@one-impression/ui'`. Keep
 // them exported and pointed at the same implementations.
 
 export const CardHeader = CardHeaderImpl;

--- a/packages/ui/src/components/FlowSidebar/SPEC.md
+++ b/packages/ui/src/components/FlowSidebar/SPEC.md
@@ -1,7 +1,7 @@
 # FlowSidebar — Canvas Primitive Spec
 
 **Status:** Spec (v0 contract — no code in this PR)
-**Owner:** `@amplify-ai/ui`
+**Owner:** `@one-impression/ui`
 **Date:** 2026-05-08
 **Consumer:** Magic Studio (initially), any product with a multi-step flow
 
@@ -164,7 +164,7 @@ All dimensions are token-driven. CSS variables are set at the `:root` of the con
 | `LongList` | 12 steps to demonstrate sticky header / footer + scrolling |
 | `BrandOrderRealistic` | The 7 actual `brand-order` flow steps from the Studio registry — used as the "happy path" visual reference for Pixel review |
 
-All stories use the `@amplify-ai/tokens-studio` theme; a controls table is exposed for `flowName`, `activeStepId`, `collapsed`.
+All stories use the `@one-impression/tokens-studio` theme; a controls table is exposed for `flowName`, `activeStepId`, `collapsed`.
 
 ---
 
@@ -260,4 +260,4 @@ packages/ui/src/components/FlowSidebar/
 export * from './components/FlowSidebar';
 ```
 
-**Token build trigger:** the three layout tokens land alongside the implementation PR (or just before it), so consumers picking up `@amplify-ai/ui` and `@amplify-ai/tokens-studio` together get a consistent release.
+**Token build trigger:** the three layout tokens land alongside the implementation PR (or just before it), so consumers picking up `@one-impression/ui` and `@one-impression/tokens-studio` together get a consistent release.

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,10 +1,10 @@
 /**
- * @amplify-ai/ui — Shared UI Components for Amplify Products
+ * @one-impression/ui — Shared UI Components for Amplify Products
  *
  * Import from here, not from individual component files.
  *
  * @example
- * import { Button, Badge, Card, Input, Dialog } from '@amplify-ai/ui';
+ * import { Button, Badge, Card, Input, Dialog } from '@one-impression/ui';
  */
 
 // Utilities

--- a/packages/ui/src/lib/chart-utils.ts
+++ b/packages/ui/src/lib/chart-utils.ts
@@ -1,6 +1,6 @@
 /**
  * Shared SVG/chart utility helpers used by data viz primitives.
- * Hand-rolled (no chart lib dep) — keeps @amplify-ai/ui zero-runtime-dep aside from clsx.
+ * Hand-rolled (no chart lib dep) — keeps @one-impression/ui zero-runtime-dep aside from clsx.
  */
 
 /** Default chart colour palette — references CSS vars defined in @amplify/tokens-* */

--- a/packages/ui/src/recipes/README.md
+++ b/packages/ui/src/recipes/README.md
@@ -1,7 +1,7 @@
-# Recipes — `@amplify-ai/ui/recipes`
+# Recipes — `@one-impression/ui/recipes`
 
 A **recipe** is a small composition of two or more primitives from
-`@amplify-ai/ui` that captures a recurring UI pattern. Recipes are NOT
+`@one-impression/ui` that captures a recurring UI pattern. Recipes are NOT
 primitives — they are convenience wrappers that:
 
 - Compose existing components, adding layout and minor glue logic only
@@ -40,9 +40,9 @@ keep it product-local.
 ## Importing
 
 ```tsx
-import { SearchCombobox, ActionCard, MetricGrid } from '@amplify-ai/ui';
+import { SearchCombobox, ActionCard, MetricGrid } from '@one-impression/ui';
 // or, equivalently:
-import { SearchCombobox } from '@amplify-ai/ui/recipes';  // if you export a /recipes subpath later
+import { SearchCombobox } from '@one-impression/ui/recipes';  // if you export a /recipes subpath later
 ```
 
 For now everything is re-exported from the package root; the

--- a/packages/ui/src/recipes/index.ts
+++ b/packages/ui/src/recipes/index.ts
@@ -1,5 +1,5 @@
 /**
- * Recipes — small compositions of @amplify-ai/ui primitives.
+ * Recipes — small compositions of @one-impression/ui primitives.
  *
  * A recipe is a thin wrapper that combines 2–4 primitives into a
  * higher-level pattern. Recipes contain minimal new logic; they are

--- a/scripts/build-tokens.js
+++ b/scripts/build-tokens.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Shared token build script for all @amplify-ai/tokens-* packages.
+ * Shared token build script for all @one-impression/tokens-* packages.
  *
  * Reads W3C DTCG-format token JSON files, resolves {references},
  * and generates platform-specific outputs:
@@ -211,7 +211,7 @@ function buildJS() {
 function buildTailwindPreset() {
   const lines = [
     '/* Auto-generated Tailwind v4 preset — do not edit */',
-    '/* Import in your globals.css: @import "@amplify-ai/tokens-' + pkg + '/dist/tailwind.css"; */',
+    '/* Import in your globals.css: @import "@one-impression/tokens-' + pkg + '/dist/tailwind.css"; */',
     '',
     '@theme {',
   ];
@@ -248,7 +248,7 @@ function buildTailwindPreset() {
 // 5b. Tailwind v4 consumer preset (Issue #88)
 // Brand-style packages only. Maps Canvas's class names (bg-brand, text-primary,
 // etc.) to the existing theme-color / semantic tier so consumers can
-// `@import "@amplify-ai/tokens-<pkg>/preset"` instead of inlining a hand-rolled
+// `@import "@one-impression/tokens-<pkg>/preset"` instead of inlining a hand-rolled
 // @theme bridge. Self-contained — re-emits the same primitives + semantic +
 // theme-color block as tailwind.css plus the consumer alias layer below.
 function buildConsumerPreset() {
@@ -258,8 +258,8 @@ function buildConsumerPreset() {
     '/* Auto-generated Tailwind v4 consumer preset — do not edit */',
     '/* Closes Issue #88: ship semantic class names (bg-brand, text-primary, ...)',
     ' * for Canvas component consumers. Self-contained — no need to also',
-    ' * @import "@amplify-ai/tokens-' + pkg + '/tailwind". */',
-    '/* Usage: @import "@amplify-ai/tokens-' + pkg + '/preset"; */',
+    ' * @import "@one-impression/tokens-' + pkg + '/tailwind". */',
+    '/* Usage: @import "@one-impression/tokens-' + pkg + '/preset"; */',
     '',
     '@theme {',
   ];
@@ -327,7 +327,7 @@ function buildConsumerPreset() {
 
   for (const [aliasName, sourceKey] of Object.entries(aliasMap)) {
     if (flat[sourceKey] === undefined) {
-      console.warn(`@amplify-ai/tokens-${pkg}: preset alias "${aliasName}" → "${sourceKey}" not found in flat tree, skipping`);
+      console.warn(`@one-impression/tokens-${pkg}: preset alias "${aliasName}" → "${sourceKey}" not found in flat tree, skipping`);
       continue;
     }
     lines.push(`  --color-${aliasName}: var(--color-${sourceKey});`);
@@ -431,7 +431,7 @@ export const spacing = ${JSON.stringify(spacing, null, 2)};
 
 /**
  * SDUI token namespace — all sdui.* tokens grouped for useToken() resolution.
- * Usage: import { sdui } from '@amplify-ai/tokens-creator/react-native';
+ * Usage: import { sdui } from '@one-impression/tokens-creator/react-native';
  *        const value = sdui.spacing.xs; // 4
  */
 export const sdui = ${JSON.stringify(sdui, null, 2)};
@@ -440,7 +440,7 @@ export const sdui = ${JSON.stringify(sdui, null, 2)};
 
 // 7. Product-agnostic semantic aliases — emits --amp-semantic-* aliases that
 //    resolve to whichever product theme is loaded. Canvas v2 primitives in
-//    @amplify-ai/ui (BriefStrip, HistoryStrip, CouncilRail, VariantCard,
+//    @one-impression/ui (BriefStrip, HistoryStrip, CouncilRail, VariantCard,
 //    StatusBar, SegmentedControl) hard-code Tailwind arbitrary classes
 //    referencing the agnostic --amp-semantic-* family. Without these aliases,
 //    every primitive renders unstyled in every consumer.
@@ -511,7 +511,7 @@ function buildSemanticAliases() {
     '',
     '/* ──────────────────────────────────────────────────────────────────',
     '   Product-agnostic semantic aliases — resolve to active product theme.',
-    '   Consumed by Canvas v2 primitives in @amplify-ai/ui via Tailwind',
+    '   Consumed by Canvas v2 primitives in @one-impression/ui via Tailwind',
     '   arbitrary classes (e.g. bg-[var(--amp-semantic-bg-accent-subtle)]).',
     '   Dark mode cascades through var() indirection automatically.',
     '   ────────────────────────────────────────────────────────────────── */',
@@ -593,7 +593,7 @@ const suffix = extras.length ? ` (${extras.join(', ')})` : '';
 if (pkg === 'creator') {
   writeFileSync(join(distDir, 'tokens.native.js'), buildReactNative());
 }
-console.log(`@amplify-ai/tokens-${pkg}: built ${total} artifacts${suffix}`);
+console.log(`@one-impression/tokens-${pkg}: built ${total} artifacts${suffix}`);
 
 // Fail build if any references could not be resolved
 if (unresolvedRefs.length > 0) {

--- a/scripts/generate-llms-docs.mjs
+++ b/scripts/generate-llms-docs.mjs
@@ -54,7 +54,7 @@ const renderExample = (c) => {
   const variantAttr = c.variants ? ` variant="${c.variants[0]}"` : '';
   const sizeAttr = c.sizes ? ` size="${c.sizes[c.sizes.length === 3 ? 1 : 0]}"` : '';
   const inner = c.subcomponents.length ? `\n  <${c.subcomponents[0]}>...</${c.subcomponents[0]}>\n` : 'children';
-  return `\`\`\`tsx\nimport { ${c.name} } from '@amplify-ai/ui';\n\n<${c.name}${variantAttr}${sizeAttr}>${inner}</${c.name}>\n\`\`\``;
+  return `\`\`\`tsx\nimport { ${c.name} } from '@one-impression/ui';\n\n<${c.name}${variantAttr}${sizeAttr}>${inner}</${c.name}>\n\`\`\``;
 };
 
 const renderLifecycle = (lifecycle) => {
@@ -108,7 +108,7 @@ const renderComponentDoc = (c, override) => {
     sections.push(`## Guidance\n\n${override.trim()}`);
   }
 
-  sections.push(`## Import\n\n\`\`\`ts\nimport { ${c.name} } from '@amplify-ai/ui';\n\`\`\``);
+  sections.push(`## Import\n\n\`\`\`ts\nimport { ${c.name} } from '@one-impression/ui';\n\`\`\``);
 
   return sections.join('\n\n') + '\n';
 };
@@ -141,7 +141,7 @@ const main = () => {
   const lines = [];
   lines.push('# Amplify Canvas Design System');
   lines.push('');
-  lines.push('> Canvas is the unified design system for Amplify products (Brand, Creator, Atmosphere). It ships React components, design tokens, and templates as `@amplify-ai/ui`, `@amplify-ai/tokens-*`, and `@amplify-ai/templates`.');
+  lines.push('> Canvas is the unified design system for Amplify products (Brand, Creator, Atmosphere). It ships React components, design tokens, and templates as `@one-impression/ui`, `@one-impression/tokens-*`, and `@one-impression/templates`.');
   lines.push('');
   lines.push('Each component below has a per-component rule sheet listing variants, props, defaults, and allowed values. Use these to compose UI without inventing components or hardcoding values.');
   lines.push('');
@@ -166,14 +166,14 @@ const main = () => {
   lines.push('');
   lines.push('## Tokens');
   lines.push('');
-  lines.push('- `@amplify-ai/tokens-foundation`: primitives (color, spacing, typography, shadow, radius, motion)');
-  lines.push('- `@amplify-ai/tokens-brand`: Brand product theme');
-  lines.push('- `@amplify-ai/tokens-atmosphere`: Atmosphere product theme');
-  lines.push('- `@amplify-ai/tokens-creator`: Creator product theme');
+  lines.push('- `@one-impression/tokens-foundation`: primitives (color, spacing, typography, shadow, radius, motion)');
+  lines.push('- `@one-impression/tokens-brand`: Brand product theme');
+  lines.push('- `@one-impression/tokens-atmosphere`: Atmosphere product theme');
+  lines.push('- `@one-impression/tokens-creator`: Creator product theme');
   lines.push('');
   lines.push('## Programmatic access');
   lines.push('');
-  lines.push('- MCP server: `@amplify-ai/mcp-server` exposes the same data via stdio + HTTP transports.');
+  lines.push('- MCP server: `@one-impression/mcp-server` exposes the same data via stdio + HTTP transports.');
   lines.push('- JSON contracts: `dist/contracts/<Component>.json` — TS-API-extracted, single source of truth.');
   lines.push('- JSON mirror: `dist/llms.json` for tools that prefer flattened structured data.');
 


### PR DESCRIPTION
## Why

The previous publish pipeline (`@amplify-ai/*` on npmjs.org, owned by a single npm account) has been **silently failing since 2026-05-22**. PRs #134, #135, #136 merged to `main` but never reached the registry — every consumer's `npm install` pulls 10-day-old artifacts, breaking local app testing for the creator app.

Root cause: the `NPM_TOKEN` in repo secrets doesn't have publish rights on the packages (owned by `apaksh`'s personal npm account; no `amplify-ai` npm org exists). The CI workflow's existing error-suppression block (`grep -qE 'EPUBLISHCONFLICT|already been published'`) masked the auth failures as "already published" skips, so no alert fired for 10 days.

## What this PR does

| Before | After |
|---|---|
| `@amplify-ai/*` on npmjs.org | `@one-impression/*` on `npm.pkg.github.com` |
| Publish auth: `NPM_TOKEN` (personal, broken) | `GITHUB_TOKEN` (auto-injected, org-owned) |
| Versioning: manual `package.json` bumps | `changesets` (matches `amplify-schemas`) |
| Bus factor: 1 (single npm account) | 0 (workflow-driven, no human owner) |

## Changes

- **Renamed 9 packages**: `tokens-foundation`, `tokens-brand`, `tokens-atmosphere`, `tokens-creator`, `ui`, `ui-native`, `sdui-runtime`, `mcp-server`, `eslint-config`
- **Added `publishConfig`** to each pointing at `https://npm.pkg.github.com`
- **Updated all cross-package deps** (peer/regular) via sed across `packages/**`
- **Updated source imports** across 189 `.ts/.tsx/.js/.mjs/.css` files
- **Updated root `.npmrc`** to point `@one-impression` at GitHub Packages
- **Added `.github/workflows/publish.yml`** — changesets-based publish, same pattern as `amplify-schemas`
- **Removed broken publish step** from `.github/workflows/ci.yml` (CI now does build + validate + secret-scan only)
- **Initialized changesets tooling** (`.changeset/config.json` with `restricted` access, `@one-impression` scope ignored list)
- **Added migration changeset** declaring major bump on all 9 packages

## What does NOT change

- `tokens-marketing` (uses scope `@amplify/`, not `@amplify-ai/`, not in publish list — left untouched)
- 6 internal-only packages (`storybook`, `templates`, `brand-oportunities`, `feature-flags`, `tokens-oportunities`, `tokens-studio`)
- The old `@amplify-ai/*` packages on npmjs.org — deprecation requires `apaksh`'s npm account (out-of-band Phase 4)

## Local verification

- `npm install`: clean, lockfile regenerated
- `npm run build` (all 9 packages): pass
- `node scripts/validate-tokens.js`: 0 errors / 0 warnings
- `rg '@amplify-ai/'` excluding CHANGELOG history: no matches

## Merge flow

This PR follows the **changesets two-merge pattern**:

1. **This PR merges** → CI on `main` detects the changeset and opens a "Version PR" (branch `changesets-release`) that bumps versions
2. **Version PR merges** → CI publishes the 9 packages to GitHub Packages

Both merges are required to get artifacts on the registry.

## Consumer follow-up

A separate PR will update `amplify-creator-app` (12 files importing `@amplify-ai/*` → `@one-impression/*`) once packages are published. No other repo imports `@amplify-ai/*` today.

## Test plan

- [ ] CI green on this PR (build + validate + secret-scan)
- [ ] Merge → Version PR opens automatically
- [ ] Merge Version PR → 9 packages publish to `npm.pkg.github.com/One-Impression/*`
- [ ] Verify: `npm view @one-impression/sdui-runtime --registry=https://npm.pkg.github.com` returns the published version
- [ ] GitHub repo Settings → Packages shows all 9 packages