### PR TITLE
fix(sdui-runtime): bottom sheet imperative present + sheet registry pattern

### DIFF
--- a/.changeset/sdui-bottom-sheet-imperative-registry.md
+++ b/.changeset/sdui-bottom-sheet-imperative-registry.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": minor
+---
+
+Rewires the bottom-sheet runtime to match gorhom's imperative `BottomSheetModal` API. `useBottomSheetStore` is reorganised around `registry` / `openSheets` / `openOrder` / `contexts` with `register`, `unregister`, `open`, `close`, `closeAll` actions; reopening an already-open sheet promotes it to topmost. `BottomSheetHost` renders one `BottomSheetHostSheet` per registered sheet, each owning its own ref and calling `present()` / `dismiss()` via a `useEffect` keyed on the open flag. Page renderers (`PageStandard`, `PageFeed`, `PageStickyFooter`) and the `BottomSheet` snippet renderer pre-register on mount and unregister on unmount, so navigating away no longer leaks orphan entries. `useBottomSheetData` reads through `useShallow` for an atomic snapshot under React 18 concurrent rendering. The `sheet` action handler now calls `open(sheet_id)` (registry lookup) instead of stamping a sheet inline.

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -34,7 +34,7 @@
     "build": "tsup && tsc --emitDeclarationOnly --noCheck",
     "dev": "tsup --watch",
     "lint": "eslint src/",
-    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts"
+    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/bottom-sheet/__tests__/*.test.ts"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/sdui-runtime/src/action-engine/handlers/sheet.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/sheet.ts
@@ -3,7 +3,11 @@ import type { Action } from "@one-impression/sdk-native-sdui";
 import type { ActionEngineConfig, ActionEngine } from "../types.js";
 
 /**
- * sheet — opens a bottom sheet by its ID via the shared bottom-sheet store.
+ * sheet — opens a previously-registered bottom sheet by id.
+ *
+ * The page renderer registers `page.bottom_sheets[]` entries on mount via
+ * `useBottomSheetStore.register()`. This handler simply opens the sheet by
+ * id (lookup pattern) — it does NOT stamp a new sheet definition.
  */
 export async function handleSheet(
   action: Action,
@@ -13,6 +17,8 @@ export async function handleSheet(
   const payload = SheetPayloadSchema.parse(action.payload);
 
   // Dynamic import to avoid hard dependency on bottom-sheet store at module level.
-  const { useBottomSheetStore } = await import("../../bottom-sheet/useBottomSheetStore.js");
-  useBottomSheetStore.getState().open({ id: payload.sheet_id });
+  const { useBottomSheetStore } = await import(
+    "../../bottom-sheet/useBottomSheetStore.js"
+  );
+  useBottomSheetStore.getState().open(payload.sheet_id);
 }

--- a/packages/sdui-runtime/src/bottom-sheet/BottomSheetHost.tsx
+++ b/packages/sdui-runtime/src/bottom-sheet/BottomSheetHost.tsx
@@ -1,9 +1,12 @@
-import React, { useCallback } from "react";
-import { BottomSheetModal, BottomSheetScrollView } from "@gorhom/bottom-sheet";
-import { useBottomSheetStore } from "./useBottomSheetStore.js";
+import React, { useCallback, useEffect, useRef } from "react";
+import {
+  BottomSheetModal,
+  BottomSheetScrollView,
+} from "@gorhom/bottom-sheet";
+import type { BottomSheetModalMethods } from "@gorhom/bottom-sheet/lib/typescript/types";
+import { useBottomSheetStore, type SheetEntry } from "./useBottomSheetStore.js";
 import { BottomSheetContext } from "./BottomSheetContext.js";
 import { Interpreter } from "../interpreter/Interpreter.js";
-import type { Node } from "@one-impression/sdk-native-sdui";
 
 const SIZE_TO_SNAP: Record<string, string[]> = {
   small: ["25%"],
@@ -12,13 +15,64 @@ const SIZE_TO_SNAP: Record<string, string[]> = {
   full: ["95%"],
 };
 
+interface BottomSheetHostSheetProps {
+  sheet: SheetEntry;
+  open: boolean;
+  onDismiss: () => void;
+}
+
 /**
- * Singleton host component — mount once at app root in _layout.tsx.
- * Subscribes to the Zustand bottom-sheet store and renders BottomSheetModals
- * for each entry in the stack.
+ * Per-sheet renderer that owns its own gorhom modal ref.
+ *
+ * gorhom's `BottomSheetModal` is an imperative API — it does NOT take a
+ * `visible` / `open` prop. To present a sheet you must call `ref.present()`,
+ * and to hide it you call `ref.dismiss()`. This child component bridges the
+ * declarative `open` flag from `useBottomSheetStore` to those imperative
+ * calls via a `useEffect` keyed on `open`.
+ */
+function BottomSheetHostSheet({
+  sheet,
+  open,
+  onDismiss,
+}: BottomSheetHostSheetProps): React.ReactElement {
+  const ref = useRef<BottomSheetModalMethods>(null);
+
+  useEffect(() => {
+    if (open) {
+      ref.current?.present();
+    } else {
+      ref.current?.dismiss();
+    }
+  }, [open]);
+
+  return (
+    <BottomSheetModal
+      ref={ref}
+      snapPoints={SIZE_TO_SNAP[sheet.size] ?? SIZE_TO_SNAP["medium"]}
+      enableDynamicSizing={sheet.size === "dynamic"}
+      onDismiss={onDismiss}
+    >
+      <BottomSheetScrollView>
+        <BottomSheetContext.Provider value={{ insideSheet: true }}>
+          {sheet.items.map((node, i) => (
+            <Interpreter key={node.id ?? i} node={node} />
+          ))}
+        </BottomSheetContext.Provider>
+      </BottomSheetScrollView>
+    </BottomSheetModal>
+  );
+}
+
+/**
+ * Singleton host component — mount once at app root in `_layout.tsx`.
+ *
+ * Subscribes to the Zustand bottom-sheet store and renders a child
+ * `BottomSheetHostSheet` for every sheet currently in the registry. Each
+ * child holds its own gorhom modal ref and reacts to its open state.
  */
 export function BottomSheetHost(): React.ReactElement {
-  const stack = useBottomSheetStore((s) => s.stack);
+  const registry = useBottomSheetStore((s) => s.registry);
+  const openSheets = useBottomSheetStore((s) => s.openSheets);
   const close = useBottomSheetStore((s) => s.close);
 
   const handleDismiss = useCallback(
@@ -28,23 +82,17 @@ export function BottomSheetHost(): React.ReactElement {
     [close],
   );
 
+  const entries = Object.values(registry);
+
   return (
     <>
-      {stack.map((sheet) => (
-        <BottomSheetModal
+      {entries.map((sheet) => (
+        <BottomSheetHostSheet
           key={sheet.id}
-          snapPoints={SIZE_TO_SNAP[sheet.size] ?? SIZE_TO_SNAP["medium"]}
-          enableDynamicSizing={sheet.size === "dynamic"}
+          sheet={sheet}
+          open={openSheets[sheet.id] === true}
           onDismiss={() => handleDismiss(sheet.id)}
-        >
-          <BottomSheetScrollView>
-            <BottomSheetContext.Provider value={{ insideSheet: true }}>
-              {(sheet.items as Node[]).map((node, i) => (
-                <Interpreter key={node.id ?? i} node={node} />
-              ))}
-            </BottomSheetContext.Provider>
-          </BottomSheetScrollView>
-        </BottomSheetModal>
+        />
       ))}
     </>
   );

--- a/packages/sdui-runtime/src/bottom-sheet/__tests__/useBottomSheetStore.test.ts
+++ b/packages/sdui-runtime/src/bottom-sheet/__tests__/useBottomSheetStore.test.ts
@@ -173,6 +173,36 @@ test("closeAll — clears openOrder", () => {
   assert.deepEqual(useBottomSheetStore.getState().openOrder, []);
 });
 
+test("unregister — removes a sheet from registry, openSheets, openOrder, contexts", () => {
+  resetStore();
+  useBottomSheetStore.getState().register("a", makeSheet("a"));
+  useBottomSheetStore.getState().register("b", makeSheet("b"));
+  useBottomSheetStore.getState().open("a", { ctx: 1 });
+  useBottomSheetStore.getState().open("b", { ctx: 2 });
+
+  useBottomSheetStore.getState().unregister("a");
+
+  const state = useBottomSheetStore.getState();
+  assert.equal(state.registry["a"], undefined);
+  assert.equal(state.openSheets["a"], undefined);
+  assert.equal(state.contexts["a"], undefined);
+  assert.deepEqual(state.openOrder, ["b"]);
+  // Untouched sheet is preserved
+  assert.ok(state.registry["b"]);
+  assert.equal(state.openSheets["b"], true);
+});
+
+test("unregister — is a no-op when sheet was never registered", () => {
+  resetStore();
+  useBottomSheetStore.getState().register("a", makeSheet("a"));
+
+  assert.doesNotThrow(() =>
+    useBottomSheetStore.getState().unregister("ghost"),
+  );
+  // Existing sheet untouched
+  assert.ok(useBottomSheetStore.getState().registry["a"]);
+});
+
 test("register + open + close — full round trip allows reopening", () => {
   resetStore();
   useBottomSheetStore.getState().register("info", makeSheet("info"));

--- a/packages/sdui-runtime/src/bottom-sheet/__tests__/useBottomSheetStore.test.ts
+++ b/packages/sdui-runtime/src/bottom-sheet/__tests__/useBottomSheetStore.test.ts
@@ -9,6 +9,7 @@ function resetStore(): void {
   useBottomSheetStore.setState({
     registry: {},
     openSheets: {},
+    openOrder: [],
     contexts: {},
   });
 }
@@ -124,6 +125,52 @@ test("closeAll — clears every open sheet and context, registry survives", () =
   assert.deepEqual(state.contexts, {});
   assert.ok(state.registry["a"]);
   assert.ok(state.registry["b"]);
+});
+
+test("open — appends to openOrder, reopening promotes id to topmost", () => {
+  resetStore();
+  useBottomSheetStore.getState().register("a", makeSheet("a"));
+  useBottomSheetStore.getState().register("b", makeSheet("b"));
+  useBottomSheetStore.getState().open("a");
+  useBottomSheetStore.getState().open("b");
+  useBottomSheetStore.getState().open("a"); // reopen already-open sheet
+
+  // "a" was already open; reopening should promote it to topmost without
+  // duplicating it in the order array.
+  assert.deepEqual(useBottomSheetStore.getState().openOrder, ["b", "a"]);
+});
+
+test("close(id) — removes id from openOrder", () => {
+  resetStore();
+  useBottomSheetStore.getState().register("a", makeSheet("a"));
+  useBottomSheetStore.getState().register("b", makeSheet("b"));
+  useBottomSheetStore.getState().open("a");
+  useBottomSheetStore.getState().open("b");
+  useBottomSheetStore.getState().close("a");
+
+  assert.deepEqual(useBottomSheetStore.getState().openOrder, ["b"]);
+});
+
+test("close() — pops the last entry from openOrder", () => {
+  resetStore();
+  useBottomSheetStore.getState().register("a", makeSheet("a"));
+  useBottomSheetStore.getState().register("b", makeSheet("b"));
+  useBottomSheetStore.getState().open("a");
+  useBottomSheetStore.getState().open("b");
+  useBottomSheetStore.getState().close();
+
+  assert.deepEqual(useBottomSheetStore.getState().openOrder, ["a"]);
+});
+
+test("closeAll — clears openOrder", () => {
+  resetStore();
+  useBottomSheetStore.getState().register("a", makeSheet("a"));
+  useBottomSheetStore.getState().register("b", makeSheet("b"));
+  useBottomSheetStore.getState().open("a");
+  useBottomSheetStore.getState().open("b");
+  useBottomSheetStore.getState().closeAll();
+
+  assert.deepEqual(useBottomSheetStore.getState().openOrder, []);
 });
 
 test("register + open + close — full round trip allows reopening", () => {

--- a/packages/sdui-runtime/src/bottom-sheet/__tests__/useBottomSheetStore.test.ts
+++ b/packages/sdui-runtime/src/bottom-sheet/__tests__/useBottomSheetStore.test.ts
@@ -1,0 +1,139 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  useBottomSheetStore,
+  type SheetEntry,
+} from "../useBottomSheetStore.ts";
+
+function resetStore(): void {
+  useBottomSheetStore.setState({
+    registry: {},
+    openSheets: {},
+    contexts: {},
+  });
+}
+
+function makeSheet(id: string, overrides: Partial<SheetEntry> = {}): SheetEntry {
+  return {
+    id,
+    size: "medium",
+    items: [],
+    ...overrides,
+  };
+}
+
+test("register — adds a sheet without opening it", () => {
+  resetStore();
+  const sheet = makeSheet("info");
+  useBottomSheetStore.getState().register("info", sheet);
+
+  const state = useBottomSheetStore.getState();
+  assert.deepEqual(state.registry["info"], sheet);
+  assert.equal(state.openSheets["info"], undefined);
+});
+
+test("register — is idempotent and overwrites existing entry", () => {
+  resetStore();
+  useBottomSheetStore.getState().register("info", makeSheet("info", { size: "small" }));
+  useBottomSheetStore.getState().register("info", makeSheet("info", { size: "large" }));
+
+  assert.equal(useBottomSheetStore.getState().registry["info"]?.size, "large");
+});
+
+test("open — sets openSheets true for a registered sheet", () => {
+  resetStore();
+  useBottomSheetStore.getState().register("info", makeSheet("info"));
+  useBottomSheetStore.getState().open("info");
+
+  assert.equal(useBottomSheetStore.getState().openSheets["info"], true);
+});
+
+test("open — stamps context payload against the sheet id", () => {
+  resetStore();
+  useBottomSheetStore.getState().register("info", makeSheet("info"));
+  useBottomSheetStore.getState().open("info", { campaignId: "c1" });
+
+  assert.deepEqual(useBottomSheetStore.getState().contexts["info"], {
+    campaignId: "c1",
+  });
+});
+
+test("open — is a no-op when sheet is not registered", () => {
+  resetStore();
+  // Silence the warn during the test by stubbing console.warn.
+  const originalWarn = console.warn;
+  let warned = false;
+  console.warn = () => {
+    warned = true;
+  };
+  try {
+    useBottomSheetStore.getState().open("ghost");
+    assert.equal(useBottomSheetStore.getState().openSheets["ghost"], undefined);
+    assert.equal(warned, true, "expected console.warn to be called");
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test("close — removes a sheet from openSheets but keeps it in registry", () => {
+  resetStore();
+  useBottomSheetStore.getState().register("info", makeSheet("info"));
+  useBottomSheetStore.getState().open("info", { x: 1 });
+  useBottomSheetStore.getState().close("info");
+
+  const state = useBottomSheetStore.getState();
+  assert.equal(state.openSheets["info"], undefined);
+  assert.equal(state.contexts["info"], undefined);
+  // Registry survives — sheet can be reopened.
+  assert.ok(state.registry["info"]);
+});
+
+test("close — without id closes the most-recently opened sheet", () => {
+  resetStore();
+  useBottomSheetStore.getState().register("a", makeSheet("a"));
+  useBottomSheetStore.getState().register("b", makeSheet("b"));
+  useBottomSheetStore.getState().open("a");
+  useBottomSheetStore.getState().open("b");
+
+  useBottomSheetStore.getState().close();
+
+  const state = useBottomSheetStore.getState();
+  assert.equal(state.openSheets["a"], true);
+  assert.equal(state.openSheets["b"], undefined);
+});
+
+test("close — without id is a no-op when nothing is open", () => {
+  resetStore();
+  useBottomSheetStore.getState().register("a", makeSheet("a"));
+
+  assert.doesNotThrow(() => useBottomSheetStore.getState().close());
+  assert.deepEqual(useBottomSheetStore.getState().openSheets, {});
+});
+
+test("closeAll — clears every open sheet and context, registry survives", () => {
+  resetStore();
+  useBottomSheetStore.getState().register("a", makeSheet("a"));
+  useBottomSheetStore.getState().register("b", makeSheet("b"));
+  useBottomSheetStore.getState().open("a", { v: 1 });
+  useBottomSheetStore.getState().open("b", { v: 2 });
+
+  useBottomSheetStore.getState().closeAll();
+
+  const state = useBottomSheetStore.getState();
+  assert.deepEqual(state.openSheets, {});
+  assert.deepEqual(state.contexts, {});
+  assert.ok(state.registry["a"]);
+  assert.ok(state.registry["b"]);
+});
+
+test("register + open + close — full round trip allows reopening", () => {
+  resetStore();
+  useBottomSheetStore.getState().register("info", makeSheet("info"));
+  useBottomSheetStore.getState().open("info");
+  useBottomSheetStore.getState().close("info");
+  useBottomSheetStore.getState().open("info", { again: true });
+
+  const state = useBottomSheetStore.getState();
+  assert.equal(state.openSheets["info"], true);
+  assert.deepEqual(state.contexts["info"], { again: true });
+});

--- a/packages/sdui-runtime/src/bottom-sheet/useBottomSheetStore.ts
+++ b/packages/sdui-runtime/src/bottom-sheet/useBottomSheetStore.ts
@@ -1,49 +1,92 @@
 import { create } from "zustand";
+import type { Node } from "@one-impression/sdk-native-sdui";
 
-const MAX_STACK_DEPTH = 2;
-
+/**
+ * Inline bottom-sheet record stored in the registry.
+ *
+ * Mirrors the `InlineBottomSheetSchema` payload from
+ * `@one-impression/sdk-native-sdui` (id, size, items, optional title +
+ * lifecycle triggers). The registry holds these by `sheet_id` so the
+ * `sheet` action handler can open them by id without re-defining the sheet.
+ */
 export interface SheetEntry {
   id: string;
   title?: string;
   size: string;
-  items: unknown[];
+  items: Node[];
   on_dismiss?: unknown;
   on_open?: unknown;
 }
 
 interface BottomSheetState {
-  stack: SheetEntry[];
-  open: (sheet: SheetEntry) => void;
-  close: (id?: string) => void;
+  /** All sheets declared by the active page, keyed by sheet_id. */
+  registry: Record<string, SheetEntry>;
+  /** Which registered sheets are currently presented. */
+  openSheets: Record<string, boolean>;
+  /** Per-sheet runtime context payload, stamped at open() time. */
+  contexts: Record<string, Record<string, unknown> | undefined>;
+
+  /**
+   * Register a sheet definition without opening it. Called by page renderers
+   * on mount for each `page.bottom_sheets[]` entry. Idempotent — overwrites
+   * any existing entry with the same id.
+   */
+  register: (sheetId: string, sheet: SheetEntry) => void;
+
+  /**
+   * Open a previously-registered sheet. Looks up the sheet by id from the
+   * registry; if no sheet was registered the call is a no-op (and logs a
+   * warning). An optional `contextPayload` is stamped against the sheet id
+   * so renderers / handlers inside the sheet can access it.
+   */
+  open: (sheetId: string, contextPayload?: Record<string, unknown>) => void;
+
+  /** Close a sheet by id; if omitted, closes the most-recently opened sheet. */
+  close: (sheetId?: string) => void;
+
+  /** Close every currently-open sheet (registry is preserved). */
   closeAll: () => void;
-  replace: (sheet: SheetEntry) => void;
 }
 
-export const useBottomSheetStore = create<BottomSheetState>((set) => ({
-  stack: [],
+export const useBottomSheetStore = create<BottomSheetState>((set, get) => ({
+  registry: {},
+  openSheets: {},
+  contexts: {},
 
-  open: (sheet) =>
+  register: (sheetId, sheet) =>
+    set((state) => ({
+      registry: { ...state.registry, [sheetId]: sheet },
+    })),
+
+  open: (sheetId, contextPayload) => {
+    const sheet = get().registry[sheetId];
+    if (!sheet) {
+      console.warn(
+        `[BottomSheetStore] open("${sheetId}") — no sheet registered with that id`,
+      );
+      return;
+    }
+    set((state) => ({
+      openSheets: { ...state.openSheets, [sheetId]: true },
+      contexts: { ...state.contexts, [sheetId]: contextPayload },
+    }));
+  },
+
+  close: (sheetId) =>
     set((state) => {
-      if (state.stack.length >= MAX_STACK_DEPTH) {
-        console.warn(
-          `[BottomSheetStore] Stack depth limit (${MAX_STACK_DEPTH}) reached — refusing to push "${sheet.id}"`,
-        );
-        return state;
+      if (sheetId) {
+        const { [sheetId]: _, ...remaining } = state.openSheets;
+        const { [sheetId]: __, ...remainingCtx } = state.contexts;
+        return { openSheets: remaining, contexts: remainingCtx };
       }
-      return { stack: [...state.stack, sheet] };
+      // No id: close the most-recently opened sheet.
+      const openIds = Object.keys(state.openSheets);
+      if (openIds.length === 0) return state;
+      const last = openIds[openIds.length - 1] as string;
+      const { [last]: _, ...remaining } = state.openSheets;
+      const { [last]: __, ...remainingCtx } = state.contexts;
+      return { openSheets: remaining, contexts: remainingCtx };
     }),
 
-  close: (id) =>
-    set((state) => ({
-      stack: id
-        ? state.stack.filter((s) => s.id !== id)
-        : state.stack.slice(0, -1),
-    })),
-
-  closeAll: () => set({ stack: [] }),
-
-  replace: (sheet) =>
-    set((state) => ({
-      stack: [...state.stack.slice(0, -1), sheet],
-    })),
+  closeAll: () => set({ openSheets: {}, contexts: {} }),
 }));

--- a/packages/sdui-runtime/src/bottom-sheet/useBottomSheetStore.ts
+++ b/packages/sdui-runtime/src/bottom-sheet/useBottomSheetStore.ts
@@ -43,6 +43,15 @@ interface BottomSheetState {
   register: (sheetId: string, sheet: SheetEntry) => void;
 
   /**
+   * Remove a registered sheet entirely — its definition, open flag,
+   * open-order entry, and stamped context all go. Called by renderers
+   * in their `useEffect` cleanup when a sheet (or its hosting page)
+   * unmounts, so navigating away does not leave orphan sheets in the
+   * registry that the host would keep rendering.
+   */
+  unregister: (sheetId: string) => void;
+
+  /**
    * Open a previously-registered sheet. Looks up the sheet by id from the
    * registry; if no sheet was registered the call is a no-op (and logs a
    * warning). An optional `contextPayload` is stamped against the sheet id
@@ -67,6 +76,19 @@ export const useBottomSheetStore = create<BottomSheetState>((set, get) => ({
     set((state) => ({
       registry: { ...state.registry, [sheetId]: sheet },
     })),
+
+  unregister: (sheetId) =>
+    set((state) => {
+      const { [sheetId]: _r, ...remainingRegistry } = state.registry;
+      const { [sheetId]: _o, ...remainingOpen } = state.openSheets;
+      const { [sheetId]: _c, ...remainingCtx } = state.contexts;
+      return {
+        registry: remainingRegistry,
+        openSheets: remainingOpen,
+        openOrder: state.openOrder.filter((id) => id !== sheetId),
+        contexts: remainingCtx,
+      };
+    }),
 
   open: (sheetId, contextPayload) => {
     const sheet = get().registry[sheetId];

--- a/packages/sdui-runtime/src/bottom-sheet/useBottomSheetStore.ts
+++ b/packages/sdui-runtime/src/bottom-sheet/useBottomSheetStore.ts
@@ -23,6 +23,15 @@ interface BottomSheetState {
   registry: Record<string, SheetEntry>;
   /** Which registered sheets are currently presented. */
   openSheets: Record<string, boolean>;
+  /**
+   * Explicit open-order history (oldest → newest). The last entry is the
+   * topmost open sheet. Tracked separately from `openSheets` so the
+   * "most recently opened" answer does not rely on JS object key
+   * insertion order (which the ECMAScript spec does not guarantee for
+   * arbitrary string keys and which breaks under serialization /
+   * Zustand persist middleware).
+   */
+  openOrder: string[];
   /** Per-sheet runtime context payload, stamped at open() time. */
   contexts: Record<string, Record<string, unknown> | undefined>;
 
@@ -51,6 +60,7 @@ interface BottomSheetState {
 export const useBottomSheetStore = create<BottomSheetState>((set, get) => ({
   registry: {},
   openSheets: {},
+  openOrder: [],
   contexts: {},
 
   register: (sheetId, sheet) =>
@@ -68,6 +78,10 @@ export const useBottomSheetStore = create<BottomSheetState>((set, get) => ({
     }
     set((state) => ({
       openSheets: { ...state.openSheets, [sheetId]: true },
+      // Move id to the end of the open-order history. Filtering an
+      // existing entry ensures reopening an already-open sheet promotes
+      // it to topmost rather than producing duplicates.
+      openOrder: [...state.openOrder.filter((id) => id !== sheetId), sheetId],
       contexts: { ...state.contexts, [sheetId]: contextPayload },
     }));
   },
@@ -77,16 +91,23 @@ export const useBottomSheetStore = create<BottomSheetState>((set, get) => ({
       if (sheetId) {
         const { [sheetId]: _, ...remaining } = state.openSheets;
         const { [sheetId]: __, ...remainingCtx } = state.contexts;
-        return { openSheets: remaining, contexts: remainingCtx };
+        return {
+          openSheets: remaining,
+          openOrder: state.openOrder.filter((id) => id !== sheetId),
+          contexts: remainingCtx,
+        };
       }
-      // No id: close the most-recently opened sheet.
-      const openIds = Object.keys(state.openSheets);
-      if (openIds.length === 0) return state;
-      const last = openIds[openIds.length - 1] as string;
+      // No id: close the most-recently opened sheet (last of openOrder).
+      if (state.openOrder.length === 0) return state;
+      const last = state.openOrder[state.openOrder.length - 1] as string;
       const { [last]: _, ...remaining } = state.openSheets;
       const { [last]: __, ...remainingCtx } = state.contexts;
-      return { openSheets: remaining, contexts: remainingCtx };
+      return {
+        openSheets: remaining,
+        openOrder: state.openOrder.slice(0, -1),
+        contexts: remainingCtx,
+      };
     }),
 
-  closeAll: () => set({ openSheets: {}, contexts: {} }),
+  closeAll: () => set({ openSheets: {}, openOrder: [], contexts: {} }),
 }));

--- a/packages/sdui-runtime/src/hooks/useBottomSheetData.ts
+++ b/packages/sdui-runtime/src/hooks/useBottomSheetData.ts
@@ -1,14 +1,23 @@
+import { useShallow } from "zustand/react/shallow";
 import { useBottomSheetStore } from "../bottom-sheet/useBottomSheetStore.js";
 
 /**
  * Returns the currently active (most-recently opened) bottom sheet entry,
  * or null if none open. Resolves the topmost open sheet against the store
  * registry — consumers read sheet data for conditional rendering.
+ *
+ * Uses `useShallow` so the registry + openOrder read is taken as a single
+ * atomic snapshot. Under React 18 concurrent rendering, two separate
+ * `useBottomSheetStore(selector)` calls could otherwise see torn state
+ * (one selector observes the new value while the other still sees the
+ * old) when a single store update mutates both fields.
  */
 export function useBottomSheetData() {
-  const registry = useBottomSheetStore((s) => s.registry);
-  const openOrder = useBottomSheetStore((s) => s.openOrder);
-  if (openOrder.length === 0) return null;
-  const topId = openOrder[openOrder.length - 1] as string;
-  return registry[topId] ?? null;
+  return useBottomSheetStore(
+    useShallow((s) => {
+      if (s.openOrder.length === 0) return null;
+      const topId = s.openOrder[s.openOrder.length - 1] as string;
+      return s.registry[topId] ?? null;
+    }),
+  );
 }

--- a/packages/sdui-runtime/src/hooks/useBottomSheetData.ts
+++ b/packages/sdui-runtime/src/hooks/useBottomSheetData.ts
@@ -1,10 +1,15 @@
 import { useBottomSheetStore } from "../bottom-sheet/useBottomSheetStore.js";
 
 /**
- * Returns the currently active (topmost) bottom sheet entry, or null if none open.
- * Ported 1:1 from legacy — consumers read sheet data for conditional rendering.
+ * Returns the currently active (most-recently opened) bottom sheet entry,
+ * or null if none open. Resolves the topmost open sheet against the store
+ * registry — consumers read sheet data for conditional rendering.
  */
 export function useBottomSheetData() {
-  const stack = useBottomSheetStore((s) => s.stack);
-  return stack.length > 0 ? stack[stack.length - 1] : null;
+  const registry = useBottomSheetStore((s) => s.registry);
+  const openSheets = useBottomSheetStore((s) => s.openSheets);
+  const openIds = Object.keys(openSheets).filter((id) => openSheets[id]);
+  if (openIds.length === 0) return null;
+  const topId = openIds[openIds.length - 1] as string;
+  return registry[topId] ?? null;
 }

--- a/packages/sdui-runtime/src/hooks/useBottomSheetData.ts
+++ b/packages/sdui-runtime/src/hooks/useBottomSheetData.ts
@@ -7,9 +7,8 @@ import { useBottomSheetStore } from "../bottom-sheet/useBottomSheetStore.js";
  */
 export function useBottomSheetData() {
   const registry = useBottomSheetStore((s) => s.registry);
-  const openSheets = useBottomSheetStore((s) => s.openSheets);
-  const openIds = Object.keys(openSheets).filter((id) => openSheets[id]);
-  if (openIds.length === 0) return null;
-  const topId = openIds[openIds.length - 1] as string;
+  const openOrder = useBottomSheetStore((s) => s.openOrder);
+  if (openOrder.length === 0) return null;
+  const topId = openOrder[openOrder.length - 1] as string;
   return registry[topId] ?? null;
 }

--- a/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
@@ -53,6 +53,7 @@ const styles = StyleSheet.create({
 export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
   const actionEngine = useActionEngine();
   const register = useBottomSheetStore((s) => s.register);
+  const unregister = useBottomSheetStore((s) => s.unregister);
   const { refreshing, onRefresh } = usePageRefresh(page.on_refresh);
   const [loadingMore, setLoadingMore] = useState(false);
   const loadingMoreRef = useRef(false);
@@ -65,19 +66,24 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
 
   // Register inline bottom sheets (do not open) — see PageStandard for details.
   useEffect(() => {
-    if (page.bottom_sheets) {
-      for (const sheet of page.bottom_sheets) {
-        register(sheet.id, {
-          id: sheet.id,
-          title: sheet.title,
-          size: sheet.size ?? "medium",
-          items: sheet.items ?? [],
-          on_dismiss: sheet.on_dismiss,
-          on_open: sheet.on_open,
-        });
-      }
+    if (!page.bottom_sheets) return;
+    for (const sheet of page.bottom_sheets) {
+      register(sheet.id, {
+        id: sheet.id,
+        title: sheet.title,
+        size: sheet.size ?? "medium",
+        items: sheet.items ?? [],
+        on_dismiss: sheet.on_dismiss,
+        on_open: sheet.on_open,
+      });
     }
-  }, [page.bottom_sheets, register]);
+    return () => {
+      if (!page.bottom_sheets) return;
+      for (const sheet of page.bottom_sheets) {
+        unregister(sheet.id);
+      }
+    };
+  }, [page.bottom_sheets, register, unregister]);
 
   // Page lifecycle: on_load / on_dismount
   useEffect(() => {

--- a/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
@@ -63,11 +63,11 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
   const loader = pageData.loader;
   const emptyState = pageData.empty_state;
 
-  // Register inline bottom sheets
+  // Register inline bottom sheets (do not open) — see PageStandard for details.
   useEffect(() => {
     if (page.bottom_sheets) {
       for (const sheet of page.bottom_sheets) {
-        bottomSheetStore.open({
+        bottomSheetStore.register(sheet.id, {
           id: sheet.id,
           title: sheet.title,
           size: sheet.size ?? "medium",
@@ -75,10 +75,10 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
           on_dismiss: sheet.on_dismiss,
           on_open: sheet.on_open,
         });
-        bottomSheetStore.close(sheet.id);
       }
     }
-  }, [page.bottom_sheets, bottomSheetStore]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page.bottom_sheets]);
 
   // Page lifecycle: on_load / on_dismount
   useEffect(() => {

--- a/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
@@ -52,7 +52,7 @@ const styles = StyleSheet.create({
  */
 export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
   const actionEngine = useActionEngine();
-  const bottomSheetStore = useBottomSheetStore();
+  const register = useBottomSheetStore((s) => s.register);
   const { refreshing, onRefresh } = usePageRefresh(page.on_refresh);
   const [loadingMore, setLoadingMore] = useState(false);
   const loadingMoreRef = useRef(false);
@@ -67,7 +67,7 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
   useEffect(() => {
     if (page.bottom_sheets) {
       for (const sheet of page.bottom_sheets) {
-        bottomSheetStore.register(sheet.id, {
+        register(sheet.id, {
           id: sheet.id,
           title: sheet.title,
           size: sheet.size ?? "medium",
@@ -77,8 +77,7 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
         });
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page.bottom_sheets]);
+  }, [page.bottom_sheets, register]);
 
   // Page lifecycle: on_load / on_dismount
   useEffect(() => {

--- a/packages/sdui-runtime/src/pages/PageStandard/PageStandard.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageStandard/PageStandard.renderer.tsx
@@ -21,25 +21,33 @@ interface PageProps {
 export function PageStandardRenderer({ page }: PageProps): React.ReactElement {
   const actionEngine = useActionEngine();
   const register = useBottomSheetStore((s) => s.register);
+  const unregister = useBottomSheetStore((s) => s.unregister);
   const { refreshing, onRefresh } = usePageRefresh(page.on_refresh);
 
   // Register inline bottom sheets so sheet actions can open them later.
   // Sheets are pre-registered (not opened) — the sheet action handler
-  // resolves them from the store registry by id.
+  // resolves them from the store registry by id. The cleanup path
+  // unregisters them on page unmount so navigating away does not leave
+  // orphan entries in the registry.
   useEffect(() => {
-    if (page.bottom_sheets) {
-      for (const sheet of page.bottom_sheets) {
-        register(sheet.id, {
-          id: sheet.id,
-          title: sheet.title,
-          size: sheet.size ?? "medium",
-          items: sheet.items ?? [],
-          on_dismiss: sheet.on_dismiss,
-          on_open: sheet.on_open,
-        });
-      }
+    if (!page.bottom_sheets) return;
+    for (const sheet of page.bottom_sheets) {
+      register(sheet.id, {
+        id: sheet.id,
+        title: sheet.title,
+        size: sheet.size ?? "medium",
+        items: sheet.items ?? [],
+        on_dismiss: sheet.on_dismiss,
+        on_open: sheet.on_open,
+      });
     }
-  }, [page.bottom_sheets, register]);
+    return () => {
+      if (!page.bottom_sheets) return;
+      for (const sheet of page.bottom_sheets) {
+        unregister(sheet.id);
+      }
+    };
+  }, [page.bottom_sheets, register, unregister]);
 
   // Page lifecycle: on_load / on_dismount
   useEffect(() => {

--- a/packages/sdui-runtime/src/pages/PageStandard/PageStandard.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageStandard/PageStandard.renderer.tsx
@@ -23,13 +23,13 @@ export function PageStandardRenderer({ page }: PageProps): React.ReactElement {
   const bottomSheetStore = useBottomSheetStore();
   const { refreshing, onRefresh } = usePageRefresh(page.on_refresh);
 
-  // Register inline bottom sheets so sheet actions can open them later
+  // Register inline bottom sheets so sheet actions can open them later.
+  // Sheets are pre-registered (not opened) — the sheet action handler
+  // resolves them from the store registry by id.
   useEffect(() => {
     if (page.bottom_sheets) {
       for (const sheet of page.bottom_sheets) {
-        // Sheets are pre-registered in the store keyed by their id.
-        // The sheet action handler resolves them from this store.
-        bottomSheetStore.open({
+        bottomSheetStore.register(sheet.id, {
           id: sheet.id,
           title: sheet.title,
           size: sheet.size ?? "medium",
@@ -37,11 +37,10 @@ export function PageStandardRenderer({ page }: PageProps): React.ReactElement {
           on_dismiss: sheet.on_dismiss,
           on_open: sheet.on_open,
         });
-        // Immediately close — we only need them registered, not visible.
-        bottomSheetStore.close(sheet.id);
       }
     }
-  }, [page.bottom_sheets, bottomSheetStore]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page.bottom_sheets]);
 
   // Page lifecycle: on_load / on_dismount
   useEffect(() => {

--- a/packages/sdui-runtime/src/pages/PageStandard/PageStandard.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageStandard/PageStandard.renderer.tsx
@@ -20,7 +20,7 @@ interface PageProps {
  */
 export function PageStandardRenderer({ page }: PageProps): React.ReactElement {
   const actionEngine = useActionEngine();
-  const bottomSheetStore = useBottomSheetStore();
+  const register = useBottomSheetStore((s) => s.register);
   const { refreshing, onRefresh } = usePageRefresh(page.on_refresh);
 
   // Register inline bottom sheets so sheet actions can open them later.
@@ -29,7 +29,7 @@ export function PageStandardRenderer({ page }: PageProps): React.ReactElement {
   useEffect(() => {
     if (page.bottom_sheets) {
       for (const sheet of page.bottom_sheets) {
-        bottomSheetStore.register(sheet.id, {
+        register(sheet.id, {
           id: sheet.id,
           title: sheet.title,
           size: sheet.size ?? "medium",
@@ -39,8 +39,7 @@ export function PageStandardRenderer({ page }: PageProps): React.ReactElement {
         });
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page.bottom_sheets]);
+  }, [page.bottom_sheets, register]);
 
   // Page lifecycle: on_load / on_dismount
   useEffect(() => {

--- a/packages/sdui-runtime/src/pages/PageStickyFooter/PageStickyFooter.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageStickyFooter/PageStickyFooter.renderer.tsx
@@ -54,11 +54,11 @@ export function PageStickyFooterRenderer({
   const footer = pageData?.footer;
   const keyboardAware = pageData?.keyboard_aware ?? false;
 
-  // Register inline bottom sheets
+  // Register inline bottom sheets (do not open) — see PageStandard for details.
   useEffect(() => {
     if (page.bottom_sheets) {
       for (const sheet of page.bottom_sheets) {
-        bottomSheetStore.open({
+        bottomSheetStore.register(sheet.id, {
           id: sheet.id,
           title: sheet.title,
           size: sheet.size ?? "medium",
@@ -66,10 +66,10 @@ export function PageStickyFooterRenderer({
           on_dismiss: sheet.on_dismiss,
           on_open: sheet.on_open,
         });
-        bottomSheetStore.close(sheet.id);
       }
     }
-  }, [page.bottom_sheets, bottomSheetStore]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page.bottom_sheets]);
 
   // Page lifecycle: on_load / on_dismount
   useEffect(() => {

--- a/packages/sdui-runtime/src/pages/PageStickyFooter/PageStickyFooter.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageStickyFooter/PageStickyFooter.renderer.tsx
@@ -46,6 +46,7 @@ export function PageStickyFooterRenderer({
 }: PageProps): React.ReactElement {
   const actionEngine = useActionEngine();
   const register = useBottomSheetStore((s) => s.register);
+  const unregister = useBottomSheetStore((s) => s.unregister);
   const { refreshing, onRefresh } = usePageRefresh(page.on_refresh);
 
   const pageData = page.data as
@@ -56,19 +57,24 @@ export function PageStickyFooterRenderer({
 
   // Register inline bottom sheets (do not open) — see PageStandard for details.
   useEffect(() => {
-    if (page.bottom_sheets) {
-      for (const sheet of page.bottom_sheets) {
-        register(sheet.id, {
-          id: sheet.id,
-          title: sheet.title,
-          size: sheet.size ?? "medium",
-          items: sheet.items ?? [],
-          on_dismiss: sheet.on_dismiss,
-          on_open: sheet.on_open,
-        });
-      }
+    if (!page.bottom_sheets) return;
+    for (const sheet of page.bottom_sheets) {
+      register(sheet.id, {
+        id: sheet.id,
+        title: sheet.title,
+        size: sheet.size ?? "medium",
+        items: sheet.items ?? [],
+        on_dismiss: sheet.on_dismiss,
+        on_open: sheet.on_open,
+      });
     }
-  }, [page.bottom_sheets, register]);
+    return () => {
+      if (!page.bottom_sheets) return;
+      for (const sheet of page.bottom_sheets) {
+        unregister(sheet.id);
+      }
+    };
+  }, [page.bottom_sheets, register, unregister]);
 
   // Page lifecycle: on_load / on_dismount
   useEffect(() => {

--- a/packages/sdui-runtime/src/pages/PageStickyFooter/PageStickyFooter.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageStickyFooter/PageStickyFooter.renderer.tsx
@@ -45,7 +45,7 @@ export function PageStickyFooterRenderer({
   page,
 }: PageProps): React.ReactElement {
   const actionEngine = useActionEngine();
-  const bottomSheetStore = useBottomSheetStore();
+  const register = useBottomSheetStore((s) => s.register);
   const { refreshing, onRefresh } = usePageRefresh(page.on_refresh);
 
   const pageData = page.data as
@@ -58,7 +58,7 @@ export function PageStickyFooterRenderer({
   useEffect(() => {
     if (page.bottom_sheets) {
       for (const sheet of page.bottom_sheets) {
-        bottomSheetStore.register(sheet.id, {
+        register(sheet.id, {
           id: sheet.id,
           title: sheet.title,
           size: sheet.size ?? "medium",
@@ -68,8 +68,7 @@ export function PageStickyFooterRenderer({
         });
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page.bottom_sheets]);
+  }, [page.bottom_sheets, register]);
 
   // Page lifecycle: on_load / on_dismount
   useEffect(() => {

--- a/packages/sdui-runtime/src/snippets/BottomSheet/BottomSheet.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/BottomSheet/BottomSheet.renderer.tsx
@@ -60,15 +60,16 @@ function BottomSheetRegistrar({
   const register = useBottomSheetStore((s) => s.register);
 
   useEffect(() => {
+    // Re-registration is idempotent (the store overwrites by id), so
+    // honoring prop changes here keeps the registry in sync if the
+    // hosting page re-renders with new sheet data.
     register(id, {
       id,
       title,
       size,
       items: items as Node[],
     });
-    // No teardown: registry persists until the page unmounts and replaces it.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [id, title, size, items, register]);
 
   // This renderer does not render inline — the BottomSheetHost handles display.
   return null;

--- a/packages/sdui-runtime/src/snippets/BottomSheet/BottomSheet.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/BottomSheet/BottomSheet.renderer.tsx
@@ -59,6 +59,8 @@ function BottomSheetRegistrar({
 }): React.ReactElement | null {
   const register = useBottomSheetStore((s) => s.register);
 
+  const unregister = useBottomSheetStore((s) => s.unregister);
+
   useEffect(() => {
     // Re-registration is idempotent (the store overwrites by id), so
     // honoring prop changes here keeps the registry in sync if the
@@ -69,7 +71,13 @@ function BottomSheetRegistrar({
       size,
       items: items as Node[],
     });
-  }, [id, title, size, items, register]);
+    // Cleanup on unmount removes the entry so navigating away does
+    // not leave a stale sheet registered (and so the host stops
+    // rendering its BottomSheetHostSheet child).
+    return () => {
+      unregister(id);
+    };
+  }, [id, title, size, items, register, unregister]);
 
   // This renderer does not render inline — the BottomSheetHost handles display.
   return null;

--- a/packages/sdui-runtime/src/snippets/BottomSheet/BottomSheet.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/BottomSheet/BottomSheet.renderer.tsx
@@ -57,20 +57,16 @@ function BottomSheetRegistrar({
   items: unknown[];
   apiEndpoint?: string;
 }): React.ReactElement | null {
-  const open = useBottomSheetStore((s) => s.open);
-  const close = useBottomSheetStore((s) => s.close);
+  const register = useBottomSheetStore((s) => s.register);
 
   useEffect(() => {
-    open({
+    register(id, {
       id,
       title,
       size,
-      items,
+      items: items as Node[],
     });
-
-    return () => {
-      close(id);
-    };
+    // No teardown: registry persists until the page unmounts and replaces it.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## Summary

Three connected fixes that make SDUI bottom sheets actually appear:

- **`useBottomSheetStore`** — split state into `registry` (sheet definitions by id), `openSheets` (which are presented), and `contexts` (per-sheet runtime payload). New `register(id, sheet)` adds without opening; `open(id, ctx?)` looks up the registered sheet and flips its open flag; `close(id?)` / `closeAll()` flip flags but preserve the registry so a sheet can be reopened.
- **`BottomSheetHost`** — now renders a `BottomSheetHostSheet` child per registered sheet. Each child owns its own gorhom modal ref and calls `ref.current?.present()` / `dismiss()` in a `useEffect` keyed on its open state. The previous declarative host (rendering `<BottomSheetModal>` with no ref) never invoked the imperative `present()` API so sheets were never visible.
- **Page renderers + `sheet` action** — `PageStandard`, `PageFeed`, `PageStickyFooter`, and the `BottomSheet` snippet now `register()` sheets on mount (no more open-then-immediately-close hack). The `sheet` action handler resolves the registered sheet by id and calls `open()`.

Adds unit tests for `register` / `open` / `close` / `closeAll` covering registration without opening, no-op on unregistered ids, context stamping, and the close-most-recent fallback.

## Why

`@gorhom/bottom-sheet`'s `BottomSheetModal` is an imperative component — there is no `visible` / `open` prop. You must hold a ref and call `.present()` to show it and `.dismiss()` to hide it. The existing host was written in the declarative style, so no SDUI bottom sheet ever rendered after the user tapped a trigger. This was first surfaced and patched in `amplify-creator-app/node_modules/@one-impression/sdui-runtime/dist` during Brief 264 Phase 4 validation (patches 8–10 in the rebuild log). This PR upstreams that fix into the source package.

## Test plan

- [x] `npm run build -w @one-impression/sdui-runtime` — clean tsup + tsc build
- [x] `npm test -w @one-impression/sdui-runtime` — 33 new + existing tests pass. (3 pre-existing failures unrelated to this PR — they fail on `origin/main` because `@one-impression/sdk-native-sdui` is not installed in CI; not introduced here.)
- [ ] Manual: tap an SDUI button with a `sheet` action in creator-app dev build; verify the sheet presents and dismisses, and that a second tap on a different sheet replaces correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)