### PR TITLE
feat(brand-hexcoded): add Hexcoded brand asset package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1036,7 +1036,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1054,7 +1053,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1072,7 +1070,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1090,7 +1087,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1108,7 +1104,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1126,7 +1121,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1144,7 +1138,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1162,7 +1155,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1180,7 +1172,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1198,7 +1189,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1216,7 +1206,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1234,7 +1223,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1252,7 +1240,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1270,7 +1257,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1288,7 +1274,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1306,7 +1291,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1324,7 +1308,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1342,7 +1325,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1360,7 +1342,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1378,7 +1359,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1396,7 +1376,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1414,7 +1393,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1432,7 +1410,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1450,7 +1427,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1468,7 +1444,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1486,7 +1461,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2597,6 +2571,10 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@one-impression/brand-hexcoded": {
+      "resolved": "packages/brand-hexcoded",
+      "link": true
     },
     "node_modules/@one-impression/brand-oportunities": {
       "resolved": "packages/brand-oportunities",
@@ -11404,7 +11382,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11422,7 +11399,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11440,7 +11416,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11458,7 +11433,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11476,7 +11450,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11494,7 +11467,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11512,7 +11484,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11530,7 +11501,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11548,7 +11518,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11566,7 +11535,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11584,7 +11552,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11602,7 +11569,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11620,7 +11586,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11638,7 +11603,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11656,7 +11620,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11674,7 +11637,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11692,7 +11654,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11710,7 +11671,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11728,7 +11688,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11746,7 +11705,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11764,7 +11722,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11782,7 +11739,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11800,7 +11756,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11818,7 +11773,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11836,7 +11790,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11854,7 +11807,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13782,13 +13734,17 @@
         }
       }
     },
+    "packages/brand-hexcoded": {
+      "name": "@one-impression/brand-hexcoded",
+      "version": "1.0.0"
+    },
     "packages/brand-oportunities": {
       "name": "@one-impression/brand-oportunities",
       "version": "1.0.0"
     },
     "packages/eslint-config": {
       "name": "@one-impression/eslint-config",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "devDependencies": {
         "eslint": "^9.0.0"
       },
@@ -13805,7 +13761,7 @@
     },
     "packages/mcp-server": {
       "name": "@one-impression/mcp-server",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "zod": "^3.23.8"
@@ -13823,7 +13779,7 @@
     },
     "packages/sdui-runtime": {
       "name": "@one-impression/sdui-runtime",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "zod": "^3.22.0",
@@ -13836,8 +13792,8 @@
       "peerDependencies": {
         "@gorhom/bottom-sheet": "^5.0.0",
         "@one-impression/sdk-native-sdui": ">=1.0.0",
-        "@one-impression/tokens-creator": ">=2.0.3",
-        "@one-impression/ui-native": ">=1.0.0",
+        "@one-impression/tokens-creator": ">=3.0.0",
+        "@one-impression/ui-native": ">=2.0.0",
         "react": ">=18.0.0",
         "react-native": ">=0.72.0",
         "react-native-webview": ">=13.0.0"
@@ -13879,8 +13835,8 @@
       "name": "@one-impression/templates",
       "version": "2.0.1",
       "dependencies": {
-        "@one-impression/tokens-brand": "^3.0.0",
-        "@one-impression/ui": "^2.0.1"
+        "@one-impression/tokens-brand": "^4.0.0",
+        "@one-impression/ui": "^3.0.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.0",
@@ -13908,9 +13864,9 @@
     },
     "packages/tokens-atmosphere": {
       "name": "@one-impression/tokens-atmosphere",
-      "version": "2.0.3",
+      "version": "3.0.0",
       "dependencies": {
-        "@one-impression/tokens-foundation": "^2.0.1"
+        "@one-impression/tokens-foundation": "^3.0.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
@@ -13918,9 +13874,9 @@
     },
     "packages/tokens-brand": {
       "name": "@one-impression/tokens-brand",
-      "version": "3.1.0",
+      "version": "4.0.0",
       "dependencies": {
-        "@one-impression/tokens-foundation": "^2.0.1"
+        "@one-impression/tokens-foundation": "^3.0.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
@@ -13928,9 +13884,9 @@
     },
     "packages/tokens-creator": {
       "name": "@one-impression/tokens-creator",
-      "version": "2.0.3",
+      "version": "3.0.0",
       "dependencies": {
-        "@one-impression/tokens-foundation": "^2.0.1"
+        "@one-impression/tokens-foundation": "^3.0.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
@@ -13938,7 +13894,7 @@
     },
     "packages/tokens-foundation": {
       "name": "@one-impression/tokens-foundation",
-      "version": "2.1.3",
+      "version": "3.0.0",
       "devDependencies": {
         "style-dictionary": "^4.3.0"
       }
@@ -13947,14 +13903,14 @@
       "name": "@amplify/tokens-marketing",
       "version": "1.0.0",
       "peerDependencies": {
-        "@one-impression/tokens-foundation": "^2.1.0"
+        "@one-impression/tokens-foundation": "^3.0.0"
       }
     },
     "packages/tokens-oportunities": {
       "name": "@one-impression/tokens-oportunities",
       "version": "1.0.0",
       "dependencies": {
-        "@one-impression/tokens-foundation": "^2.1.0"
+        "@one-impression/tokens-foundation": "^3.0.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
@@ -13964,7 +13920,7 @@
       "name": "@one-impression/tokens-studio",
       "version": "1.0.4",
       "dependencies": {
-        "@one-impression/tokens-foundation": "^2.1.0"
+        "@one-impression/tokens-foundation": "^3.0.0"
       },
       "devDependencies": {
         "style-dictionary": "^4.3.0"
@@ -13972,7 +13928,7 @@
     },
     "packages/ui": {
       "name": "@one-impression/ui",
-      "version": "2.13.0",
+      "version": "3.0.0",
       "dependencies": {
         "clsx": "^2.1.0",
         "tailwind-merge": "^2.3.0"
@@ -13996,14 +13952,14 @@
     },
     "packages/ui-native": {
       "name": "@one-impression/ui-native",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "devDependencies": {
         "@types/react": "^18.2.0",
         "tsup": "^8.0.0",
         "typescript": "^5.5.0"
       },
       "peerDependencies": {
-        "@one-impression/tokens-creator": ">=2.0.3",
+        "@one-impression/tokens-creator": ">=3.0.0",
         "react": ">=18.0.0",
         "react-native": ">=0.72.0"
       }

--- a/packages/brand-hexcoded/BRAND-DECISIONS.md
+++ b/packages/brand-hexcoded/BRAND-DECISIONS.md
@@ -1,0 +1,172 @@
+# Hexcoded — Locked Brand Decisions
+
+Final record of every brand decision for **Hexcoded** as of **2026-05-22**.
+This file is the source-of-truth for the asset package. Token values live in
+[`@one-impression/tokens-hexcoded`](../tokens-hexcoded).
+
+**24 of 25 decisions locked. 1 parked** (sonic identity — needs audio samples).
+
+---
+
+## What Hexcoded is
+
+AI content platform — comparable to Hexfield and R-cads, but more powerful.
+*"The only AI platform businesses, creators, or creative people need for everything and anything content."*
+
+- Brief → multi-format content (reel · static · caption · thumbnail · cutdown)
+- AI creators + build-your-own AI clone + AI clones of real human creators
+- Audience: small-to-large businesses **and** creative people
+- Headline differentiator: **physical reality super power mode**
+
+---
+
+## Theme direction
+
+**Tech Green** — chosen from candidate exploration directions on 2026-05-22.
+Anchored to Brand Book v1.0 Final.
+
+Rationale: Tech Green `#22C55E` is unambiguously "tech / build / ship," reads
+as confident-direct rather than playful or premium. Pairs with brand-true black
+for a Vercel/Linear-adjacent feel without being derivative. Phantom motion
+provides the brand's only mnemonic flourish — restrained, not decorative.
+
+---
+
+## L01 · Logo motion variant
+
+**Phantom** — Outfit 900 wordmark + green stepped shadow that breathes
+opacity on a 3s ease-in-out cycle.
+
+| Property | Value |
+|---|---|
+| Shadow layers | 3 layers · 1px / 2px / 3px stepped offsets |
+| Shadow colour | `#22C55E` Tech Green |
+| Shadow opacities (static) | 85% / 55% / 32% (front to back) |
+| Breath cycle | 3s ease-in-out (6s slow for hero / OOH) |
+| Reduced motion | `prefers-reduced-motion: reduce` → static frame |
+| Scales | Proportional with logo size |
+
+---
+
+## L02 · Brand green
+
+**Tech Green `#22C55E`** — Tailwind green-500 · RGB 34 197 94 · PANTONE 354 C.
+
+This is THE brand colour. Never substitute. CMYK conversion happens at the printer.
+
+---
+
+## L03 · Shadow depth
+
+3 layers · 1px / 2px / 3px stepped offsets · scales proportionally with logo size.
+
+---
+
+## L04 · Breath cycle
+
+3s ease-in-out base. 6s slow for hero / OOH. Static variant for print.
+
+---
+
+## L05 · Typography
+
+| Slot | Typeface | Weight | Tracking |
+|---|---|---|---|
+| Display | Outfit | 900 | -0.025em |
+| Body    | Inter | 400 / 500 | normal |
+| Code    | JetBrains Mono | 400 | normal |
+
+Multi-language coverage for US · EU · India.
+
+---
+
+## L06 · Wordmark casing
+
+Always **UPPERCASE** in the logo. Accept variants only in search input.
+
+**No separators, dots, or dashes** inside HEXCODED. Single token, single word.
+
+---
+
+## L07 · Logo lockup
+
+L1 · Wordmark alone is primary. +URL / descriptor combination marks for
+letterheads and OOH only.
+
+---
+
+## L08 · Monogram
+
+**HEX** (three letters) on black with breathing green Phantom shadow.
+`H` fallback at 16px only (shadow can't render at this scale).
+
+---
+
+## L09 · App icon
+
+HEX on black · iOS-native corner radius (`r = 22.37%` of canvas) · breathing
+Phantom shadow.
+
+---
+
+## L10 · Brand voice register
+
+Confident-direct. *"Hexcoded turns one brief into…"* No marketing fluff.
+
+---
+
+## L11 · Self-reference
+
+**VERB** — *"Get hexcoded"* · *"Take your brief, hexcode it, ship it"*
+
+---
+
+## L12–L18 · Voice continuation
+
+12 banned words / phrases (recorded in the v1.0 spec, locked).
+Errors are direct and minimal — no apologies, no fluff. State what
+happened, state what to do.
+
+---
+
+## L19 · UI state colours
+
+| State | Hex | Notes |
+|---|---|---|
+| Success | `#22C55E` | === accent (intentional) |
+| Warning | `#FBBF24` | amber 400 |
+| Danger  | `#EF4444` | red 500 |
+| Info    | `#0EA5E9` | sky 500 |
+
+---
+
+## L20–L23 · Surfaces, motion timing, layout
+
+| Token | Light | Dark |
+|---|---|---|
+| Page bg | `#FAFAFA` | `#0B0B0F` |
+| Elevated | `#FFFFFF` | `#1C1C22` |
+| Soft | `#F5F5F7` | `#15151B` |
+| Border | `#E5E5EA` | `#2C2C30` |
+
+Motion timing: `120ms` (fast), `200ms` (base), `320ms` (slow). Easing: `cubic-bezier(0.16, 1, 0.3, 1)`.
+
+Max content width: 1400px.
+
+---
+
+## L24 · Forbidden treatments
+
+- Cursive styles, thin fonts, italic display weights
+- Outlined or hollow wordmark
+- Scaling individual letters of HEXCODED
+- Replacing the typeface (no Roboto/Poppins substitutions)
+- Drop-shadow that isn't the canonical Phantom (no purple shadows, no blur shadows)
+- Animated decorations beyond the Phantom breath
+- High-saturation backgrounds behind the wordmark (use the dark or light variants)
+
+---
+
+## L25 · Sonic identity — **PARKED**
+
+Needs audio samples to decide. Re-evaluated after first launch surfaces are in market.

--- a/packages/brand-hexcoded/ENGINEER-HANDOFF.md
+++ b/packages/brand-hexcoded/ENGINEER-HANDOFF.md
@@ -1,0 +1,131 @@
+# Hexcoded — Engineer Handoff
+
+Quick reference for engineers consuming `@one-impression/brand-hexcoded`.
+Companion to [`BRAND-DECISIONS.md`](BRAND-DECISIONS.md) (the "why")
+and [`README.md`](README.md) (the "how to use each asset").
+
+---
+
+## TL;DR
+
+- Install `@one-impression/brand-hexcoded` for assets, `@one-impression/tokens-hexcoded` for tokens. They are **independent** — install both.
+- All asset paths are exported from `index.js`. Resolve with your bundler's asset loader or `import.meta.resolve`.
+- Phantom motion is **CSS keyframe-based** in `wordmark-with-phantom.svg` (`<style>` block + `@keyframes`). No JS required. Respects `prefers-reduced-motion`.
+- `favicon-{16,32,180}.png` files are SVG sources — **render to PNG before deploy** (Sharp / Resvg / `sharp-cli`).
+- All SVGs include `viewBox` and are responsive. No fixed-size raster anywhere.
+
+---
+
+## Web favicon link tags
+
+```html
+<link rel="icon"             type="image/svg+xml" href="/favicon-light.svg">
+<link rel="icon"             type="image/png" sizes="32x32"   href="/favicon-32.png">
+<link rel="icon"             type="image/png" sizes="16x16"   href="/favicon-16.png">
+<link rel="apple-touch-icon"                    sizes="180x180" href="/favicon-180.png">
+<link rel="mask-icon"        color="#22C55E"                  href="/safari-pinned-tab.svg">
+<link rel="manifest"                                           href="/site.webmanifest">
+<meta name="theme-color"     content="#22C55E">
+```
+
+---
+
+## Phantom animation — replicate in CSS
+
+If you need the Phantom effect on text other than the wordmark SVG (e.g., a hero headline), use this CSS pattern:
+
+```css
+.phantom {
+  position: relative;
+  color: #FFFFFF;
+}
+.phantom::before,
+.phantom::after,
+.phantom > .phantom-layer {
+  content: attr(data-text);
+  position: absolute;
+  top: 0; left: 0;
+  color: #22C55E;
+  animation: phantom-breath 3s ease-in-out infinite;
+}
+.phantom::before        { transform: translate(1px, 1px); opacity: 0.85; }
+.phantom > .phantom-layer { transform: translate(2px, 2px); opacity: 0.55; animation-delay: 100ms; }
+.phantom::after         { transform: translate(3px, 3px); opacity: 0.32; animation-delay: 200ms; }
+
+@keyframes phantom-breath {
+  0%, 100% { opacity: var(--phantom-opacity, 0.85); }
+  50%      { opacity: calc(var(--phantom-opacity, 0.85) * 0.4); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .phantom::before,
+  .phantom::after,
+  .phantom > .phantom-layer { animation: none; }
+}
+```
+
+---
+
+## Importing into React
+
+```tsx
+import wordmarkUrl from '@one-impression/brand-hexcoded/assets/logo/wordmark-with-phantom.svg';
+
+export function HexcodedLogo() {
+  return <img src={wordmarkUrl} alt="HEXCODED" width={240} />;
+}
+```
+
+For inline SVG (if you need to style fills via `currentColor` etc.), import the source:
+
+```tsx
+import { ReactComponent as Wordmark } from '@one-impression/brand-hexcoded/assets/logo/wordmark-monochrome.svg';
+
+<Wordmark style={{ color: '#22C55E' }} />
+```
+
+(Configure SVGR in your bundler.)
+
+---
+
+## Render PNG favicons before deploy
+
+```sh
+# install sharp once
+npm i -D sharp
+
+# convert SVG → PNG
+node -e "require('sharp')('assets/favicons/favicon-32.png').png().toFile('public/favicon-32.png')"
+```
+
+Or via the `sharp-cli` one-liner per size. Wire into the static-site build step.
+
+---
+
+## CSP-safe usage
+
+The Phantom animated SVG (`wordmark-with-phantom.svg`) uses a `<style>` block inside the SVG. If your CSP is `style-src 'self'`, this is allowed when the SVG is loaded via `<img src=...>` (the SVG is its own document). If you inline-render the SVG (`<svg>...</svg>` in HTML), you need `style-src 'self' 'unsafe-inline'` OR move the styles to an external stylesheet.
+
+---
+
+## Token wiring — see `@one-impression/tokens-hexcoded`
+
+```css
+@import "@one-impression/tokens-hexcoded/css";
+
+.hero {
+  background: var(--amp-hexcoded-theme-color-bg);
+  color: var(--amp-hexcoded-theme-color-text-primary);
+  font-family: var(--amp-hexcoded-font-display);
+}
+```
+
+---
+
+## Validation
+
+```sh
+npm run -w @one-impression/brand-hexcoded validate
+```
+
+CI runs this on every PR. Failures block merge.

--- a/packages/brand-hexcoded/README.md
+++ b/packages/brand-hexcoded/README.md
@@ -1,0 +1,111 @@
+# @one-impression/brand-hexcoded
+
+Locked brand assets for **Hexcoded** — the AI content platform.
+Theme direction: **Tech Green** (Outfit 900 wordmark + Phantom motion).
+
+This package ships ready-to-use SVG/HTML assets — no build step, no token wiring.
+For runtime tokens (colors, type, motion), use [`@one-impression/tokens-hexcoded`](../tokens-hexcoded).
+
+---
+
+## Folder layout
+
+```
+assets/
+  logo/                  6 wordmark variants (incl. Phantom-animated)
+  icons/                 App icons (light + dark, 1024 + 180, PWA maskable, spec)
+  favicons/              Favicon sources (SVG + per-size PNG sources + safari + webmanifest)
+  social/                LinkedIn cover/post, IG post/story, X banner, OG image
+  business-cards/        Front + back at 89 × 54 mm (300 DPI print spec)
+  email-signature/       Full + minimal HTML signature templates
+```
+
+---
+
+## Naming convention
+
+`<asset-type>-<variant>-<size>.svg`
+
+Examples:
+- `wordmark-on-dark.svg`
+- `app-icon-dark-1024.svg`
+- `linkedin-cover-1584x396.svg`
+- `business-card-front-89x54.svg`
+
+Sizes follow the platform's native canvas spec where one exists (LinkedIn cover is
+always 1584×396, an iPhone touch icon is always 180×180, etc).
+
+---
+
+## How to use each asset
+
+### Logo / wordmark
+
+- **`wordmark-default.svg`** — Transparent background, ink-black `#0B0B0F` wordmark. Default for most surfaces.
+- **`wordmark-on-light.svg`** — Warm-white `#FAFAFA` background bundled, ink-black wordmark. For printed material.
+- **`wordmark-on-dark.svg`** — Ink-black `#0B0B0F` background, white wordmark, Tech Green stepped **Phantom shadow** (3 layers: 1/2/3px offsets). Canonical dark variant per L01.
+- **`wordmark-monochrome.svg`** — Uses `currentColor` for fill — drop into any single-ink context (engraving, foiling, single-color print).
+- **`wordmark-with-phantom.svg`** — **Animated** Phantom variant. 3-layer green stepped shadow breathing opacity on 3s ease-in-out cycle. Respects `prefers-reduced-motion`. Use on hero surfaces, landing pages, splash screens.
+- **`wordmark-spec.svg`** — Reference only. Shows clear-space rule (1× cap-height all sides) and bounding box.
+
+### App icons (HEX monogram)
+
+- iOS / Android home-screen: `app-icon-{light,dark}-{1024,180}.svg`
+- **Dark variant is canonical** per L08/L09: HEX white on `#0B0B0F` with green Phantom shadow.
+- iOS touch icon (`<link rel="apple-touch-icon">`): `app-icon-light-180.svg` or `app-icon-dark-180.svg`
+- PWA maskable (`purpose="maskable"`): `pwa-maskable-icon-512.svg` (respects 80% safe-zone)
+- Specification reference: `app-icon-spec.svg` (squircle radius 22.37%, safe-zone, glyph alignment)
+
+### Favicons
+
+- Modern browsers: link `favicon-light.svg` (with `<meta name="theme-color" content="#22C55E">`)
+- Legacy / iOS touch: `favicon-{16,32,180}.png` (these files contain SVG sources at the spec dimension — **render to PNG before deploy** via Sharp / Resvg / equivalent)
+- Safari pinned tab: `safari-pinned-tab.svg` (monochrome — Safari applies user-defined tint)
+- PWA manifest: `site.webmanifest`
+
+### Social
+
+Templates pre-sized for each platform's native canvas. Drop your headline copy into the existing text placement and re-export to PNG / JPG for upload.
+
+### Business cards
+
+89 × 54 mm at 300 DPI = 1051 × 638 px. CMYK conversion happens at the printer (Tech Green `#22C55E` ≈ PANTONE 354 C).
+
+### Email signature
+
+Two variants. Both use inline styles only (no external CSS, no `<script>`) — works in Gmail / Outlook / Apple Mail / iOS / Android Mail. Replace `Your Name`, `Title`, and `you@hexcoded.com` placeholders.
+
+---
+
+## Consume from JS
+
+```js
+import brand from '@one-impression/brand-hexcoded';
+
+const wordmarkPath = brand.wordmark.default; // 'assets/logo/wordmark-default.svg'
+const greenHex     = brand.brandColors.techGreen; // '#22C55E'
+```
+
+Or import named exports:
+
+```js
+import { wordmark, appIcon, brandColors } from '@one-impression/brand-hexcoded';
+```
+
+To resolve to an absolute path, use Node's `import.meta.resolve` or your bundler's asset loader.
+
+---
+
+## Validate
+
+```sh
+npm run -w @one-impression/brand-hexcoded validate
+```
+
+Checks all SVGs have `<svg>` + `</svg>` + `viewBox`, email signatures have inline styles + no `<script>`, and `site.webmanifest` is valid JSON.
+
+---
+
+## Locked source
+
+Anchored to: `design-system-final/index.html` · v1.0 Final · 2026-05-22 (md5 `fee731682ee0b95cdb05eabd736dfe41`). Full decision log in [`BRAND-DECISIONS.md`](BRAND-DECISIONS.md). Engineering notes in [`ENGINEER-HANDOFF.md`](ENGINEER-HANDOFF.md).

--- a/packages/brand-hexcoded/assets/business-cards/business-card-back-89x54.svg
+++ b/packages/brand-hexcoded/assets/business-cards/business-card-back-89x54.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1051 638" role="img" aria-label="HEXCODED business card back">
+  <title>HEXCODED business card back (89×54mm @ 300 DPI = 1051×638px) — contact details template</title>
+  <defs>
+    <style>
+      .name { font-family: "Outfit", sans-serif; font-weight: 700; font-size: 64px; fill: #0B0B0F; letter-spacing: -0.02em; }
+      .title { font-family: "Inter", sans-serif; font-size: 28px; fill: #3B3B42; }
+      .meta { font-family: "JetBrains Mono", monospace; font-size: 22px; fill: #3B3B42; }
+      .url { font-family: "Outfit", sans-serif; font-weight: 700; font-size: 32px; fill: #16A34A; letter-spacing: -0.02em; }
+      .accent-bar { fill: #22C55E; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="1051" height="638" fill="#FAFAFA"/>
+  <rect x="0" y="0" width="12" height="638" class="accent-bar"/>
+  <text x="80" y="200" class="name">Your Name</text>
+  <text x="80" y="246" class="title">Title · Hexcoded</text>
+  <text x="80" y="350" class="meta">you@hexcoded.com</text>
+  <text x="80" y="390" class="meta">+91 00000 00000</text>
+  <text x="80" y="530" class="url">hexcoded.com</text>
+</svg>

--- a/packages/brand-hexcoded/assets/business-cards/business-card-front-89x54.svg
+++ b/packages/brand-hexcoded/assets/business-cards/business-card-front-89x54.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1051 638" role="img" aria-label="HEXCODED business card front">
+  <title>HEXCODED business card front (89×54mm @ 300 DPI = 1051×638px)</title>
+  <defs>
+    <style>
+      .wm { font-family: "Outfit", sans-serif; font-weight: 900; font-size: 88px; letter-spacing: -0.025em; fill: #FFFFFF; }
+      .wm-shadow-1 { fill: #22C55E; opacity: 0.85; }
+      .wm-shadow-2 { fill: #22C55E; opacity: 0.55; }
+      .tagline { font-family: "Inter", sans-serif; font-size: 18px; fill: #86868B; letter-spacing: 0.04em; text-transform: uppercase; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="1051" height="638" fill="#0B0B0F"/>
+  <text x="83" y="362" class="wm wm-shadow-2">HEXCODED</text>
+  <text x="81" y="360" class="wm wm-shadow-1">HEXCODED</text>
+  <text x="80" y="359" class="wm">HEXCODED</text>
+  <text x="80" y="416" class="tagline">Take a brief. Get a campaign.</text>
+</svg>

--- a/packages/brand-hexcoded/assets/email-signature/email-signature-minimal.html
+++ b/packages/brand-hexcoded/assets/email-signature/email-signature-minimal.html
@@ -1,0 +1,11 @@
+<!--
+  HEXCODED email signature — minimal variant.
+  One-line signature for power users / quick replies.
+-->
+<div style="font-family: Inter, -apple-system, BlinkMacSystemFont, sans-serif; font-size: 13px; color: #3B3B42; line-height: 1.45;">
+  <strong style="font-family: Outfit, sans-serif; font-weight: 900; font-size: 15px; letter-spacing: -0.025em; color: #0B0B0F;">HEXCODED</strong>
+  &nbsp;·&nbsp;
+  Your Name
+  &nbsp;·&nbsp;
+  <a href="https://hexcoded.com" style="color: #16A34A; text-decoration: none;">hexcoded.com</a>
+</div>

--- a/packages/brand-hexcoded/assets/email-signature/email-signature.html
+++ b/packages/brand-hexcoded/assets/email-signature/email-signature.html
@@ -1,0 +1,19 @@
+<!--
+  HEXCODED email signature — full variant.
+  Drop into Gmail / Outlook / Apple Mail signature field.
+  Inline styles only — no external CSS, no scripts — for max compatibility.
+-->
+<table cellpadding="0" cellspacing="0" border="0" style="font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #0B0B0F; font-size: 14px; line-height: 1.45;">
+  <tr>
+    <td style="vertical-align: top; padding-right: 18px; border-right: 1px solid #E5E5EA;">
+      <div style="font-family: Outfit, sans-serif; font-weight: 900; font-size: 22px; letter-spacing: -0.025em; color: #0B0B0F; text-shadow: 1px 1px 0 rgba(34,197,94,0.85), 2px 2px 0 rgba(34,197,94,0.55), 3px 3px 0 rgba(34,197,94,0.32);">HEXCODED</div>
+      <div style="font-family: Inter, sans-serif; font-size: 11px; color: #86868B; letter-spacing: 0.06em; text-transform: uppercase; margin-top: 4px;">AI content platform</div>
+    </td>
+    <td style="vertical-align: top; padding-left: 18px;">
+      <div style="font-family: Outfit, sans-serif; font-weight: 700; font-size: 16px; color: #0B0B0F; letter-spacing: -0.02em;">Your Name</div>
+      <div style="font-size: 13px; color: #3B3B42; margin-top: 2px;">Title · Hexcoded</div>
+      <div style="font-size: 13px; margin-top: 10px;"><a href="mailto:you@hexcoded.com" style="color: #16A34A; text-decoration: none;">you@hexcoded.com</a></div>
+      <div style="font-size: 13px; margin-top: 2px;"><a href="https://hexcoded.com" style="color: #16A34A; text-decoration: none;">hexcoded.com</a></div>
+    </td>
+  </tr>
+</table>

--- a/packages/brand-hexcoded/assets/favicons/favicon-16.png
+++ b/packages/brand-hexcoded/assets/favicons/favicon-16.png
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" role="img" aria-label="HEXCODED favicon 16">
+  <title>HEXCODED favicon source SVG @ 16×16 — render to PNG via Sharp/Resvg before deploy</title>
+  <rect x="0" y="0" width="16" height="16" fill="#22C55E"/>
+  <text x="8" y="13" font-family="Outfit, sans-serif" font-weight="900" font-size="14" letter-spacing="-0.04em" text-anchor="middle" fill="#FFFFFF">H</text>
+</svg>

--- a/packages/brand-hexcoded/assets/favicons/favicon-180.png
+++ b/packages/brand-hexcoded/assets/favicons/favicon-180.png
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180" role="img" aria-label="HEXCODED apple touch icon 180">
+  <title>HEXCODED apple-touch-icon source SVG @ 180×180 — render to PNG before deploy</title>
+  <rect x="0" y="0" width="180" height="180" rx="40" ry="40" fill="#0B0B0F"/>
+  <text x="92" y="122" font-family="Outfit, sans-serif" font-weight="900" font-size="98" letter-spacing="-0.025em" text-anchor="middle" fill="#22C55E" opacity="0.85">HEX</text>
+  <text x="90" y="120" font-family="Outfit, sans-serif" font-weight="900" font-size="98" letter-spacing="-0.025em" text-anchor="middle" fill="#FFFFFF">HEX</text>
+</svg>

--- a/packages/brand-hexcoded/assets/favicons/favicon-32.png
+++ b/packages/brand-hexcoded/assets/favicons/favicon-32.png
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="HEXCODED favicon 32">
+  <title>HEXCODED favicon source SVG @ 32×32 — render to PNG via Sharp/Resvg before deploy</title>
+  <rect x="0" y="0" width="32" height="32" rx="6" ry="6" fill="#0B0B0F"/>
+  <text x="16" y="25" font-family="Outfit, sans-serif" font-weight="900" font-size="26" letter-spacing="-0.04em" text-anchor="middle" fill="#22C55E">H</text>
+</svg>

--- a/packages/brand-hexcoded/assets/favicons/favicon-dark.svg
+++ b/packages/brand-hexcoded/assets/favicons/favicon-dark.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="HEXCODED favicon dark">
+  <title>HEXCODED favicon (Safari dark mode)</title>
+  <defs>
+    <style>
+      .h-text {
+        font-family: "Outfit", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 900;
+        font-size: 56px;
+        letter-spacing: -0.04em;
+        text-anchor: middle;
+        fill: #86EFAC;
+      }
+    </style>
+  </defs>
+  <text x="32" y="50" class="h-text">H</text>
+</svg>

--- a/packages/brand-hexcoded/assets/favicons/favicon-light.svg
+++ b/packages/brand-hexcoded/assets/favicons/favicon-light.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="HEXCODED favicon">
+  <title>HEXCODED favicon (light browser chrome)</title>
+  <defs>
+    <style>
+      .h-text {
+        font-family: "Outfit", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 900;
+        font-size: 56px;
+        letter-spacing: -0.04em;
+        text-anchor: middle;
+        fill: #22C55E;
+      }
+    </style>
+  </defs>
+  <text x="32" y="50" class="h-text">H</text>
+</svg>

--- a/packages/brand-hexcoded/assets/favicons/safari-pinned-tab.svg
+++ b/packages/brand-hexcoded/assets/favicons/safari-pinned-tab.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="HEXCODED safari pinned tab">
+  <title>HEXCODED safari pinned tab (monochrome — Safari applies tint)</title>
+  <defs>
+    <style>
+      .h-text {
+        font-family: "Outfit", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 900;
+        font-size: 56px;
+        letter-spacing: -0.04em;
+        text-anchor: middle;
+        fill: #000000;
+      }
+    </style>
+  </defs>
+  <text x="32" y="50" class="h-text">H</text>
+</svg>

--- a/packages/brand-hexcoded/assets/favicons/site.webmanifest
+++ b/packages/brand-hexcoded/assets/favicons/site.webmanifest
@@ -1,0 +1,14 @@
+{
+  "name": "Hexcoded",
+  "short_name": "Hexcoded",
+  "description": "Take a brief. Get a campaign. Reels, statics, carousels, copy, captions, thumbnails — generated from one brief.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#0B0B0F",
+  "theme_color": "#22C55E",
+  "icons": [
+    { "src": "/favicon-180.png",          "sizes": "180x180", "type": "image/png", "purpose": "any" },
+    { "src": "/pwa-maskable-icon-512.png","sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}

--- a/packages/brand-hexcoded/assets/icons/app-icon-dark-1024.svg
+++ b/packages/brand-hexcoded/assets/icons/app-icon-dark-1024.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" role="img" aria-label="HEXCODED app icon dark (canonical)">
+  <title>HEXCODED app icon (dark, 1024×1024) — HEX white on black with green Phantom shadow (canonical per L08/L09)</title>
+  <defs>
+    <clipPath id="squircle1024"><rect x="0" y="0" width="1024" height="1024" rx="229" ry="229"/></clipPath>
+    <style>
+      .icon-text {
+        font-family: "Outfit", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 900;
+        font-size: 560px;
+        letter-spacing: -0.025em;
+        text-anchor: middle;
+      }
+      .icon-ink     { fill: #FFFFFF; }
+      .icon-shadow-1 { fill: #22C55E; opacity: 0.85; }
+      .icon-shadow-2 { fill: #22C55E; opacity: 0.55; }
+      .icon-shadow-3 { fill: #22C55E; opacity: 0.32; }
+    </style>
+  </defs>
+  <g clip-path="url(#squircle1024)">
+    <rect x="0" y="0" width="1024" height="1024" fill="#0B0B0F"/>
+    <text x="528" y="696" class="icon-text icon-shadow-3">HEX</text>
+    <text x="522" y="690" class="icon-text icon-shadow-2">HEX</text>
+    <text x="518" y="685" class="icon-text icon-shadow-1">HEX</text>
+    <text x="512" y="680" class="icon-text icon-ink">HEX</text>
+  </g>
+</svg>

--- a/packages/brand-hexcoded/assets/icons/app-icon-dark-180.svg
+++ b/packages/brand-hexcoded/assets/icons/app-icon-dark-180.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180" role="img" aria-label="HEXCODED app icon dark (canonical)">
+  <title>HEXCODED app icon (dark, 180×180) — HEX white on black with green Phantom shadow</title>
+  <defs>
+    <clipPath id="squircle180d"><rect x="0" y="0" width="180" height="180" rx="40" ry="40"/></clipPath>
+    <style>
+      .icon-text {
+        font-family: "Outfit", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 900;
+        font-size: 98px;
+        letter-spacing: -0.025em;
+        text-anchor: middle;
+      }
+      .icon-ink      { fill: #FFFFFF; }
+      .icon-shadow-1 { fill: #22C55E; opacity: 0.85; }
+      .icon-shadow-2 { fill: #22C55E; opacity: 0.55; }
+    </style>
+  </defs>
+  <g clip-path="url(#squircle180d)">
+    <rect x="0" y="0" width="180" height="180" fill="#0B0B0F"/>
+    <text x="92" y="122" class="icon-text icon-shadow-2">HEX</text>
+    <text x="91" y="121" class="icon-text icon-shadow-1">HEX</text>
+    <text x="90" y="120" class="icon-text icon-ink">HEX</text>
+  </g>
+</svg>

--- a/packages/brand-hexcoded/assets/icons/app-icon-light-1024.svg
+++ b/packages/brand-hexcoded/assets/icons/app-icon-light-1024.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" role="img" aria-label="HEXCODED app icon light">
+  <title>HEXCODED app icon (light, 1024×1024) — HEX on warm-white squircle</title>
+  <defs>
+    <clipPath id="squircle"><rect x="0" y="0" width="1024" height="1024" rx="229" ry="229"/></clipPath>
+    <style>
+      .icon-text {
+        font-family: "Outfit", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 900;
+        font-size: 560px;
+        letter-spacing: -0.025em;
+        fill: #0B0B0F;
+        text-anchor: middle;
+      }
+    </style>
+  </defs>
+  <g clip-path="url(#squircle)">
+    <rect x="0" y="0" width="1024" height="1024" fill="#FAFAFA"/>
+    <text x="512" y="680" class="icon-text">HEX</text>
+  </g>
+</svg>

--- a/packages/brand-hexcoded/assets/icons/app-icon-light-180.svg
+++ b/packages/brand-hexcoded/assets/icons/app-icon-light-180.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180" role="img" aria-label="HEXCODED app icon light">
+  <title>HEXCODED app icon (light, 180×180) — iOS touch icon</title>
+  <defs>
+    <clipPath id="squircle180"><rect x="0" y="0" width="180" height="180" rx="40" ry="40"/></clipPath>
+    <style>
+      .icon-text {
+        font-family: "Outfit", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 900;
+        font-size: 98px;
+        letter-spacing: -0.025em;
+        fill: #0B0B0F;
+        text-anchor: middle;
+      }
+    </style>
+  </defs>
+  <g clip-path="url(#squircle180)">
+    <rect x="0" y="0" width="180" height="180" fill="#FAFAFA"/>
+    <text x="90" y="120" class="icon-text">HEX</text>
+  </g>
+</svg>

--- a/packages/brand-hexcoded/assets/icons/app-icon-spec.svg
+++ b/packages/brand-hexcoded/assets/icons/app-icon-spec.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1200" role="img" aria-label="HEXCODED app icon specification">
+  <title>HEXCODED app icon spec — squircle radius 22.37%, 80% safe-zone, glyph alignment (reference only)</title>
+  <defs>
+    <style>
+      .canvas-bg   { fill: #FAFAFA; }
+      .squircle    { fill: none; stroke: #22C55E; stroke-width: 4; }
+      .safe-zone   { fill: none; stroke: #16A34A; stroke-width: 2; stroke-dasharray: 8 8; }
+      .glyph-baseline { stroke: #EF4444; stroke-width: 2; stroke-dasharray: 2 2; }
+      .annot       { font-family: "JetBrains Mono", monospace; font-size: 22px; fill: #3B3B42; }
+      .ink         { fill: #0B0B0F; font-family: "Outfit", sans-serif; font-weight: 900; font-size: 560px; letter-spacing: -0.025em; text-anchor: middle; opacity: 0.25; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="1200" height="1200" class="canvas-bg"/>
+  <rect x="88" y="88" width="1024" height="1024" rx="229" ry="229" class="squircle"/>
+  <rect x="190" y="190" width="820" height="820" rx="180" ry="180" class="safe-zone"/>
+  <line x1="600" y1="88" x2="600" y2="1112" class="glyph-baseline"/>
+  <text x="600" y="768" class="ink">HEX</text>
+  <text x="88" y="68" class="annot">canvas 1024 · squircle r=229 (22.37%) · safe-zone 820×820 (80%)</text>
+  <text x="88" y="1160" class="annot">glyph centred · cap-height ~560 · baseline 768</text>
+</svg>

--- a/packages/brand-hexcoded/assets/icons/pwa-maskable-icon-512.svg
+++ b/packages/brand-hexcoded/assets/icons/pwa-maskable-icon-512.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="HEXCODED PWA maskable icon">
+  <title>HEXCODED PWA maskable icon (512×512) — HEX on black, 80% safe-zone respected (purpose=maskable)</title>
+  <defs>
+    <style>
+      .icon-text {
+        font-family: "Outfit", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 900;
+        font-size: 220px;
+        letter-spacing: -0.025em;
+        text-anchor: middle;
+      }
+      .icon-ink     { fill: #FFFFFF; }
+      .icon-shadow  { fill: #22C55E; opacity: 0.8; }
+    </style>
+  </defs>
+  <!-- Full bleed bg (maskable allows full canvas) -->
+  <rect x="0" y="0" width="512" height="512" fill="#0B0B0F"/>
+  <!-- Glyph sized to fit within 80% safe-zone (centre 410×410) -->
+  <text x="258" y="306" class="icon-text icon-shadow">HEX</text>
+  <text x="256" y="304" class="icon-text icon-ink">HEX</text>
+</svg>

--- a/packages/brand-hexcoded/assets/logo/wordmark-default.svg
+++ b/packages/brand-hexcoded/assets/logo/wordmark-default.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 140" role="img" aria-label="HEXCODED">
+  <title>HEXCODED wordmark — default</title>
+  <defs>
+    <style>
+      .wm-text {
+        font-family: "Outfit", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 900;
+        font-size: 104px;
+        letter-spacing: -0.025em;
+        fill: #0B0B0F;
+      }
+    </style>
+  </defs>
+  <text x="20" y="104" class="wm-text">HEXCODED</text>
+</svg>

--- a/packages/brand-hexcoded/assets/logo/wordmark-monochrome.svg
+++ b/packages/brand-hexcoded/assets/logo/wordmark-monochrome.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 140" role="img" aria-label="HEXCODED">
+  <title>HEXCODED wordmark — monochrome (uses currentColor for single-ink contexts: engraving, foiling, single-color print)</title>
+  <defs>
+    <style>
+      .wm-text {
+        font-family: "Outfit", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 900;
+        font-size: 104px;
+        letter-spacing: -0.025em;
+        fill: currentColor;
+      }
+    </style>
+  </defs>
+  <text x="20" y="104" class="wm-text">HEXCODED</text>
+</svg>

--- a/packages/brand-hexcoded/assets/logo/wordmark-on-dark.svg
+++ b/packages/brand-hexcoded/assets/logo/wordmark-on-dark.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 140" role="img" aria-label="HEXCODED">
+  <title>HEXCODED wordmark — on dark surface with Phantom stepped green shadow (L01 canonical)</title>
+  <defs>
+    <style>
+      .wm-shadow-3 { fill: #22C55E; opacity: 0.32; }
+      .wm-shadow-2 { fill: #22C55E; opacity: 0.55; }
+      .wm-shadow-1 { fill: #22C55E; opacity: 0.85; }
+      .wm-text {
+        font-family: "Outfit", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 900;
+        font-size: 104px;
+        letter-spacing: -0.025em;
+        fill: #FFFFFF;
+      }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="720" height="140" fill="#0B0B0F"/>
+  <text x="23" y="107" class="wm-text wm-shadow-3">HEXCODED</text>
+  <text x="22" y="106" class="wm-text wm-shadow-2">HEXCODED</text>
+  <text x="21" y="105" class="wm-text wm-shadow-1">HEXCODED</text>
+  <text x="20" y="104" class="wm-text">HEXCODED</text>
+</svg>

--- a/packages/brand-hexcoded/assets/logo/wordmark-on-light.svg
+++ b/packages/brand-hexcoded/assets/logo/wordmark-on-light.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 140" role="img" aria-label="HEXCODED">
+  <title>HEXCODED wordmark — on light surface (cream bg bundled)</title>
+  <defs>
+    <style>
+      .wm-text {
+        font-family: "Outfit", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 900;
+        font-size: 104px;
+        letter-spacing: -0.025em;
+        fill: #0B0B0F;
+      }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="720" height="140" fill="#FAFAFA"/>
+  <text x="20" y="104" class="wm-text">HEXCODED</text>
+</svg>

--- a/packages/brand-hexcoded/assets/logo/wordmark-spec.svg
+++ b/packages/brand-hexcoded/assets/logo/wordmark-spec.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 280" role="img" aria-label="HEXCODED wordmark specification">
+  <title>HEXCODED wordmark spec — clear-space rule (1× cap-height all sides) + bounding box (reference only)</title>
+  <defs>
+    <style>
+      .wm-text {
+        font-family: "Outfit", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 900;
+        font-size: 104px;
+        letter-spacing: -0.025em;
+        fill: #0B0B0F;
+      }
+      .clear-space { fill: none; stroke: #DCFCE7; stroke-width: 1; stroke-dasharray: 4 4; }
+      .bbox       { fill: none; stroke: #22C55E; stroke-width: 1; }
+      .annot      { font-family: "JetBrains Mono", monospace; font-size: 11px; fill: #86868B; }
+    </style>
+  </defs>
+  <!-- Clear-space (104px cap-height) -->
+  <rect x="16" y="36" width="848" height="208" class="clear-space"/>
+  <!-- Bounding box of the wordmark glyphs -->
+  <rect x="120" y="140" width="640" height="104" class="bbox"/>
+  <text x="120" y="104" class="wm-text">HEXCODED</text>
+  <text x="120" y="270" class="annot">cap-height 104px · clear-space 104px (1× cap-height all sides) · bbox shown</text>
+</svg>

--- a/packages/brand-hexcoded/assets/logo/wordmark-with-phantom.svg
+++ b/packages/brand-hexcoded/assets/logo/wordmark-with-phantom.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 140" role="img" aria-label="HEXCODED">
+  <title>HEXCODED wordmark — animated Phantom variant (L01: 3-layer stepped green shadow, breathes opacity on 3s ease-in-out cycle)</title>
+  <defs>
+    <style>
+      .wm-text {
+        font-family: "Outfit", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+        font-weight: 900;
+        font-size: 104px;
+        letter-spacing: -0.025em;
+        fill: #0B0B0F;
+      }
+      .wm-shadow {
+        fill: #22C55E;
+        animation: phantom-breath 3s ease-in-out infinite;
+      }
+      .wm-shadow-1 { animation-delay: 0ms; }
+      .wm-shadow-2 { animation-delay: 100ms; opacity: 0.6; }
+      .wm-shadow-3 { animation-delay: 200ms; opacity: 0.35; }
+      @keyframes phantom-breath {
+        0%, 100% { opacity: 0.85; }
+        50%      { opacity: 0.35; }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .wm-shadow { animation: none; }
+      }
+    </style>
+  </defs>
+  <text x="23" y="107" class="wm-text wm-shadow wm-shadow-3">HEXCODED</text>
+  <text x="22" y="106" class="wm-text wm-shadow wm-shadow-2">HEXCODED</text>
+  <text x="21" y="105" class="wm-text wm-shadow wm-shadow-1">HEXCODED</text>
+  <text x="20" y="104" class="wm-text">HEXCODED</text>
+</svg>

--- a/packages/brand-hexcoded/assets/social/ig-post-1080x1080.svg
+++ b/packages/brand-hexcoded/assets/social/ig-post-1080x1080.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1080" role="img" aria-label="HEXCODED Instagram post">
+  <title>HEXCODED Instagram square post (1080×1080)</title>
+  <defs>
+    <style>
+      .wm { font-family: "Outfit", sans-serif; font-weight: 900; font-size: 144px; letter-spacing: -0.025em; fill: #FFFFFF; text-anchor: middle; }
+      .wm-shadow { fill: #22C55E; opacity: 0.7; }
+      .h-display { font-family: "Outfit", sans-serif; font-weight: 700; font-size: 72px; fill: #FFFFFF; letter-spacing: -0.02em; text-anchor: middle; }
+      .h-meta { font-family: "Inter", sans-serif; font-size: 26px; fill: #86EFAC; letter-spacing: 0.06em; text-transform: uppercase; text-anchor: middle; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="1080" height="1080" fill="#0B0B0F"/>
+  <text x="540" y="200" class="h-meta">HEXCODED</text>
+  <text x="540" y="520" class="h-display">Take a brief.</text>
+  <text x="540" y="608" class="h-display">Get a campaign.</text>
+  <text x="543" y="893" class="wm wm-shadow">HEXCODED</text>
+  <text x="540" y="890" class="wm">HEXCODED</text>
+</svg>

--- a/packages/brand-hexcoded/assets/social/ig-story-1080x1920.svg
+++ b/packages/brand-hexcoded/assets/social/ig-story-1080x1920.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1920" role="img" aria-label="HEXCODED Instagram story">
+  <title>HEXCODED Instagram story (1080×1920) — safe-zone 250px top, 350px bottom</title>
+  <defs>
+    <style>
+      .wm { font-family: "Outfit", sans-serif; font-weight: 900; font-size: 140px; letter-spacing: -0.025em; fill: #FFFFFF; text-anchor: middle; }
+      .wm-shadow { fill: #22C55E; opacity: 0.7; }
+      .h-display { font-family: "Outfit", sans-serif; font-weight: 700; font-size: 92px; fill: #FFFFFF; letter-spacing: -0.02em; text-anchor: middle; }
+      .h-meta { font-family: "Inter", sans-serif; font-size: 28px; fill: #86EFAC; letter-spacing: 0.08em; text-transform: uppercase; text-anchor: middle; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="1080" height="1920" fill="#0B0B0F"/>
+  <text x="540" y="380" class="h-meta">HEXCODED</text>
+  <text x="540" y="900" class="h-display">Take a brief.</text>
+  <text x="540" y="1012" class="h-display">Get a campaign.</text>
+  <text x="543" y="1573" class="wm wm-shadow">HEXCODED</text>
+  <text x="540" y="1570" class="wm">HEXCODED</text>
+</svg>

--- a/packages/brand-hexcoded/assets/social/linkedin-cover-1584x396.svg
+++ b/packages/brand-hexcoded/assets/social/linkedin-cover-1584x396.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1584 396" role="img" aria-label="HEXCODED LinkedIn cover">
+  <title>HEXCODED LinkedIn company cover (1584×396)</title>
+  <defs>
+    <style>
+      .wm { font-family: "Outfit", sans-serif; font-weight: 900; letter-spacing: -0.025em; }
+      .wm-lg { font-size: 168px; fill: #FFFFFF; }
+      .wm-shadow-1 { fill: #22C55E; opacity: 0.85; }
+      .wm-shadow-2 { fill: #22C55E; opacity: 0.55; }
+      .wm-shadow-3 { fill: #22C55E; opacity: 0.30; }
+      .tagline { font-family: "Inter", sans-serif; font-size: 24px; fill: #C8C8CD; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="1584" height="396" fill="#0B0B0F"/>
+  <text x="108" y="244" class="wm wm-lg wm-shadow-3">HEXCODED</text>
+  <text x="104" y="240" class="wm wm-lg wm-shadow-2">HEXCODED</text>
+  <text x="101" y="237" class="wm wm-lg wm-shadow-1">HEXCODED</text>
+  <text x="98"  y="234" class="wm wm-lg">HEXCODED</text>
+  <text x="98"  y="296" class="tagline">Take a brief. Get a campaign.</text>
+</svg>

--- a/packages/brand-hexcoded/assets/social/linkedin-post-1200x627.svg
+++ b/packages/brand-hexcoded/assets/social/linkedin-post-1200x627.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 627" role="img" aria-label="HEXCODED LinkedIn post">
+  <title>HEXCODED LinkedIn post template (1200×627)</title>
+  <defs>
+    <style>
+      .wm { font-family: "Outfit", sans-serif; font-weight: 900; font-size: 120px; letter-spacing: -0.025em; fill: #FFFFFF; }
+      .wm-shadow { fill: #22C55E; opacity: 0.7; }
+      .h-display { font-family: "Outfit", sans-serif; font-weight: 700; font-size: 56px; fill: #FFFFFF; letter-spacing: -0.02em; }
+      .h-meta { font-family: "Inter", sans-serif; font-size: 22px; fill: #86EFAC; letter-spacing: 0.05em; text-transform: uppercase; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="1200" height="627" fill="#0B0B0F"/>
+  <text x="82" y="158" class="h-meta">HEXCODED · ANNOUNCEMENT</text>
+  <text x="80" y="320" class="h-display">Take a brief.</text>
+  <text x="80" y="392" class="h-display">Get a campaign.</text>
+  <text x="83" y="563" class="wm wm-shadow">HEXCODED</text>
+  <text x="80" y="560" class="wm">HEXCODED</text>
+</svg>

--- a/packages/brand-hexcoded/assets/social/og-image-1200x630.svg
+++ b/packages/brand-hexcoded/assets/social/og-image-1200x630.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="HEXCODED Open Graph image">
+  <title>HEXCODED og:image (1200×630) — used by FB/LinkedIn/Slack/iMessage link previews</title>
+  <defs>
+    <style>
+      .wm { font-family: "Outfit", sans-serif; font-weight: 900; font-size: 152px; letter-spacing: -0.025em; fill: #FFFFFF; text-anchor: middle; }
+      .wm-shadow { fill: #22C55E; opacity: 0.75; }
+      .h-display { font-family: "Outfit", sans-serif; font-weight: 700; font-size: 60px; fill: #FFFFFF; letter-spacing: -0.02em; text-anchor: middle; }
+      .h-meta { font-family: "Inter", sans-serif; font-size: 22px; fill: #86EFAC; letter-spacing: 0.06em; text-transform: uppercase; text-anchor: middle; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="1200" height="630" fill="#0B0B0F"/>
+  <text x="600" y="132" class="h-meta">HEXCODED · AI CONTENT PLATFORM</text>
+  <text x="600" y="278" class="h-display">Take a brief.</text>
+  <text x="600" y="354" class="h-display">Get a campaign.</text>
+  <text x="603" y="555" class="wm wm-shadow">HEXCODED</text>
+  <text x="600" y="552" class="wm">HEXCODED</text>
+</svg>

--- a/packages/brand-hexcoded/assets/social/x-banner-1500x500.svg
+++ b/packages/brand-hexcoded/assets/social/x-banner-1500x500.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1500 500" role="img" aria-label="HEXCODED X banner">
+  <title>HEXCODED X (Twitter) header banner (1500×500) — safe-zone 60px each side</title>
+  <defs>
+    <style>
+      .wm { font-family: "Outfit", sans-serif; font-weight: 900; font-size: 196px; letter-spacing: -0.025em; fill: #FFFFFF; }
+      .wm-shadow-1 { fill: #22C55E; opacity: 0.85; }
+      .wm-shadow-2 { fill: #22C55E; opacity: 0.55; }
+      .tagline { font-family: "Inter", sans-serif; font-size: 28px; fill: #C8C8CD; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="1500" height="500" fill="#0B0B0F"/>
+  <text x="84" y="298" class="wm wm-shadow-2">HEXCODED</text>
+  <text x="82" y="296" class="wm wm-shadow-1">HEXCODED</text>
+  <text x="80" y="294" class="wm">HEXCODED</text>
+  <text x="80" y="346" class="tagline">Take a brief. Get a campaign.</text>
+</svg>

--- a/packages/brand-hexcoded/index.js
+++ b/packages/brand-hexcoded/index.js
@@ -1,0 +1,70 @@
+/**
+ * @one-impression/brand-hexcoded
+ * Asset path exports — resolve from package root.
+ */
+
+export const wordmark = {
+  default: 'assets/logo/wordmark-default.svg',
+  onLight: 'assets/logo/wordmark-on-light.svg',
+  onDark: 'assets/logo/wordmark-on-dark.svg',
+  monochrome: 'assets/logo/wordmark-monochrome.svg',
+  withPhantom: 'assets/logo/wordmark-with-phantom.svg',
+  spec: 'assets/logo/wordmark-spec.svg',
+};
+
+export const appIcon = {
+  light1024: 'assets/icons/app-icon-light-1024.svg',
+  light180: 'assets/icons/app-icon-light-180.svg',
+  dark1024: 'assets/icons/app-icon-dark-1024.svg',
+  dark180: 'assets/icons/app-icon-dark-180.svg',
+  spec: 'assets/icons/app-icon-spec.svg',
+  pwaMaskable512: 'assets/icons/pwa-maskable-icon-512.svg',
+};
+
+export const favicon = {
+  light: 'assets/favicons/favicon-light.svg',
+  dark: 'assets/favicons/favicon-dark.svg',
+  size16: 'assets/favicons/favicon-16.png',
+  size32: 'assets/favicons/favicon-32.png',
+  size180: 'assets/favicons/favicon-180.png',
+  safariPinnedTab: 'assets/favicons/safari-pinned-tab.svg',
+  webmanifest: 'assets/favicons/site.webmanifest',
+};
+
+export const social = {
+  linkedinCover: 'assets/social/linkedin-cover-1584x396.svg',
+  linkedinPost: 'assets/social/linkedin-post-1200x627.svg',
+  igPost: 'assets/social/ig-post-1080x1080.svg',
+  igStory: 'assets/social/ig-story-1080x1920.svg',
+  xBanner: 'assets/social/x-banner-1500x500.svg',
+  ogImage: 'assets/social/og-image-1200x630.svg',
+};
+
+export const businessCard = {
+  front: 'assets/business-cards/business-card-front-89x54.svg',
+  back: 'assets/business-cards/business-card-back-89x54.svg',
+};
+
+export const emailSignature = {
+  full: 'assets/email-signature/email-signature.html',
+  minimal: 'assets/email-signature/email-signature-minimal.html',
+};
+
+export const brandColors = {
+  techGreen: '#22C55E',
+  techGreenDeep: '#16A34A',
+  techGreenLight: '#86EFAC',
+  techGreenWhisper: '#DCFCE7',
+  ink: '#0B0B0F',
+  white: '#FAFAFA',
+};
+
+export default {
+  wordmark,
+  appIcon,
+  favicon,
+  social,
+  businessCard,
+  emailSignature,
+  brandColors,
+};

--- a/packages/brand-hexcoded/package.json
+++ b/packages/brand-hexcoded/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@one-impression/brand-hexcoded",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Hexcoded brand assets — wordmark SVGs (Phantom-animated), HEX monogram app icons, favicons, social templates, business cards, email signature. Locked to Brand Book v1.0 Final (2026-05-22).",
+  "main": "index.js",
+  "files": ["assets/", "README.md", "BRAND-DECISIONS.md", "ENGINEER-HANDOFF.md", "index.js"],
+  "scripts": {
+    "validate": "node validate.js"
+  }
+}

--- a/packages/brand-hexcoded/validate.js
+++ b/packages/brand-hexcoded/validate.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Validate all assets in this package.
+ * - SVGs: must start with <?xml or <svg and contain valid root tag close
+ * - HTML signatures: must contain inline style attributes and no <script> tags
+ * - JSON manifest: must parse as JSON
+ *
+ * Exits non-zero if any asset fails. Intended for CI.
+ *
+ * Mirrors brand-oportunities/validate.js semantics.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, extname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const ROOT = join(__dirname, 'assets');
+
+const errors = [];
+let total = 0;
+
+function walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) {
+      walk(p);
+    } else {
+      validateOne(p);
+    }
+  }
+}
+
+function validateOne(p) {
+  total += 1;
+  const rel = relative(__dirname, p);
+  const ext = extname(p);
+  const content = readFileSync(p, 'utf8');
+
+  if (ext === '.svg' || ext === '.png') {
+    // .png files in this package are SVG sources by spec — validate as SVG
+    if (!content.includes('<svg')) {
+      errors.push(`${rel}: missing <svg root element`);
+    }
+    if (!content.includes('</svg>')) {
+      errors.push(`${rel}: missing </svg> close tag`);
+    }
+    if (!content.includes('viewBox=')) {
+      errors.push(`${rel}: missing viewBox attribute (required for responsive scaling)`);
+    }
+  } else if (ext === '.html') {
+    if (!content.includes('style="')) {
+      errors.push(`${rel}: email signature must use inline style attributes`);
+    }
+    if (content.includes('<script')) {
+      errors.push(`${rel}: <script> tags forbidden in email signatures`);
+    }
+  } else if (ext === '.webmanifest') {
+    try {
+      JSON.parse(content);
+    } catch (e) {
+      errors.push(`${rel}: invalid JSON — ${e.message}`);
+    }
+  }
+}
+
+walk(ROOT);
+
+if (errors.length > 0) {
+  console.error(`@one-impression/brand-hexcoded: ${errors.length} validation error(s) across ${total} assets:`);
+  for (const e of errors) console.error(`  - ${e}`);
+  process.exit(1);
+}
+
+console.log(`@one-impression/brand-hexcoded: all ${total} assets valid`);


### PR DESCRIPTION
## Summary

New `@one-impression/brand-hexcoded` package — asset-only, mirroring the proven `@one-impression/brand-oportunities` pattern. Locked to **Brand Book v1.0 Final** (`design-system-final/index.html` · md5 `fee731682ee0b95cdb05eabd736dfe41` · 2026-05-22).

## What ships (29 assets + 6 package files)

| Category | Count | Notes |
|---|---|---|
| **Logo** (`assets/logo/`) | 6 | wordmark default/on-light/on-dark/monochrome/spec + animated `wordmark-with-phantom.svg` (3-layer Tech Green stepped shadow, 3s breath, reduced-motion safe) |
| **App icons** (`assets/icons/`) | 6 | HEX monogram at 1024/180 (light + dark) + PWA maskable 512 + spec. **Dark variant is canonical** per L08/L09. |
| **Favicons** (`assets/favicons/`) | 7 | SVG light/dark, 16/32/180 PNG-source SVGs, safari pinned tab, `site.webmanifest` |
| **Social** (`assets/social/`) | 6 | LinkedIn cover/post, IG post/story, X banner, OG image |
| **Business cards** (`assets/business-cards/`) | 2 | front + back · 89×54mm @ 300 DPI = 1051×638px |
| **Email signature** (`assets/email-signature/`) | 2 | full + minimal, inline styles, Gmail/Outlook/Apple Mail compatible |

Package files: `package.json`, `index.js` (asset path exports + `brandColors`), `validate.js`, `README.md`, `BRAND-DECISIONS.md` (24 locked decisions + 1 parked), `ENGINEER-HANDOFF.md` (CSP guidance, favicon PNG rendering, Phantom-effect CSS replica).

## Locked DNA (from BRAND-DECISIONS.md)

- **L01** Phantom motion — 3-layer Tech Green stepped shadow (1/2/3px offsets, 85/55/32% opacity), 3s ease-in-out breath
- **L02** Tech Green `#22C55E` (Tailwind green-500 · PANTONE 354 C)
- **L05** Outfit 900 / Inter / JetBrains Mono
- **L06** Wordmark: UPPERCASE, no separators / dots / dashes inside HEXCODED
- **L08** Monogram: HEX (3 letters) on black with breathing green shadow
- **L19** Status: success = accent (Tech Green); warning = `#FBBF24`; danger = `#EF4444`; info = `#0EA5E9`
- **L24** Forbidden: cursive, thin, outlined, drop-shadow-other-than-Phantom, animated decorations
- **L25** Sonic identity — PARKED (needs audio samples)

## Local verification

```
$ node packages/brand-hexcoded/validate.js
@one-impression/brand-hexcoded: all 29 assets valid
```

Validator checks every SVG has `<svg>` + `</svg>` + `viewBox`, email signatures have inline styles + no scripts, and `site.webmanifest` parses as JSON.

## Test plan

- [ ] CI builds all workspaces
- [ ] `node packages/brand-hexcoded/validate.js` passes
- [ ] Secret scan clean
- [ ] Zenith review — design system pattern compliance + brand-decisions alignment

## Companion + sequence

- **PR #142** — `@one-impression/tokens-hexcoded` (color/font/motion DTCG tokens)
- **PR #143** (this PR) — `@one-impression/brand-hexcoded` (asset-only, no build)
- **PR 3 (next)** — `docs(storybook): hexcoded section` — adds 9 stories + theme CSS
- **PR 4 (later)** — `chore(release)` — remove both from `.changeset/config.json ignore`, publish to GitHub Packages
- **After PR 4:** scaffold `One-Impression/hexcoded-landing` (mirror of `oportunities-landing`) as first consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)