### PR TITLE
fix(tokens-marketing): mark as private to prevent publish to npmjs.org

### DIFF
--- a/packages/tokens-marketing/package.json
+++ b/packages/tokens-marketing/package.json
@@ -22,5 +22,6 @@
   "files": [
     "src/",
     "dist/"
-  ]
+  ],
+  "private": true
 }


### PR DESCRIPTION
## Why

PR #140's publish run successfully published **14 packages** to GitHub Packages but failed exit-1 on a trailing `@amplify/tokens-marketing`:

```
🦋 error an error occurred while publishing @amplify/tokens-marketing: ENEEDAUTH
   This command requires you to be logged in to https://registry.npmjs.org
```

Root cause:
- Package name uses `@amplify` scope (not `@amplify-ai` or `@one-impression`)
- No `publishConfig` block, so npm tried to publish to the default registry (`registry.npmjs.org`), which has no auth set up in the workflow
- The package was never published before and isn't consumed by any consumer repo

## Fix

Mark `@amplify/tokens-marketing` as `private: true` so changesets-publish skips it entirely.

## Impact

- No consumer is affected (the package isn't installed anywhere)
- Future publish runs go green
- If we later want to ship this package publicly, follow-up renames it to `@one-impression/tokens-marketing` and adds publishConfig pointing at GitHub Packages

## Verification (post-merge)

- Add a small changeset for any tracked package → merge → Version PR → merge → publish run goes green (no ENEEDAUTH)