### PR TITLE
fix(changesets): use full @one-impression/ scope in config + pre-existing changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,12 +11,12 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [
-    "storybook",
+    "@one-impression/storybook",
     "@one-impression/templates",
-    "brand-oportunities",
-    "feature-flags",
+    "@one-impression/brand-oportunities",
+    "@one-impression/feature-flags",
     "@amplify/tokens-marketing",
-    "tokens-oportunities",
-    "tokens-studio"
+    "@one-impression/tokens-oportunities",
+    "@one-impression/tokens-studio"
   ]
 }

--- a/.changeset/sdui-action-handlers.md
+++ b/.changeset/sdui-action-handlers.md
@@ -1,5 +1,5 @@
 ---
-"@amplify-ai/sdui-runtime": minor
+"@one-impression/sdui-runtime": minor
 ---
 
 Add SDUI action handlers and capability handlers (Task 23, Brief #264)

--- a/.changeset/sdui-bff-client-state.md
+++ b/.changeset/sdui-bff-client-state.md
@@ -1,5 +1,5 @@
 ---
-"@amplify-ai/sdui-runtime": minor
+"@one-impression/sdui-runtime": minor
 ---
 
 Add BFF client, Zustand state stores, icon store, and theme bridge to sdui-runtime.
@@ -7,4 +7,4 @@ Add BFF client, Zustand state stores, icon store, and theme bridge to sdui-runti
 - BFF client with auth/retry/error/on-load-action interceptors and TanStack Query hooks
 - 8 Zustand stores: page, bottom-sheet-data, bottom-sheet-form, navigation-stack, search-params, aerobar, file-upload, auth
 - Icon store with MMKV persistence, essentials fallback, and foreground re-fetch policy
-- Theme bridge mapping @amplify-ai/tokens-creator sdui.* tokens to RN-resolvable values
+- Theme bridge mapping @one-impression/tokens-creator sdui.* tokens to RN-resolvable values

--- a/.changeset/sdui-page-renderers.md
+++ b/.changeset/sdui-page-renderers.md
@@ -1,5 +1,5 @@
 ---
-"@amplify-ai/sdui-runtime": minor
+"@one-impression/sdui-runtime": minor
 ---
 
 feat(sdui-runtime): add 5 page layout container renderers

--- a/.changeset/sdui-runtime-cond-and-branch.md
+++ b/.changeset/sdui-runtime-cond-and-branch.md
@@ -1,5 +1,5 @@
 ---
-"@amplify-ai/sdui-runtime": minor
+"@one-impression/sdui-runtime": minor
 ---
 
 Add runtime handlers for the new SDUI primitives shipped in

--- a/.changeset/sdui-runtime-foundation.md
+++ b/.changeset/sdui-runtime-foundation.md
@@ -1,8 +1,8 @@
 ---
-"@amplify-ai/sdui-runtime": major
+"@one-impression/sdui-runtime": major
 ---
 
-feat(sdui-runtime): add @amplify-ai/sdui-runtime@1.0.0 — SDUI runtime foundation
+feat(sdui-runtime): add @one-impression/sdui-runtime@1.0.0 — SDUI runtime foundation
 
 New package providing the foundation layer for the SDUI runtime in amplify-creator-app:
 - SduiNode base wrapper (Zod validation, error boundary, click/view/load/dismount lifecycle, telemetry)

--- a/.changeset/sdui-runtime-subpath-exports.md
+++ b/.changeset/sdui-runtime-subpath-exports.md
@@ -1,5 +1,5 @@
 ---
-"@amplify-ai/sdui-runtime": minor
+"@one-impression/sdui-runtime": minor
 ---
 
 Emit standalone bundles at `/bff`, `/icon-store`, and `/action-engine`
@@ -8,7 +8,7 @@ subpath exports.
 Previously consumers had to deep-import `dist/bff/index.js` to avoid
 pulling the full runtime into every chunk. The package now advertises
 three first-class subpath exports, each backed by its own tsup entry,
-so `import { ... } from "@amplify-ai/sdui-runtime/bff"` (etc.) works
+so `import { ... } from "@one-impression/sdui-runtime/bff"` (etc.) works
 without falling through to the root bundle.
 
 Also marks `react-native-svg` and `react-native-mmkv` as externals so

--- a/.changeset/sdui-snippet-renderers.md
+++ b/.changeset/sdui-snippet-renderers.md
@@ -1,5 +1,5 @@
 ---
-"@amplify-ai/sdui-runtime": minor
+"@one-impression/sdui-runtime": minor
 ---
 
 feat(sdui-runtime): add 43 Tier 2 snippet renderers for Creator App SDUI

--- a/.changeset/sdui-tokens-and-icon-manifest.md
+++ b/.changeset/sdui-tokens-and-icon-manifest.md
@@ -1,5 +1,5 @@
 ---
-"@amplify-ai/tokens-creator": minor
+"@one-impression/tokens-creator": minor
 ---
 
 feat(tokens-creator): extend sdui.* token contract + icon manifest pipeline

--- a/.changeset/sdui-ui-component-renderers.md
+++ b/.changeset/sdui-ui-component-renderers.md
@@ -1,5 +1,5 @@
 ---
-"@amplify-ai/sdui-runtime": minor
+"@one-impression/sdui-runtime": minor
 ---
 
 feat(sdui-runtime): add 18 Tier 1 ui_component renderers

--- a/.changeset/tokens-creator-palette.md
+++ b/.changeset/tokens-creator-palette.md
@@ -1,5 +1,5 @@
 ---
-"@amplify-ai/tokens-creator": minor
+"@one-impression/tokens-creator": minor
 ---
 
 feat(tokens-creator): add palette semantic alias module
@@ -10,8 +10,8 @@ SDUI token names (`"sdui.color.neutral-strong"`) across all 7 token families
 (color, font-size, font-weight, spacing, radius, icon-size, border-width).
 Build-time validator ensures every alias resolves in every theme JSON.
 
-New export path: `@amplify-ai/tokens-creator/palette`. Consumers replace
+New export path: `@one-impression/tokens-creator/palette`. Consumers replace
 inline token strings and local `const color = {...}` duplication with
-`import { palette } from "@amplify-ai/tokens-creator/palette"`. Theme
+`import { palette } from "@one-impression/tokens-creator/palette"`. Theme
 resolution stays entirely client-side; the BFF emits palette names and the
 renderer paints the theme-correct value at paint time.

--- a/.changeset/ui-native-v1.md
+++ b/.changeset/ui-native-v1.md
@@ -1,10 +1,10 @@
 ---
-"@amplify-ai/ui-native": major
+"@one-impression/ui-native": major
 ---
 
 feat(ui-native): initial release — 18 React Native primitives for Creator App SDUI
 
-Token-resolved components consuming @amplify-ai/tokens-creator/react-native:
+Token-resolved components consuming @one-impression/tokens-creator/react-native:
 - Layout: Box, Stack
 - Foundation: Text, Icon, Image, Separator
 - Interactive: Button, Card, Input, Chip, Checkbox, Radio, Tag, Tab


### PR DESCRIPTION
## Why

PR #138's `publish.yml` run on main failed with a changesets validation error:

```
ValidationError: The package or glob expression "storybook" is specified in the `ignore` option but it is not found in the project.
```

Two root causes:

### 1. Bare directory names in `.changeset/config.json` `ignore` list

Changesets validates the ignore list against actual package names (with scope) from `packages/*/package.json`. PR #138's config had `storybook`, `brand-oportunities`, etc. as bare strings — these don't match `@one-impression/storybook` etc., so validation fails.

### 2. Pre-existing changesets reference old scope

There were 11 unconsumed changesets on main from prior work (ui-native-v1, sdui-runtime-foundation, tokens-creator-palette, etc.) that still declared `@amplify-ai/*` package names in their frontmatter. After PR #138's rename, those package names no longer exist — validation fails.

## What this fixes

- `.changeset/config.json`: ignore list now uses `@one-impression/<name>` for each
- 11 changeset files: `@amplify-ai/` → `@one-impression/` (sed across .changeset/*.md)

## Local verification

```
$ npx changeset status
Packages to be bumped at major:
  - @one-impression/tokens-foundation
  - @one-impression/tokens-brand
  - @one-impression/tokens-atmosphere
  - @one-impression/tokens-creator
  - @one-impression/ui
  - @one-impression/ui-native
  - @one-impression/sdui-runtime
  - @one-impression/mcp-server
  - @one-impression/eslint-config
```

## After merge

`publish.yml` on main re-runs, opens the Version PR, then merging that publishes 9 packages to `npm.pkg.github.com/One-Impression/*`.