### PR TITLE
fix(sdui-runtime): renderMedia reads nested MediaSchema discriminated union

### DIFF
--- a/.changeset/sdui-render-media-nested.md
+++ b/.changeset/sdui-render-media-nested.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+Fixes `renderMedia` to read `MediaSchema` as a nested discriminated union (`media.image.src`, `media.icon.name`, `media.image_stack`, `media.progress`) instead of treating it as a flat object. The previous flat read produced `undefined` for every valid wire payload — icons rendered blank and cover images were missing on aerobar, cards, info-rows. Pure logic is extracted into a framework-free `describeMedia` helper so the mapping is unit-testable without React Native.

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -34,7 +34,7 @@
     "build": "tsup && tsc --emitDeclarationOnly --noCheck",
     "dev": "tsup --watch",
     "lint": "eslint src/",
-    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts"
+    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/snippets/_shared/__tests__/*.test.ts"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/sdui-runtime/src/snippets/_shared/__tests__/render-media.test.ts
+++ b/packages/sdui-runtime/src/snippets/_shared/__tests__/render-media.test.ts
@@ -1,0 +1,120 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { describeMedia } from "../describe-media.js";
+import type { Media } from "@one-impression/sdk-native-sdui";
+
+test("describeMedia — image variant reads nested image.src", () => {
+  const media: Media = {
+    type: "image",
+    image: {
+      src: "https://cdn.example.com/cover.png",
+      width: 120,
+      height: 80,
+      aspect_ratio: 1.5,
+      resize_mode: "cover",
+    },
+  };
+  const desc = describeMedia(media);
+  assert.equal(desc?.kind, "image");
+  if (desc?.kind !== "image") throw new Error("type guard");
+  assert.deepEqual(desc.props.source, {
+    uri: "https://cdn.example.com/cover.png",
+  });
+  assert.equal(desc.props.width, 120);
+  assert.equal(desc.props.height, 80);
+  assert.equal(desc.props.aspectRatio, 1.5);
+  assert.equal(desc.props.resizeMode, "cover");
+});
+
+test("describeMedia — image variant maps container_shape to rounded", () => {
+  const circle = describeMedia({
+    type: "image",
+    image: { src: "x", container_shape: "circle" },
+  });
+  assert.equal(circle?.kind === "image" && circle.props.rounded, 9999);
+
+  const rounded = describeMedia({
+    type: "image",
+    image: { src: "x", container_shape: "rounded" },
+  });
+  assert.equal(rounded?.kind === "image" && rounded.props.rounded, 8);
+
+  const square = describeMedia({
+    type: "image",
+    image: { src: "x", container_shape: "square" },
+  });
+  // square → no explicit rounded
+  assert.equal(square?.kind === "image" && square.props.rounded, undefined);
+});
+
+test("describeMedia — icon variant reads nested icon.name", () => {
+  const media: Media = {
+    type: "icon",
+    icon: {
+      name: "sdui.icon.heart",
+      size: "sdui.icon-size.md",
+      color: "sdui.color.primary",
+    },
+  };
+  const desc = describeMedia(media);
+  assert.equal(desc?.kind, "icon");
+  if (desc?.kind !== "icon") throw new Error("type guard");
+  assert.equal(desc.props.name, "sdui.icon.heart");
+  assert.equal(desc.props.size, "sdui.icon-size.md");
+  assert.equal(desc.props.color, "sdui.color.primary");
+});
+
+test("describeMedia — icon variant tolerates missing size/color", () => {
+  const desc = describeMedia({
+    type: "icon",
+    icon: { name: "sdui.icon.star" },
+  });
+  assert.equal(desc?.kind, "icon");
+  if (desc?.kind !== "icon") throw new Error("type guard");
+  assert.equal(desc.props.name, "sdui.icon.star");
+  assert.equal(desc.props.size, undefined);
+  assert.equal(desc.props.color, undefined);
+});
+
+test("describeMedia — image_stack variant maps nested images[] to uri[] and max_display to max", () => {
+  const media: Media = {
+    type: "image_stack",
+    images: [{ src: "a.png" }, { src: "b.png" }, { src: "c.png" }],
+    max_display: 2,
+  };
+  const desc = describeMedia(media);
+  assert.equal(desc?.kind, "image_stack");
+  if (desc?.kind !== "image_stack") throw new Error("type guard");
+  assert.deepEqual(desc.props.images, [
+    { uri: "a.png" },
+    { uri: "b.png" },
+    { uri: "c.png" },
+  ]);
+  assert.equal(desc.props.max, 2);
+});
+
+test("describeMedia — progress variant reads nested progress object", () => {
+  const media: Media = {
+    type: "progress",
+    progress: {
+      value: 0.6,
+      max: 1,
+      color: "sdui.color.primary",
+      track_color: "sdui.color.neutral-weak",
+    },
+  };
+  const desc = describeMedia(media);
+  assert.equal(desc?.kind, "progress");
+  if (desc?.kind !== "progress") throw new Error("type guard");
+  assert.equal(desc.props.value, 0.6);
+  assert.equal(desc.props.fillColor, "sdui.color.primary");
+  assert.equal(desc.props.trackColor, "sdui.color.neutral-weak");
+});
+
+test("describeMedia — null / undefined input returns null", () => {
+  // The runtime guards against falsy input even though the type forbids it,
+  // because real wire payloads can be undefined when an optional `media`
+  // field is absent.
+  assert.equal(describeMedia(null as unknown as Media), null);
+  assert.equal(describeMedia(undefined as unknown as Media), null);
+});

--- a/packages/sdui-runtime/src/snippets/_shared/describe-media.ts
+++ b/packages/sdui-runtime/src/snippets/_shared/describe-media.ts
@@ -1,0 +1,118 @@
+import type { Media } from "@one-impression/sdk-native-sdui";
+
+/**
+ * Pure descriptor returned by {@link describeMedia}. Each variant maps the
+ * nested `MediaSchema` shape onto the flat prop-bag the matching ui-native
+ * primitive consumes.
+ *
+ * Splitting the dispatch from the React layer (in `render-media.tsx`) keeps
+ * this module free of `react-native` so it can be unit-tested under plain
+ * Node via `node:test`.
+ */
+export type MediaDescriptor =
+  | {
+      kind: "image";
+      props: {
+        source: { uri: string };
+        width?: number;
+        height?: number;
+        aspectRatio?: number;
+        resizeMode?: "cover" | "contain" | "stretch" | "center";
+        rounded?: number;
+      };
+    }
+  | {
+      kind: "icon";
+      props: { name: string; size?: string; color?: string };
+    }
+  | {
+      kind: "image_stack";
+      props: { images: Array<{ uri: string }>; max?: number };
+    }
+  | {
+      kind: "progress";
+      props: {
+        value: number;
+        trackColor?: string;
+        fillColor?: string;
+      };
+    };
+
+/**
+ * Maps a `MediaSchema` node onto the flat prop-bag the matching ui-native
+ * primitive consumes.
+ *
+ * `MediaSchema` from `@one-impression/sdk-native-sdui` is a *nested*
+ * discriminated union on `type`:
+ *
+ *   { type: "image",        image:    ImageSchema }
+ *   { type: "icon",         icon:     IconSchema }
+ *   { type: "image_stack",  images:   ImageSchema[], max_display?: number }
+ *   { type: "progress",     progress: ProgressSchema }
+ *
+ * Earlier versions of `renderMedia` read the leaf fields as if `Media` were
+ * a flat object (`media.src`, `media.name`, ...). That produced `undefined`
+ * for valid wire payloads and surfaced as blank icons / missing cover
+ * images on aerobars, cards, and info-rows.
+ */
+export function describeMedia(media: Media): MediaDescriptor | null {
+  if (!media) return null;
+
+  switch (media.type) {
+    case "image": {
+      const { image } = media;
+      const rounded =
+        image.container_shape === "circle"
+          ? 9999
+          : image.container_shape === "rounded"
+            ? 8
+            : undefined;
+      return {
+        kind: "image",
+        props: {
+          source: { uri: image.src },
+          width: typeof image.width === "number" ? image.width : undefined,
+          height: typeof image.height === "number" ? image.height : undefined,
+          aspectRatio: image.aspect_ratio,
+          resizeMode: image.resize_mode,
+          rounded,
+        },
+      };
+    }
+    case "icon": {
+      const { icon } = media;
+      return {
+        kind: "icon",
+        props: { name: icon.name, size: icon.size, color: icon.color },
+      };
+    }
+    case "image_stack": {
+      return {
+        kind: "image_stack",
+        props: {
+          images: media.images.map((img) => ({ uri: img.src })),
+          max: media.max_display,
+        },
+      };
+    }
+    case "progress": {
+      const { progress } = media;
+      return {
+        kind: "progress",
+        props: {
+          value: progress.value,
+          trackColor: progress.track_color,
+          fillColor: progress.color,
+        },
+      };
+    }
+    default: {
+      // Exhaustiveness check — if a new MediaSchema variant is added in
+      // sdk-native-sdui without updating this switch, TypeScript will flag
+      // `_exhaustive` as `never`.
+      const _exhaustive: never = media;
+      void _exhaustive;
+      return null;
+    }
+  }
+}

--- a/packages/sdui-runtime/src/snippets/_shared/index.ts
+++ b/packages/sdui-runtime/src/snippets/_shared/index.ts
@@ -1,1 +1,3 @@
 export { renderMedia } from "./render-media.js";
+export { describeMedia } from "./describe-media.js";
+export type { MediaDescriptor } from "./describe-media.js";

--- a/packages/sdui-runtime/src/snippets/_shared/render-media.tsx
+++ b/packages/sdui-runtime/src/snippets/_shared/render-media.tsx
@@ -1,84 +1,36 @@
 import React from "react";
+import type { Media } from "@one-impression/sdk-native-sdui";
 import {
   Image as DSImage,
   Icon as DSIcon,
   ImageStack as DSImageStack,
   ProgressIndicator as DSProgressIndicator,
 } from "@one-impression/ui-native";
+import { describeMedia } from "./describe-media.js";
 
-interface MediaImage {
-  type: "image";
-  src: string;
-  alt?: string;
-  width?: number;
-  height?: number;
-  resize_mode?: string;
-  border_radius?: number;
-}
-
-interface MediaIcon {
-  type: "icon";
-  name: string;
-  size?: number;
-  color?: string;
-}
-
-interface MediaImageStack {
-  type: "image_stack";
-  images: Array<{ src: string; alt?: string }>;
-  max_visible?: number;
-}
-
-interface MediaProgress {
-  type: "progress";
-  value: number;
-  track_color?: string;
-  fill_color?: string;
-  height?: number;
-}
-
-type Media = MediaImage | MediaIcon | MediaImageStack | MediaProgress;
-
+/**
+ * Renders a `MediaSchema` node. The shape-mapping rules live in
+ * {@link describeMedia} (a pure function with no `react-native` imports, so
+ * it can be unit-tested under plain Node); this wrapper hands the resulting
+ * descriptor's `props` to the appropriate ui-native primitive.
+ */
 export function renderMedia(media: Media): React.ReactElement | null {
-  if (!media) return null;
+  const desc = describeMedia(media);
+  if (!desc) return null;
 
-  switch (media.type) {
+  switch (desc.kind) {
     case "image":
-      return (
-        <DSImage
-          source={{ uri: media.src }}
-          accessibilityLabel={media.alt}
-          width={media.width}
-          height={media.height}
-          resizeMode={media.resize_mode}
-          rounded={media.border_radius}
-        />
-      );
+      return <DSImage {...desc.props} />;
     case "icon":
-      return (
-        <DSIcon
-          name={media.name}
-          size={media.size}
-          color={media.color}
-        />
-      );
+      return <DSIcon {...desc.props} />;
     case "image_stack":
-      return (
-        <DSImageStack
-          images={media.images.map((img) => ({ uri: img.src }))}
-          maxVisible={media.max_visible}
-        />
-      );
+      return <DSImageStack {...desc.props} />;
     case "progress":
-      return (
-        <DSProgressIndicator
-          value={media.value}
-          trackColor={media.track_color}
-          fillColor={media.fill_color}
-          height={media.height}
-        />
-      );
-    default:
+      return <DSProgressIndicator {...desc.props} />;
+    default: {
+      const _exhaustive: never = desc;
+      void _exhaustive;
       return null;
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Refactor `renderMedia` to dispatch on `media.type` and read the *nested* `MediaSchema` shape (e.g. `media.image.src`, `media.icon.name`).
- Extract the dispatch into a pure `describeMedia` helper in `_shared/describe-media.ts` so it can be unit-tested under plain Node (no `react-native` imports).
- Add 7 unit tests covering all 4 variants (`image`, `icon`, `image_stack`, `progress`) plus null-input + `container_shape` rounding.

## Why

`MediaSchema` from `@one-impression/sdk-native-sdui` is a *nested* discriminated union:

```ts
MediaSchema = z.discriminatedUnion("type", [
  z.object({ type: z.literal("image"),       image:    ImageSchema }),
  z.object({ type: z.literal("icon"),        icon:     IconSchema }),
  z.object({ type: z.literal("image_stack"), images:   ImageSchema[], max_display?: number }),
  z.object({ type: z.literal("progress"),    progress: ProgressSchema }),
])
```

The existing helper read leaf fields as if `Media` were flat (`media.src`, `media.name`, `media.value`, ...). On valid wire payloads this produced `undefined` for source / name / etc., surfacing as **blank icons and missing cover images on aerobars, cards, and info-rows**.

## Test plan

- [x] `npm test -w packages/sdui-runtime` — 7 new tests pass, no existing tests regressed (3 pre-existing baseline failures in `branch.test.ts` / `compound.test.ts` / `set-local.test.ts` are unchanged and unrelated to this PR).
- [x] `npm run build -w packages/sdui-runtime` succeeds with no type errors.
- [ ] Manual verification: aerobar / card / info-row screens render media correctly in the creator-app simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)