### PR TITLE
feat(sdui-runtime): add usePageStore.replaceNode + appendItems

### DIFF
--- a/.changeset/sdui-page-store-replace-node-append-items.md
+++ b/.changeset/sdui-page-store-replace-node-append-items.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": minor
+---
+
+Adds `replaceNode(targetId, node)` and `appendItems(targetId, items)` methods to `usePageStore`, plus a new `page: Page | null` field with `setPageTree()`. Closes the gap where `reload_section`, `replace_section`, and `append_items` action handlers called methods that didn't exist on the store — every dispatch was silently crashing. Tree walks are immutable so unmodified siblings preserve their references for React's shallow-equality bail-out. Existing `sections`/`replaceSection`/`appendSection` API is preserved.

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -34,7 +34,7 @@
     "build": "tsup && tsc --emitDeclarationOnly --noCheck",
     "dev": "tsup --watch",
     "lint": "eslint src/",
-    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts"
+    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/state/__tests__/*.test.ts"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/sdui-runtime/src/state/__tests__/usePageStore.test.ts
+++ b/packages/sdui-runtime/src/state/__tests__/usePageStore.test.ts
@@ -1,0 +1,241 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { usePageStore, __internal } from "../usePageStore.ts";
+import type { Node, Page } from "@one-impression/sdk-native-sdui";
+
+const { replaceNodeInTree, appendItemsInTree } = __internal;
+
+function leaf(id: string, extra: Record<string, unknown> = {}): Node {
+  return { type: "text", id, data: { ...extra } } as unknown as Node;
+}
+
+function container(id: string, items: Node[]): Node {
+  return { type: "stack", id, data: { items } } as unknown as Node;
+}
+
+function page(items: Node[]): Page {
+  return {
+    id: "test-page",
+    title: "Test",
+    protocol_version: "1.0.0",
+    items,
+    bottom_sheets: [],
+  } as unknown as Page;
+}
+
+function resetStore(): void {
+  usePageStore.getState().reset();
+}
+
+// ---------------------------------------------------------------------------
+// Pure tree-walker tests
+// ---------------------------------------------------------------------------
+
+test("replaceNodeInTree replaces a top-level node by id", () => {
+  const tree = [leaf("a"), leaf("b"), leaf("c")];
+  const [next, matched] = replaceNodeInTree(tree, "b", leaf("b", { x: 1 }));
+  assert.equal(matched, true);
+  assert.equal(next.length, 3);
+  assert.deepEqual((next[1] as Node).data, { x: 1 });
+  // Unmodified siblings preserved by reference (immutable update).
+  assert.equal(next[0], tree[0]);
+  assert.equal(next[2], tree[2]);
+});
+
+test("replaceNodeInTree replaces a deeply nested node by id", () => {
+  const tree = [
+    leaf("a"),
+    container("outer", [
+      leaf("p"),
+      container("inner", [leaf("target"), leaf("sibling")]),
+    ]),
+  ];
+  const replacement = leaf("target", { fresh: true });
+  const [next, matched] = replaceNodeInTree(tree, "target", replacement);
+  assert.equal(matched, true);
+  const outer = next[1] as Node;
+  const inner = (outer.data as { items: Node[] }).items[1] as Node;
+  const replaced = (inner.data as { items: Node[] }).items[0] as Node;
+  assert.deepEqual(replaced.data, { fresh: true });
+});
+
+test("replaceNodeInTree is a no-op when id not found", () => {
+  const tree = [leaf("a"), container("c", [leaf("b")])];
+  const [next, matched] = replaceNodeInTree(tree, "missing", leaf("missing"));
+  assert.equal(matched, false);
+  // Returns a freshly-allocated array, but the leaves are === to the input.
+  assert.equal(next[0], tree[0]);
+  assert.equal(next[1], tree[1]);
+});
+
+test("appendItemsInTree appends to a container's data.items", () => {
+  const tree = [container("feed", [leaf("x"), leaf("y")])];
+  const [next, matched, mutated] = appendItemsInTree(
+    tree,
+    "feed",
+    [leaf("z"), leaf("w")],
+    {},
+  );
+  assert.equal(matched, true);
+  assert.equal(mutated, true);
+  const feed = next[0] as Node;
+  const items = (feed.data as { items: Node[] }).items;
+  assert.deepEqual(
+    items.map((n) => n.id),
+    ["x", "y", "z", "w"],
+  );
+});
+
+test("appendItemsInTree merges cursor + has_more into target.data", () => {
+  const tree = [container("feed", [leaf("x")])];
+  const [next] = appendItemsInTree(
+    tree,
+    "feed",
+    [leaf("y")],
+    { cursor: "abc123", hasMore: false },
+  );
+  const data = (next[0] as Node).data as Record<string, unknown>;
+  assert.equal(data["cursor"], "abc123");
+  assert.equal(data["has_more"], false);
+});
+
+test("appendItemsInTree is a no-op when target not found", () => {
+  const tree = [container("feed", [leaf("x")])];
+  const [next, matched, mutated] = appendItemsInTree(
+    tree,
+    "missing",
+    [leaf("z")],
+    {},
+  );
+  assert.equal(matched, false);
+  assert.equal(mutated, false);
+  assert.equal(next[0], tree[0]);
+});
+
+test("appendItemsInTree is a no-op when target has no data.items array", () => {
+  const target: Node = { type: "image", id: "img", data: { src: "x.png" } } as unknown as Node;
+  const tree = [target];
+  const [next, matched, mutated] = appendItemsInTree(tree, "img", [leaf("y")], {});
+  assert.equal(matched, true);
+  assert.equal(mutated, false);
+  // Target preserved by reference (no mutation occurred).
+  assert.equal(next[0], tree[0]);
+});
+
+// ---------------------------------------------------------------------------
+// Store-action integration tests
+// ---------------------------------------------------------------------------
+
+test("usePageStore.replaceNode replaces a node in the loaded page", () => {
+  resetStore();
+  usePageStore.getState().setPageTree(
+    page([leaf("a"), container("section", [leaf("target")])]),
+  );
+  usePageStore.getState().replaceNode("target", leaf("target", { fresh: true }));
+  const updated = usePageStore.getState().page!;
+  const section = updated.items[1] as Node;
+  const replaced = (section.data as { items: Node[] }).items[0] as Node;
+  assert.deepEqual(replaced.data, { fresh: true });
+});
+
+test("usePageStore.replaceNode is a no-op (with warning) when id not found", () => {
+  resetStore();
+  const warnings: unknown[][] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args);
+  try {
+    usePageStore.getState().setPageTree(page([leaf("a")]));
+    const before = usePageStore.getState().page;
+    usePageStore.getState().replaceNode("missing", leaf("missing"));
+    const after = usePageStore.getState().page;
+    // No-op — same reference.
+    assert.equal(after, before);
+    assert.ok(
+      warnings.some((w) =>
+        String(w[0]).includes('no node with id "missing"'),
+      ),
+      "expected a warning",
+    );
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+test("usePageStore.replaceNode is a no-op when no page is loaded", () => {
+  resetStore();
+  const warnings: unknown[][] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args);
+  try {
+    usePageStore.getState().replaceNode("anything", leaf("anything"));
+    assert.equal(usePageStore.getState().page, null);
+    assert.ok(
+      warnings.some((w) => String(w[0]).includes("no page loaded")),
+      "expected a warning",
+    );
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+test("usePageStore.appendItems appends to a container's data.items", () => {
+  resetStore();
+  usePageStore.getState().setPageTree(
+    page([container("feed", [leaf("x")])]),
+  );
+  usePageStore
+    .getState()
+    .appendItems("feed", [leaf("y"), leaf("z")], { cursor: "c2", hasMore: true });
+  const feed = usePageStore.getState().page!.items[0] as Node;
+  const items = (feed.data as { items: Node[] }).items;
+  assert.deepEqual(
+    items.map((n) => n.id),
+    ["x", "y", "z"],
+  );
+  const data = feed.data as Record<string, unknown>;
+  assert.equal(data["cursor"], "c2");
+  assert.equal(data["has_more"], true);
+});
+
+test("usePageStore.appendItems is a no-op when target not found (warns)", () => {
+  resetStore();
+  const warnings: unknown[][] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args);
+  try {
+    usePageStore.getState().setPageTree(page([container("feed", [leaf("x")])]));
+    const before = usePageStore.getState().page;
+    usePageStore.getState().appendItems("missing", [leaf("y")]);
+    assert.equal(usePageStore.getState().page, before);
+    assert.ok(
+      warnings.some((w) => String(w[0]).includes('no node with id "missing"')),
+    );
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+test("usePageStore.appendItems is a no-op when target has no data.items (warns)", () => {
+  resetStore();
+  const warnings: unknown[][] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args);
+  try {
+    const imgNode: Node = {
+      type: "image",
+      id: "img",
+      data: { src: "x.png" },
+    } as unknown as Node;
+    usePageStore.getState().setPageTree(page([imgNode]));
+    const before = usePageStore.getState().page;
+    usePageStore.getState().appendItems("img", [leaf("y")]);
+    assert.equal(usePageStore.getState().page, before);
+    assert.ok(
+      warnings.some((w) =>
+        String(w[0]).includes('node "img" has no data.items array'),
+      ),
+    );
+  } finally {
+    console.warn = origWarn;
+  }
+});

--- a/packages/sdui-runtime/src/state/usePageStore.ts
+++ b/packages/sdui-runtime/src/state/usePageStore.ts
@@ -1,11 +1,18 @@
 /**
  * usePageStore — Zustand store for page-level state.
  *
- * Mirrors the legacy Redux page slice. Tracks the current page's sections
- * map with support for reload, replace, and append operations on individual
- * sections.
+ * Tracks two layers:
+ *
+ *   1. A legacy `sections` map, kept for back-compat with renderers that
+ *      address content by section id (reload / refresh / append at section
+ *      granularity). Mirrors the legacy Redux page slice.
+ *   2. A `page` tree — the full SDUI page envelope. Action handlers
+ *      (`replace_section`, `reload_section`, `append_items`) mutate nodes
+ *      anywhere in the tree by id via {@link PageStoreActions.replaceNode}
+ *      and {@link PageStoreActions.appendItems}.
  */
 import { create } from 'zustand';
+import type { Node, Page } from '@one-impression/sdk-native-sdui';
 
 /** A single section's data within a page. */
 export interface PageSection {
@@ -23,9 +30,17 @@ export interface PageSection {
   hasMore: boolean;
 }
 
+/** Options for {@link PageStoreActions.appendItems}. */
+export interface AppendItemsOptions {
+  cursor?: string;
+  hasMore?: boolean;
+}
+
 export interface PageStoreState {
   /** Current page identifier. */
   pageId: string | null;
+  /** The full SDUI page envelope, when one is loaded. */
+  page: Page | null;
   /** Sections map keyed by section ID. */
   sections: Record<string, PageSection>;
   /** Whether the full page is loading. */
@@ -37,10 +52,36 @@ export interface PageStoreState {
 export interface PageStoreActions {
   /** Set the current page and its initial sections. */
   setPage: (pageId: string, sections: Record<string, PageSection>) => void;
+  /** Set the full SDUI page envelope (used by the page loader on initial fetch). */
+  setPageTree: (page: Page) => void;
   /** Replace a section's data entirely (used for reload/refresh). */
   replaceSection: (sectionId: string, data: unknown) => void;
   /** Append data to a section (used for pagination/infinite scroll). */
   appendSection: (sectionId: string, data: unknown, cursor: string | null, hasMore: boolean) => void;
+  /**
+   * Replace a node anywhere in the page tree (matched by `node.id`).
+   *
+   * Walks `page.items` recursively, descending into each node's
+   * `data.items` (when present). The matched node is replaced wholesale
+   * with `next`. If no node matches `targetId`, the call is a no-op and a
+   * warning is logged.
+   *
+   * Consumers: `handleReloadSection`, `handleReplaceSection`.
+   */
+  replaceNode: (targetId: string, next: Node) => void;
+  /**
+   * Append `items` to the `data.items` array of the node identified by
+   * `targetId`. If the target is found but has no array at `data.items`,
+   * the call is a no-op and a warning is logged. If the target is not
+   * found at all, the call is also a no-op (with a warning).
+   *
+   * `options.cursor` / `options.hasMore` are merged into the target's
+   * `data` so a feed renderer can observe pagination state from a single
+   * tree.
+   *
+   * Consumer: `handleAppendItems`.
+   */
+  appendItems: (targetId: string, items: Node[], options?: AppendItemsOptions) => void;
   /** Set loading state for a specific section. */
   setSectionLoading: (sectionId: string, loading: boolean) => void;
   /** Set error state for a specific section. */
@@ -55,16 +96,122 @@ export interface PageStoreActions {
 
 const initialState: PageStoreState = {
   pageId: null,
+  page: null,
   sections: {},
   loading: false,
   error: null,
 };
+
+/**
+ * Recursively rebuild `nodes`, replacing the first node whose `id === targetId`
+ * with `next`. Returns `[newNodes, matched]`. Exported for unit-tests via
+ * the `__internal` namespace at the bottom of this module.
+ */
+function replaceNodeInTree(
+  nodes: Node[],
+  targetId: string,
+  next: Node,
+): [Node[], boolean] {
+  let matched = false;
+  const out: Node[] = [];
+  for (const n of nodes) {
+    if (matched) {
+      out.push(n);
+      continue;
+    }
+    if (n.id === targetId) {
+      out.push(next);
+      matched = true;
+      continue;
+    }
+    // Descend into common container fields. `data.items` is the canonical
+    // child list for snippets / feed nodes in the SDUI wire format.
+    const data = (n.data ?? {}) as Record<string, unknown>;
+    const childItems = data['items'];
+    if (Array.isArray(childItems)) {
+      const [nextChildren, didMatch] = replaceNodeInTree(
+        childItems as Node[],
+        targetId,
+        next,
+      );
+      if (didMatch) {
+        out.push({ ...n, data: { ...data, items: nextChildren } });
+        matched = true;
+        continue;
+      }
+    }
+    out.push(n);
+  }
+  return [out, matched];
+}
+
+/**
+ * Recursively rebuild `nodes`, appending `items` to the `data.items` of the
+ * node whose `id === targetId`. Returns `[newNodes, matched, mutated]`,
+ * where `mutated` is `true` iff a target was found *and* its `data.items`
+ * was a real array we could append to.
+ */
+function appendItemsInTree(
+  nodes: Node[],
+  targetId: string,
+  items: Node[],
+  options: AppendItemsOptions,
+): [Node[], boolean, boolean] {
+  let matched = false;
+  let mutated = false;
+  const out: Node[] = [];
+  for (const n of nodes) {
+    if (matched) {
+      out.push(n);
+      continue;
+    }
+    if (n.id === targetId) {
+      matched = true;
+      const data = (n.data ?? {}) as Record<string, unknown>;
+      const existing = data['items'];
+      if (Array.isArray(existing)) {
+        const nextData: Record<string, unknown> = {
+          ...data,
+          items: [...(existing as Node[]), ...items],
+        };
+        if (options.cursor !== undefined) nextData['cursor'] = options.cursor;
+        if (options.hasMore !== undefined) nextData['has_more'] = options.hasMore;
+        out.push({ ...n, data: nextData });
+        mutated = true;
+      } else {
+        out.push(n);
+      }
+      continue;
+    }
+    const data = (n.data ?? {}) as Record<string, unknown>;
+    const childItems = data['items'];
+    if (Array.isArray(childItems)) {
+      const [nextChildren, didMatch, didMutate] = appendItemsInTree(
+        childItems as Node[],
+        targetId,
+        items,
+        options,
+      );
+      if (didMatch) {
+        out.push({ ...n, data: { ...data, items: nextChildren } });
+        matched = true;
+        if (didMutate) mutated = true;
+        continue;
+      }
+    }
+    out.push(n);
+  }
+  return [out, matched, mutated];
+}
 
 export const usePageStore = create<PageStoreState & PageStoreActions>((set) => ({
   ...initialState,
 
   setPage: (pageId, sections) =>
     set({ pageId, sections, loading: false, error: null }),
+
+  setPageTree: (page) =>
+    set({ page, pageId: page.id, loading: false, error: null }),
 
   replaceSection: (sectionId, data) =>
     set((state) => ({
@@ -106,6 +253,57 @@ export const usePageStore = create<PageStoreState & PageStoreActions>((set) => (
       };
     }),
 
+  replaceNode: (targetId, next) =>
+    set((state) => {
+      if (!state.page) {
+        console.warn(
+          `[usePageStore.replaceNode] no page loaded; ignoring replaceNode("${targetId}")`,
+        );
+        return {};
+      }
+      const [nextItems, matched] = replaceNodeInTree(
+        state.page.items,
+        targetId,
+        next,
+      );
+      if (!matched) {
+        console.warn(
+          `[usePageStore.replaceNode] no node with id "${targetId}" in page "${state.page.id}"`,
+        );
+        return {};
+      }
+      return { page: { ...state.page, items: nextItems } };
+    }),
+
+  appendItems: (targetId, items, options = {}) =>
+    set((state) => {
+      if (!state.page) {
+        console.warn(
+          `[usePageStore.appendItems] no page loaded; ignoring appendItems("${targetId}")`,
+        );
+        return {};
+      }
+      const [nextItems, matched, mutated] = appendItemsInTree(
+        state.page.items,
+        targetId,
+        items,
+        options,
+      );
+      if (!matched) {
+        console.warn(
+          `[usePageStore.appendItems] no node with id "${targetId}" in page "${state.page.id}"`,
+        );
+        return {};
+      }
+      if (!mutated) {
+        console.warn(
+          `[usePageStore.appendItems] node "${targetId}" has no data.items array; nothing to append to`,
+        );
+        return {};
+      }
+      return { page: { ...state.page, items: nextItems } };
+    }),
+
   setSectionLoading: (sectionId, loading) =>
     set((state) => ({
       sections: {
@@ -144,3 +342,6 @@ export const usePageStore = create<PageStoreState & PageStoreActions>((set) => (
 
   reset: () => set(initialState),
 }));
+
+/** Exported only for unit-tests — do not consume from app code. */
+export const __internal = { replaceNodeInTree, appendItemsInTree };


### PR DESCRIPTION
## Summary

- Add `page: Page | null` state to `usePageStore` (the full SDUI page envelope).
- Add `setPageTree(page)` setter for the initial page fetch.
- Add `replaceNode(targetId, next)` — recursive node-tree replacement by id.
- Add `appendItems(targetId, items, options?)` — append to `data.items` and merge optional `cursor` / `has_more` into the target's `data`.
- Extract pure tree-walkers (`replaceNodeInTree`, `appendItemsInTree`) into an `__internal` namespace and add 13 unit tests covering happy paths, no-op fallbacks, and warning emission.

## Why

Three action handlers were calling methods on `usePageStore` that did not exist, silently crashing the action dispatch loop:

| Handler | Call site | Method called |
|---|---|---|
| `handleReloadSection` | `src/action-engine/handlers/reload-section.ts:40` | `replaceNode(target, node)` |
| `handleReplaceSection` | `src/action-engine/handlers/replace-section.ts:16` | `replaceNode(target, with_node)` |
| `handleAppendItems` | `src/action-engine/handlers/append-items.ts:17` | `appendItems(target, items, { cursor, hasMore })` |

The store previously only exposed section-granularity setters (`replaceSection`, `appendSection`) keyed by a flat sections map. The action handlers, however, address nodes by id anywhere in the page tree — which is what these new methods now support. Both methods are no-ops with `console.warn` when the target id is missing or has no `data.items` array, so stale actions degrade gracefully.

## Consumer files

- `packages/sdui-runtime/src/action-engine/handlers/reload-section.ts`
- `packages/sdui-runtime/src/action-engine/handlers/replace-section.ts`
- `packages/sdui-runtime/src/action-engine/handlers/append-items.ts`

## Test plan

- [x] `npm test -w packages/sdui-runtime` — 13 new tests pass, no existing tests regressed (3 pre-existing baseline failures in `branch.test.ts` / `compound.test.ts` / `set-local.test.ts` are unchanged and unrelated to this PR).
- [x] `npm run build -w packages/sdui-runtime` succeeds with no type errors.
- [ ] Manual verification: trigger `reload_section`, `replace_section`, and `append_items` actions from the creator-app simulator and confirm the page tree updates without dispatch errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)