### PR TITLE
feat(tokens-hexcoded): add Hexcoded design tokens (v1.0 Final)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -17,6 +17,7 @@
     "@one-impression/feature-flags",
     "@amplify/tokens-marketing",
     "@one-impression/tokens-oportunities",
-    "@one-impression/tokens-studio"
+    "@one-impression/tokens-studio",
+    "@one-impression/tokens-hexcoded"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1036,7 +1036,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1054,7 +1053,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1072,7 +1070,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1090,7 +1087,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1108,7 +1104,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1126,7 +1121,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1144,7 +1138,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1162,7 +1155,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1180,7 +1172,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1198,7 +1189,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1216,7 +1206,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1234,7 +1223,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1252,7 +1240,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1270,7 +1257,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1288,7 +1274,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1306,7 +1291,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1324,7 +1308,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1342,7 +1325,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1360,7 +1342,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1378,7 +1359,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1396,7 +1376,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1414,7 +1393,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1432,7 +1410,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1450,7 +1427,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1468,7 +1444,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1486,7 +1461,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2640,6 +2614,10 @@
     },
     "node_modules/@one-impression/tokens-foundation": {
       "resolved": "packages/tokens-foundation",
+      "link": true
+    },
+    "node_modules/@one-impression/tokens-hexcoded": {
+      "resolved": "packages/tokens-hexcoded",
       "link": true
     },
     "node_modules/@one-impression/tokens-oportunities": {
@@ -11404,7 +11382,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11422,7 +11399,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11440,7 +11416,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11458,7 +11433,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11476,7 +11450,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11494,7 +11467,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11512,7 +11484,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11530,7 +11501,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11548,7 +11518,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11566,7 +11535,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11584,7 +11552,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11602,7 +11569,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11620,7 +11586,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11638,7 +11603,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11656,7 +11620,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11674,7 +11637,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11692,7 +11654,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11710,7 +11671,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11728,7 +11688,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11746,7 +11705,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11764,7 +11722,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11782,7 +11739,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11800,7 +11756,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11818,7 +11773,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11836,7 +11790,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11854,7 +11807,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13788,7 +13740,7 @@
     },
     "packages/eslint-config": {
       "name": "@one-impression/eslint-config",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "devDependencies": {
         "eslint": "^9.0.0"
       },
@@ -13805,7 +13757,7 @@
     },
     "packages/mcp-server": {
       "name": "@one-impression/mcp-server",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "zod": "^3.23.8"
@@ -13823,7 +13775,7 @@
     },
     "packages/sdui-runtime": {
       "name": "@one-impression/sdui-runtime",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "zod": "^3.22.0",
@@ -13836,8 +13788,8 @@
       "peerDependencies": {
         "@gorhom/bottom-sheet": "^5.0.0",
         "@one-impression/sdk-native-sdui": ">=1.0.0",
-        "@one-impression/tokens-creator": ">=2.0.3",
-        "@one-impression/ui-native": ">=1.0.0",
+        "@one-impression/tokens-creator": ">=3.0.0",
+        "@one-impression/ui-native": ">=2.0.0",
         "react": ">=18.0.0",
         "react-native": ">=0.72.0",
         "react-native-webview": ">=13.0.0"
@@ -13879,8 +13831,8 @@
       "name": "@one-impression/templates",
       "version": "2.0.1",
       "dependencies": {
-        "@one-impression/tokens-brand": "^3.0.0",
-        "@one-impression/ui": "^2.0.1"
+        "@one-impression/tokens-brand": "^4.0.0",
+        "@one-impression/ui": "^3.0.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.0",
@@ -13908,9 +13860,9 @@
     },
     "packages/tokens-atmosphere": {
       "name": "@one-impression/tokens-atmosphere",
-      "version": "2.0.3",
+      "version": "3.0.0",
       "dependencies": {
-        "@one-impression/tokens-foundation": "^2.0.1"
+        "@one-impression/tokens-foundation": "^3.0.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
@@ -13918,9 +13870,9 @@
     },
     "packages/tokens-brand": {
       "name": "@one-impression/tokens-brand",
-      "version": "3.1.0",
+      "version": "4.0.0",
       "dependencies": {
-        "@one-impression/tokens-foundation": "^2.0.1"
+        "@one-impression/tokens-foundation": "^3.0.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
@@ -13928,9 +13880,9 @@
     },
     "packages/tokens-creator": {
       "name": "@one-impression/tokens-creator",
-      "version": "2.0.3",
+      "version": "3.0.0",
       "dependencies": {
-        "@one-impression/tokens-foundation": "^2.0.1"
+        "@one-impression/tokens-foundation": "^3.0.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
@@ -13938,7 +13890,17 @@
     },
     "packages/tokens-foundation": {
       "name": "@one-impression/tokens-foundation",
-      "version": "2.1.3",
+      "version": "3.0.0",
+      "devDependencies": {
+        "style-dictionary": "^4.3.0"
+      }
+    },
+    "packages/tokens-hexcoded": {
+      "name": "@one-impression/tokens-hexcoded",
+      "version": "1.0.0",
+      "dependencies": {
+        "@one-impression/tokens-foundation": "^3.0.0"
+      },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
@@ -13947,14 +13909,14 @@
       "name": "@amplify/tokens-marketing",
       "version": "1.0.0",
       "peerDependencies": {
-        "@one-impression/tokens-foundation": "^2.1.0"
+        "@one-impression/tokens-foundation": "^3.0.0"
       }
     },
     "packages/tokens-oportunities": {
       "name": "@one-impression/tokens-oportunities",
       "version": "1.0.0",
       "dependencies": {
-        "@one-impression/tokens-foundation": "^2.1.0"
+        "@one-impression/tokens-foundation": "^3.0.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
@@ -13964,7 +13926,7 @@
       "name": "@one-impression/tokens-studio",
       "version": "1.0.4",
       "dependencies": {
-        "@one-impression/tokens-foundation": "^2.1.0"
+        "@one-impression/tokens-foundation": "^3.0.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
@@ -13972,7 +13934,7 @@
     },
     "packages/ui": {
       "name": "@one-impression/ui",
-      "version": "2.13.0",
+      "version": "3.0.0",
       "dependencies": {
         "clsx": "^2.1.0",
         "tailwind-merge": "^2.3.0"
@@ -13996,14 +13958,14 @@
     },
     "packages/ui-native": {
       "name": "@one-impression/ui-native",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "devDependencies": {
         "@types/react": "^18.2.0",
         "tsup": "^8.0.0",
         "typescript": "^5.5.0"
       },
       "peerDependencies": {
-        "@one-impression/tokens-creator": ">=2.0.3",
+        "@one-impression/tokens-creator": ">=3.0.0",
         "react": ">=18.0.0",
         "react-native": ">=0.72.0"
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:creator": "npm run build -w packages/tokens-creator",
     "build:atmosphere": "npm run build -w packages/tokens-atmosphere",
     "build:studio": "npm run build -w packages/tokens-studio",
+    "build:hexcoded": "npm run build -w packages/tokens-hexcoded",
     "lint": "npm run lint --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
     "clean": "rm -rf packages/*/dist",

--- a/packages/tokens-hexcoded/README.md
+++ b/packages/tokens-hexcoded/README.md
@@ -1,0 +1,92 @@
+# @one-impression/tokens-hexcoded
+
+Hexcoded design tokens — the Tech Green direction (Outfit + Phantom motion) for the AI content platform.
+
+> Hexcoded is a verb. "Take your brief, hexcode it, ship it."
+
+## What this is
+
+Token package for **Hexcoded**, the AI content platform that turns one brief into multi-format content (reel · static · caption · thumbnail · cutdown). These tokens encode the locked **Tech Green direction** from Brand Book v1.0 Final (2026-05-22):
+
+- **Tech Green** (`#22C55E`) as THE brand colour — wordmark, primary actions, success state
+- **Outfit** display (`weight 900` with `-0.025em` tracking) for the HEXCODED wordmark
+- **Inter** for body, **JetBrains Mono** for code/numbers
+- **Brand-true black** (`#0B0B0F`) as the dark surface — same hex as primary ink
+- **Phantom motion** (size-aware breathing shadow) lives in `@one-impression/brand-hexcoded` — not in tokens
+- **Light + dark themes** — soft warm white in light, brand-true black in dark; accent unchanged across modes
+
+## Locked DNA
+
+These are **not negotiable** at the package level (24 decisions locked, 1 parked):
+
+| Element | Value |
+|---|---|
+| Brand colour | `#22C55E` Tech Green (Tailwind green-500 · PANTONE 354 C) |
+| Wordmark | UPPERCASE only · no separators / dots / dashes inside HEXCODED |
+| Display font | `'Outfit', sans-serif` at weight `900` |
+| Display tracking | `-0.025em` |
+| Body font | `'Inter', sans-serif` |
+| Mono font | `'JetBrains Mono', monospace` |
+| Monogram | `HEX` on `#0B0B0F`, breathing green shadow (Phantom) |
+| Brand voice | Confident-direct · "Hexcoded turns one brief into…" · no marketing fluff |
+| Self-reference | VERB — "Get hexcoded" · "Hexcode it" |
+
+## Consume
+
+Install:
+
+```bash
+npm install @one-impression/tokens-hexcoded
+```
+
+### Tailwind v4
+
+```css
+/* globals.css */
+@import "@one-impression/tokens-hexcoded/tailwind";
+```
+
+### Plain CSS
+
+```css
+/* globals.css */
+@import "@one-impression/tokens-hexcoded/css";
+
+.button {
+  background: var(--amp-hexcoded-theme-color-accent);
+  color: var(--amp-hexcoded-theme-color-text-primary);
+  font-family: var(--amp-hexcoded-font-display);
+  font-weight: var(--amp-hexcoded-weight-display);
+  letter-spacing: var(--amp-hexcoded-letter-spacing-tight);
+}
+```
+
+### JS / TS
+
+```ts
+import * as tokens from '@one-impression/tokens-hexcoded/js';
+
+console.log(tokens.themeColorAccent); // '#22C55E'
+```
+
+### SCSS
+
+```scss
+@use '@one-impression/tokens-hexcoded/scss' as hexcoded;
+
+.button {
+  background: hexcoded.$amp-hexcoded-theme-color-accent;
+}
+```
+
+## Theme switching
+
+Light is the default. Dark mode follows `prefers-color-scheme`, or attach `[data-theme="dark"]` to switch manually. Accent (Tech Green) is constant across modes — only surfaces and ink invert.
+
+## Companion package
+
+For wordmark SVGs, monogram, favicons, app icons, social templates, business cards, and email signature templates, use [`@one-impression/brand-hexcoded`](../brand-hexcoded).
+
+## Source
+
+Locked to: `design-system-final/index.html` · v1.0 Final · 2026-05-22 (md5 `fee731682ee0b95cdb05eabd736dfe41`).

--- a/packages/tokens-hexcoded/build.js
+++ b/packages/tokens-hexcoded/build.js
@@ -1,0 +1,7 @@
+// Delegates to shared build script
+import { execSync } from 'child_process';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '../..');
+execSync(`node ${join(root, 'scripts/build-tokens.js')} hexcoded`, { stdio: 'inherit' });

--- a/packages/tokens-hexcoded/package.json
+++ b/packages/tokens-hexcoded/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@one-impression/tokens-hexcoded",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Hexcoded design tokens — Tech Green direction (Outfit + Phantom motion) for the AI content platform. Locked to Brand Book v1.0 Final (2026-05-22).",
+  "main": "dist/tokens.js",
+  "exports": {
+    "./css": "./dist/variables.css",
+    "./scss": "./dist/variables.scss",
+    "./tailwind": "./dist/tailwind.css",
+    "./json": "./dist/tokens.json",
+    "./js": "./dist/tokens.js",
+    ".": "./dist/tokens.js"
+  },
+  "scripts": {
+    "build": "node build.js"
+  },
+  "dependencies": {
+    "@one-impression/tokens-foundation": "^3.0.0"
+  },
+  "devDependencies": {
+    "style-dictionary": "^4.3.0"
+  },
+  "files": [
+    "dist/",
+    "tokens/"
+  ]
+}

--- a/packages/tokens-hexcoded/tokens/theme-dark.json
+++ b/packages/tokens-hexcoded/tokens/theme-dark.json
@@ -1,0 +1,32 @@
+{
+  "theme": {
+    "$description": "Hexcoded — Dark theme. Sourced from @media (prefers-color-scheme: dark) block in design-system-final/index.html. Accent stays Tech Green (unchanged); surfaces invert to brand-true black; shadows deepen.",
+    "product": "hexcoded",
+    "mode": "dark",
+    "color": {
+      "$type": "color",
+      "bg":             { "$value": "#0B0B0F", "$description": "Brand-true black page background" },
+      "bg-elev":        { "$value": "#1C1C22", "$description": "Elevated surface (cards, modals) — dark" },
+      "bg-soft":        { "$value": "#15151B", "$description": "Subtle inset / grouped sections — dark" },
+
+      "accent":         { "$value": "#22C55E", "$description": "Tech Green — same as light (no shift; brand is constant)" },
+      "accent-deep":    { "$value": "#16A34A", "$description": "Tech Green deep — pressed state on dark" },
+      "accent-light":   { "$value": "#86EFAC", "$description": "Tech Green light — soft accent on dark surfaces" },
+      "accent-whisper": { "$value": "#DCFCE7", "$description": "Tech Green whisper — subtlest tint on dark" },
+
+      "text-primary":   { "$value": "#FAFAFA", "$description": "Primary text on dark — soft warm white" },
+      "text-secondary": { "$value": "#C8C8CD", "$description": "Body copy on dark" },
+      "text-tertiary":  { "$value": "#86868B", "$description": "Secondary text / captions on dark (unchanged from light)" },
+
+      "border":         { "$value": "#2C2C30", "$description": "Default border on dark" }
+    }
+  },
+  "status": {
+    "$type": "color",
+    "$description": "Hexcoded status scale on dark — same hex values, sufficient contrast on warm-black surfaces (Tech Green AAA on #0B0B0F).",
+    "success":  { "$value": "#22C55E", "$description": "Success / approved — Tech Green" },
+    "warning":  { "$value": "#FBBF24", "$description": "Warning / needs attention — amber 400" },
+    "danger":   { "$value": "#EF4444", "$description": "Error / blocked / rejected — red 500" },
+    "info":     { "$value": "#0EA5E9", "$description": "Informational — sky 500" }
+  }
+}

--- a/packages/tokens-hexcoded/tokens/theme-light.json
+++ b/packages/tokens-hexcoded/tokens/theme-light.json
@@ -1,0 +1,61 @@
+{
+  "theme": {
+    "$description": "Hexcoded — Light theme. Locked to Brand Book v1.0 Final (2026-05-22). Tech Green #22C55E is THE brand colour; Outfit display + Inter body + JetBrains Mono code. Source: design-system-final/index.html (Section 05 · Tokens).",
+    "product": "hexcoded",
+    "mode": "light",
+    "color": {
+      "$type": "color",
+      "bg":             { "$value": "#FAFAFA", "$description": "Page background — soft warm white" },
+      "bg-elev":        { "$value": "#FFFFFF", "$description": "Elevated surface (cards, modals) — pure white" },
+      "bg-soft":        { "$value": "#F5F5F7", "$description": "Subtle inset / grouped sections — Apple-soft grey" },
+
+      "accent":         { "$value": "#22C55E", "$description": "Tech Green — THE Hexcoded brand colour (Tailwind green-500 · RGB 34 197 94 · PANTONE 354 C). Locked L02." },
+      "accent-deep":    { "$value": "#16A34A", "$description": "Tech Green deep — interactive pressed / hover-down" },
+      "accent-light":   { "$value": "#86EFAC", "$description": "Tech Green light — hover background / soft accent surfaces" },
+      "accent-whisper": { "$value": "#DCFCE7", "$description": "Tech Green whisper — subtlest accent tint (banner backgrounds)" },
+
+      "text-primary":   { "$value": "#0B0B0F", "$description": "Primary ink — brand-true near-black" },
+      "text-secondary": { "$value": "#3B3B42", "$description": "Body copy" },
+      "text-tertiary":  { "$value": "#86868B", "$description": "Secondary text / captions" },
+
+      "border":         { "$value": "#E5E5EA", "$description": "Default 1px hairline border" }
+    }
+  },
+  "status": {
+    "$type": "color",
+    "$description": "Hexcoded status scale — locked L19. Success === accent (Tech Green); warning amber; danger red; info sky.",
+    "success":  { "$value": "#22C55E", "$description": "Success / approved — same as brand accent (intentional)" },
+    "warning":  { "$value": "#FBBF24", "$description": "Warning / needs attention — amber 400" },
+    "danger":   { "$value": "#EF4444", "$description": "Error / blocked / rejected — red 500" },
+    "info":     { "$value": "#0EA5E9", "$description": "Informational / neutral signal — sky 500" }
+  },
+  "font": {
+    "$type": "fontFamily",
+    "$description": "Hexcoded typography — locked L05. Outfit display + Inter body + JetBrains Mono code. Multi-language coverage for US · EU · India.",
+    "display": { "$value": "'Outfit', sans-serif", "$description": "Display / wordmark / headers — Outfit at weight 900 in the wordmark" },
+    "body":    { "$value": "'Inter', -apple-system, BlinkMacSystemFont, sans-serif", "$description": "Body / UI text" },
+    "mono":    { "$value": "'JetBrains Mono', SFMono-Regular, monospace", "$description": "Monospace — code, data, numbers" }
+  },
+  "weight": {
+    "$type": "fontWeight",
+    "display":      { "$value": "900", "$description": "Display weight — Outfit Black for wordmark (locked L05/L06)" },
+    "body-default": { "$value": "400", "$description": "Default body weight — Inter Regular" },
+    "body-emphasis":{ "$value": "500", "$description": "Emphasised body — Inter Medium for crisp UI labels" }
+  },
+  "letter-spacing": {
+    "$type": "dimension",
+    "tight":   { "$value": "-0.025em", "$description": "Display tracking — Outfit wordmark and large headings" }
+  },
+  "motion": {
+    "$type": "other",
+    "$description": "Hexcoded motion scale — locked L04. 3s ease-in-out is the Phantom breath cycle on the wordmark (in brand-hexcoded). UI durations below are for components.",
+    "ease":   { "$value": "cubic-bezier(0.16, 1, 0.3, 1)", "$description": "Default easing — gentle out-back curve for surfaces" },
+    "d-fast": { "$value": "120ms", "$description": "Fast — micro-interactions, hover transitions" },
+    "d-base": { "$value": "200ms", "$description": "Base — default UI transitions" },
+    "d-slow": { "$value": "320ms", "$description": "Slow — page-level / modal enter-exit" }
+  },
+  "layout": {
+    "$type": "dimension",
+    "max-width": { "$value": "1400px", "$description": "Maximum content width on landing / dashboard surfaces" }
+  }
+}

--- a/scripts/build-tokens.js
+++ b/scripts/build-tokens.js
@@ -23,7 +23,7 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
 
-const VALID_PACKAGES = ['foundation', 'brand', 'atmosphere', 'creator', 'studio', 'oportunities'];
+const VALID_PACKAGES = ['foundation', 'brand', 'atmosphere', 'creator', 'studio', 'oportunities', 'hexcoded'];
 const pkg = process.argv[2];
 if (!pkg || !VALID_PACKAGES.includes(pkg)) {
   console.error(`Usage: node scripts/build-tokens.js <${VALID_PACKAGES.join('|')}>`);


### PR DESCRIPTION
## Summary

New `@one-impression/tokens-hexcoded` package — design tokens for the **Hexcoded** AI content platform, mirroring the proven `@one-impression/tokens-oportunities` pattern.

Tokens are extracted **1:1** from the locked **Brand Book v1.0 Final** design system reference (`design-system-final/index.html` · md5 `fee731682ee0b95cdb05eabd736dfe41` · 2026-05-22).

## What ships

- **Light + dark theme** DTCG JSON (`tokens/theme-light.json`, `tokens/theme-dark.json`)
  - `theme.color`: Tech Green `#22C55E` accent (+ deep/light/whisper), warm-white surfaces, warm-black ink, neutral border
  - `status`: success/warning/danger/info (success === accent — intentional)
  - `font`: Outfit display · Inter body · JetBrains Mono
  - `weight`, `letter-spacing`, `motion`, `layout.max-width`
- **Delegating `build.js`** → `scripts/build-tokens.js hexcoded`
- **`package.json`** exports `./css`, `./scss`, `./tailwind`, `./json`, `./js` (matches tokens-oportunities exactly)
- **`README.md`** with consume examples (Tailwind v4, plain CSS, JS/TS, SCSS)

## Monorepo wiring (3 one-line edits)

- `scripts/build-tokens.js`: `'hexcoded'` added to `VALID_PACKAGES`
- root `package.json`: `build:hexcoded` script
- `.changeset/config.json`: added to `ignore` list (manual publish via follow-up PR)

## Locked v1.0 DNA (not negotiable at package level)

- Tech Green `#22C55E` (Tailwind green-500 · PANTONE 354 C) is THE brand colour — locked **L02**
- Outfit weight `900` with `-0.025em` tracking for the wordmark — locked **L05/L06**
- Brand-true black `#0B0B0F` for dark surface and primary ink — locked **L08**
- Phantom motion (size-aware breathing wordmark shadow) ships in companion **brand-hexcoded** package (PR 2 — separate)
- Accent is **constant across light/dark** (brand is constant; only surfaces invert)

## Pattern compliance

Mirrors `tokens-oportunities` 1:1 across all 6 monorepo touch-points (per `feedback_check_capabilities_before_building.md`). Companion `brand-hexcoded` asset package follows in **PR 2** (mirrors `brand-oportunities`).

## Local verification

```
$ node scripts/build-tokens.js hexcoded
@one-impression/tokens-hexcoded: built 5 artifacts

$ ls packages/tokens-hexcoded/dist/
tailwind.css  tokens.js  tokens.json  variables.css  variables.scss

$ grep amp-hexcoded-theme-color-accent packages/tokens-hexcoded/dist/variables.css
  --amp-hexcoded-theme-color-accent: #22C55E;

$ node scripts/validate-tokens.js
Errors: 0  Warnings: 0  ·  All checks passed
```

## Test plan

- [ ] CI builds all workspaces (`npm run build`)
- [ ] CI runs `validate-tokens.js` (0 errors/warnings expected)
- [ ] Secret scan clean
- [ ] Zenith review — design-system pattern compliance
- [ ] No published artifact (changeset-ignored → manual publish in PR 4)

## Follow-up PRs

- **PR 2** `feat(brand-hexcoded): asset package` — Phantom wordmark SVGs, HEX monogram, favicons, social, email signature
- **PR 3** `docs(storybook): hexcoded section` — `stories/hexcoded/` + `public/_themes/hexcoded.css`
- **PR 4** `chore(release): publish @one-impression/{tokens,brand}-hexcoded@1.0.0` — remove from changesets ignore, publish to GitHub Packages
- After PR 4: scaffold `One-Impression/hexcoded-landing` repo (mirror of `oportunities-landing`) as first consumer

## §B13 note

The repo name `amplify-design-system` is product-prefixed but now serves 4 businesses (Amplify/Oportunities/Hexcoded + soon more). Pre-existing condition (Oportunities is already here); separate rename initiative recommended, not blocking this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)