### PR TITLE
fix(sdui-runtime): bff_call dispatches body.action from response + on_success/on_error chains

### DIFF
--- a/.changeset/sdui-bff-call-response-action.md
+++ b/.changeset/sdui-bff-call-response-action.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+The `bff_call` action handler now parses the response JSON body and dispatches `body.action` (if present) before any declared `on_success` chain. Re-enables server-driven action chaining the runtime had previously discarded — required for `append_items` on infinite scroll, post-submit navigation, and any BFF response that carries its own follow-up action. Defensive `.catch(() => null)` on the body parse tolerates non-JSON / empty responses.

--- a/packages/sdui-runtime/src/action-engine/handlers/__tests__/bff-call.test.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/__tests__/bff-call.test.ts
@@ -1,0 +1,161 @@
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { handleBffCall } from "../bff-call.ts";
+import type { ActionEngine, ActionEngineConfig } from "../../types.ts";
+import type { Action } from "@one-impression/sdk-native-sdui";
+
+const noopConfig: ActionEngineConfig = {
+  bffBaseUrl: "https://bff.example.test",
+  authToken: () => null,
+  onNavigate: () => undefined,
+  onToast: () => undefined,
+  onDeeplink: () => undefined,
+};
+
+interface SpyEngine extends ActionEngine {
+  log: Array<{ type: string; tag?: string }>;
+}
+
+function makeSpyEngine(): SpyEngine {
+  const log: SpyEngine["log"] = [];
+  return {
+    log,
+    dispatch: async (action: Action) => {
+      const tag = (action.payload?.tag as string | undefined) ?? undefined;
+      log.push({ type: action.type, tag });
+    },
+  };
+}
+
+// Mock fetch — replace global fetch with a programmable stub for each test.
+type FetchStub = (input: unknown, init?: unknown) => Promise<Response>;
+let originalFetch: typeof globalThis.fetch | undefined;
+
+function installFetch(stub: FetchStub): void {
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = stub as unknown as typeof globalThis.fetch;
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const bffAction = (overrides: Record<string, unknown> = {}): Action =>
+  ({
+    type: "bff_call",
+    payload: {
+      method: "POST",
+      endpoint: "creator.events.track",
+      ...overrides,
+    },
+  }) as Action;
+
+test("bff_call — 200 with body.action dispatches that action", async () => {
+  installFetch(async () =>
+    jsonResponse({
+      action: { type: "toast", payload: { tag: "from-body" } },
+    }),
+  );
+  const engine = makeSpyEngine();
+  await handleBffCall(bffAction(), noopConfig, engine);
+  assert.deepEqual(
+    engine.log.map((e) => e.tag),
+    ["from-body"],
+  );
+});
+
+test("bff_call — 200 with body.action + on_success dispatches body.action first, then on_success", async () => {
+  installFetch(async () =>
+    jsonResponse({
+      action: { type: "toast", payload: { tag: "body" } },
+    }),
+  );
+  const engine = makeSpyEngine();
+  await handleBffCall(
+    bffAction({
+      on_success: { type: "toast", payload: { tag: "success" } },
+    }),
+    noopConfig,
+    engine,
+  );
+  assert.deepEqual(
+    engine.log.map((e) => e.tag),
+    ["body", "success"],
+    "body.action must dispatch before payload.on_success",
+  );
+});
+
+test("bff_call — 500 with on_error dispatches on_error", async () => {
+  installFetch(async () => jsonResponse({ error: "boom" }, 500));
+  const engine = makeSpyEngine();
+  await handleBffCall(
+    bffAction({
+      on_error: { type: "toast", payload: { tag: "err" } },
+    }),
+    noopConfig,
+    engine,
+  );
+  assert.deepEqual(
+    engine.log.map((e) => e.tag),
+    ["err"],
+  );
+});
+
+test("bff_call — 200 with no body.action and no on_success — nothing fires", async () => {
+  installFetch(async () => jsonResponse({ data: "ok" }));
+  const engine = makeSpyEngine();
+  await handleBffCall(bffAction(), noopConfig, engine);
+  assert.equal(engine.log.length, 0);
+});
+
+test("bff_call — 200 with empty / non-JSON body — nothing fires, no throw", async () => {
+  installFetch(
+    async () =>
+      new Response("", {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+      }),
+  );
+  const engine = makeSpyEngine();
+  await handleBffCall(bffAction(), noopConfig, engine);
+  assert.equal(engine.log.length, 0);
+});
+
+test("bff_call — 200 with body.action and on_success — both dispatched in order, with telemetry between", async () => {
+  installFetch(async () =>
+    jsonResponse({
+      action: {
+        type: "append_items",
+        payload: { tag: "append", section_id: "feed", items: [] },
+      },
+    }),
+  );
+  const engine = makeSpyEngine();
+  await handleBffCall(
+    bffAction({
+      on_success: { type: "navigate", payload: { tag: "nav", to: "/next" } },
+    }),
+    noopConfig,
+    engine,
+  );
+  assert.deepEqual(
+    engine.log.map((e) => ({ type: e.type, tag: e.tag })),
+    [
+      { type: "append_items", tag: "append" },
+      { type: "navigate", tag: "nav" },
+    ],
+  );
+});

--- a/packages/sdui-runtime/src/action-engine/handlers/bff-call.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/bff-call.ts
@@ -60,7 +60,21 @@ export async function handleBffCall(
       throw new Error(`BFF ${payload.method} ${endpointPath} returned ${res.status}`);
     }
 
+    // Server may bundle a follow-up action chain in the response body
+    // (e.g. append_items for pagination, navigate after submit).
+    // Parse defensively — non-JSON / empty bodies are tolerated.
+    const body = await res.json().catch(() => null);
+    if (
+      body &&
+      typeof body === "object" &&
+      "action" in body &&
+      (body as { action?: unknown }).action
+    ) {
+      await engine.dispatch((body as { action: Action }).action);
+    }
+
     // Non-optimistic success dispatch (or confirm optimistic).
+    // Body-driven action runs first; on_success is the caller-declared chain.
     if (!payload.optimistic && payload.on_success) {
       await engine.dispatch(payload.on_success as Action);
     }


### PR DESCRIPTION
## Summary

The `bff_call` handler in `packages/sdui-runtime/src/action-engine/handlers/bff-call.ts` previously fired the HTTP request but discarded the response body. This patch:

1. Parses the JSON body defensively (non-JSON / empty body tolerated via `.catch(() => null)`)
2. Dispatches `body.action` first if present in the response
3. Then dispatches `payload.on_success` (existing behaviour preserved)
4. On non-2xx, dispatches `payload.on_error` (existing behaviour preserved)

Dispatch order on success: **`body.action` (server-driven) → `payload.on_success` (caller-declared)**.

## Why

Server-driven action chaining is a first-class SDUI pattern: the BFF returns `{ action: { type, payload } }` in the response body so the runtime fans it out to the next renderer-side mutation. Without this, two flows broke:

- **`append_items` pagination** — the next page handler returns `action: { type: "append_items", ... }` and the feed never updates.
- **Post-submit navigate** — submit handlers return `action: { type: "navigate", ... }` and the user never advances.

The schema already exposes `on_success` / `on_error` (used as the caller-declared chain). This PR does not introduce new schema fields.

## Test plan

- [x] `pnpm/npm -r --filter @one-impression/sdui-runtime build` — clean
- [x] 6 new unit tests in `bff-call.test.ts`:
  - 200 with `body.action` → action dispatched
  - 200 with `body.action` + `on_success` → both dispatched in declared order
  - 500 with `on_error` → `on_error` dispatched
  - 200 with no `body.action` and no `on_success` → nothing fires
  - 200 with empty / non-JSON body → no throw, nothing fires
  - 200 `append_items` + `navigate` chain — ordering pinned
- [x] Baseline verified: without the fix, 3 of the new tests fail; with the fix, all 6 pass.
- [ ] Manual: run creator-app, scroll feed past first page, confirm `append_items` fires.
- [ ] Manual: submit OTP form, confirm post-submit `navigate` fires.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)