### PR TITLE
feat(sdui-runtime): Form + Input wire through FormContext for submit-time value merge

### DIFF
--- a/.changeset/sdui-form-input-form-context.md
+++ b/.changeset/sdui-form-input-form-context.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": minor
+---
+
+Wires `Form` and `Input` together through a `FormContext` so submit-time `bff_call` actions see the latest input values. `Input` reads `data.field_name` and propagates each keystroke to `FormContext.setValue(field_name, value)`; `Form` wraps its submit button in `FormSubmitWrapper`, which intercepts the `bff_call` action and merges the ref-backed values snapshot into `payload.request_body` at click time. The merge logic + state factory are extracted into a framework-free `form-values.ts` so the contract is unit-testable without React Native. Mount-time seeding of FormContext captures refs to keep the empty-deps useEffect lint-clean. Without this, OTP entry and every form submit fired with empty bodies.

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -34,7 +34,7 @@
     "build": "tsup && tsc --emitDeclarationOnly --noCheck",
     "dev": "tsup --watch",
     "lint": "eslint src/",
-    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts"
+    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/snippets/Form/__tests__/*.test.ts"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/sdui-runtime/src/snippets/Form/Form.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/Form/Form.renderer.tsx
@@ -1,16 +1,16 @@
 import React, { createContext, useContext, useRef, useCallback } from "react";
+import { Pressable } from "react-native";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { FormSchema } from "@one-impression/sdk-native-sdui";
 import { Box, Stack } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";
+import { mergeFormValuesIntoAction } from "./form-values.js";
+import type { FormState } from "./form-values.js";
 
-interface FormState {
-  values: Record<string, unknown>;
-  setValue: (key: string, value: unknown) => void;
-  getValues: () => Record<string, unknown>;
-}
+export { mergeFormValuesIntoAction } from "./form-values.js";
+export type { FormState } from "./form-values.js";
 
 export const FormContext = createContext<FormState>({
   values: {},
@@ -49,8 +49,11 @@ function FormInner({
   fields: Node[];
   submitButton?: Node;
 }): React.ReactElement {
+  // Ref-backed values store — avoids re-rendering the whole Form
+  // (and every controlled Input) on every keystroke. Inputs read
+  // their local UI state from their own useState; FormContext just
+  // collects the latest snapshot for submit-time merge.
   const valuesRef = useRef<Record<string, unknown>>({});
-  const actionEngine = useActionEngine();
 
   const setValue = useCallback((key: string, value: unknown) => {
     valuesRef.current[key] = value;
@@ -74,10 +77,55 @@ function FormInner({
         </Stack>
         {submitButton && (
           <Box paddingTop={16}>
-            <Interpreter node={submitButton} />
+            <FormSubmitWrapper
+              submitButton={submitButton}
+              getValues={getValues}
+            />
           </Box>
         )}
       </Box>
     </FormContext.Provider>
   );
 }
+
+/**
+ * FormSubmitWrapper — intercepts the submit button's `on_click` so that
+ * at click time we merge `getValues()` into a `bff_call` action's
+ * `payload.request_body`. The button's own dispatch chain is removed
+ * from the rendered node (so the inner Clickable becomes a no-op) and
+ * we dispatch the transformed action from this outer Pressable.
+ *
+ * For non-bff_call actions, the original action is dispatched as-is.
+ * When the button has no `on_click` (rare — typically misconfigured),
+ * rendering falls through unchanged.
+ */
+export function FormSubmitWrapper({
+  submitButton,
+  getValues,
+}: {
+  submitButton: Node;
+  getValues: () => Record<string, unknown>;
+}): React.ReactElement {
+  const actionEngine = useActionEngine();
+  const onClick = submitButton.on_click;
+
+  if (!onClick) {
+    return <Interpreter node={submitButton} />;
+  }
+
+  // Clone with on_click stripped — the inner SduiNode/Clickable should
+  // not also fire the action; we own dispatch here.
+  const buttonWithoutClick: Node = { ...submitButton, on_click: undefined };
+
+  const handlePress = (): void => {
+    const merged = mergeFormValuesIntoAction(onClick, getValues());
+    actionEngine.dispatch(merged);
+  };
+
+  return (
+    <Pressable onPress={handlePress} accessibilityRole="button">
+      <Interpreter node={buttonWithoutClick} />
+    </Pressable>
+  );
+}
+

--- a/packages/sdui-runtime/src/snippets/Form/__tests__/form-values.test.ts
+++ b/packages/sdui-runtime/src/snippets/Form/__tests__/form-values.test.ts
@@ -1,0 +1,130 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mergeFormValuesIntoAction,
+  createFormState,
+} from "../form-values.ts";
+import type { Action } from "@one-impression/sdk-native-sdui";
+
+// ---- FormState propagation (the contract InputInner relies on) -------------
+
+test("Input inside Form — setValue writes into FormState, getValues snapshots latest", () => {
+  // This is the contract InputInner relies on: on every keystroke it
+  // calls formCtx.setValue(fieldName, value). FormSubmitWrapper later
+  // reads formCtx.getValues() at click time.
+  const form = createFormState();
+  form.setValue("phone", "98");
+  form.setValue("phone", "987");
+  form.setValue("phone", "9876543210");
+  form.setValue("country_code", "+91");
+
+  assert.deepEqual(form.getValues(), {
+    phone: "9876543210",
+    country_code: "+91",
+  });
+});
+
+test("Input outside Form (no fieldName) — InputInner skips setValue, FormState stays empty", () => {
+  // Simulates the InputInner behaviour: when fieldName is undefined,
+  // the input never calls formCtx.setValue, so the default FormContext
+  // (or any provided one) is never written.
+  const form = createFormState();
+  const fieldName: string | undefined = undefined;
+  const userTyped = ["a", "ab", "abc"];
+
+  for (const next of userTyped) {
+    if (fieldName) {
+      form.setValue(fieldName, next);
+    }
+    // Otherwise: stand-alone controlled input — value lives only in
+    // local useState. Nothing leaks into FormState.
+  }
+
+  assert.deepEqual(form.getValues(), {});
+});
+
+// ---- mergeFormValuesIntoAction (FormSubmitWrapper click-time contract) -----
+
+const bffSubmit = (overrides: Record<string, unknown> = {}): Action =>
+  ({
+    type: "bff_call",
+    payload: {
+      method: "POST",
+      endpoint: "creator.auth.otpVerify",
+      ...overrides,
+    },
+  }) as Action;
+
+test("Form submit — merges current values into bff_call request_body", () => {
+  const form = createFormState();
+  form.setValue("phone", "9876543210");
+  form.setValue("otp", "123456");
+
+  const merged = mergeFormValuesIntoAction(bffSubmit(), form.getValues());
+
+  assert.equal(merged.type, "bff_call");
+  assert.deepEqual(merged.payload?.request_body, {
+    phone: "9876543210",
+    otp: "123456",
+  });
+});
+
+test("Form submit — preserves existing request_body keys, form values overlay", () => {
+  // The builder may seed `request_body` with non-user fields like
+  // device_id or app_version. Form values should overlay, not replace.
+  const merged = mergeFormValuesIntoAction(
+    bffSubmit({
+      request_body: { device_id: "abc", phone: "old" },
+    }),
+    { phone: "new", otp: "999" },
+  );
+
+  assert.deepEqual(merged.payload?.request_body, {
+    device_id: "abc",
+    phone: "new",
+    otp: "999",
+  });
+});
+
+test("Form submit — empty values object leaves request_body untouched", () => {
+  const merged = mergeFormValuesIntoAction(
+    bffSubmit({ request_body: { device_id: "abc" } }),
+    {},
+  );
+
+  assert.deepEqual(merged.payload?.request_body, { device_id: "abc" });
+});
+
+test("Form submit — non-bff_call action passes through unchanged", () => {
+  const navigate: Action = {
+    type: "navigate",
+    payload: { to: "/home" },
+  } as Action;
+
+  const merged = mergeFormValuesIntoAction(navigate, { phone: "999" });
+
+  assert.equal(merged, navigate, "non-bff_call returns the same reference");
+});
+
+test("Form submit — bff_call with no payload at all is tolerated", () => {
+  const action = { type: "bff_call" } as Action;
+  const merged = mergeFormValuesIntoAction(action, { phone: "1" });
+
+  assert.deepEqual(merged.payload?.request_body, { phone: "1" });
+});
+
+test("Form submit — latest setValue wins (snapshot is read at click time)", () => {
+  // Pin: getValues() returns the LATEST snapshot at the moment of
+  // dispatch, not a stale snapshot captured at render time.
+  const form = createFormState();
+  form.setValue("phone", "first");
+  // ... time passes, user keeps typing ...
+  form.setValue("phone", "final");
+
+  const merged = mergeFormValuesIntoAction(bffSubmit(), form.getValues());
+
+  assert.equal(
+    (merged.payload?.request_body as Record<string, unknown>).phone,
+    "final",
+  );
+});

--- a/packages/sdui-runtime/src/snippets/Form/form-values.ts
+++ b/packages/sdui-runtime/src/snippets/Form/form-values.ts
@@ -1,0 +1,56 @@
+import type { Action } from "@one-impression/sdk-native-sdui";
+
+/**
+ * Returns a new Action with form values merged into the request_body
+ * for `bff_call` actions; passes the action through unchanged
+ * otherwise. Existing keys in `payload.request_body` are preserved,
+ * with form values overlaying them (the latest user-entered value
+ * wins).
+ *
+ * Pure function — extracted from Form.renderer.tsx so it can be
+ * unit-tested without a React Native runtime.
+ */
+export function mergeFormValuesIntoAction(
+  action: Action,
+  values: Record<string, unknown>,
+): Action {
+  if (action.type !== "bff_call") {
+    return action;
+  }
+  const payload = (action.payload ?? {}) as Record<string, unknown>;
+  const existingBody = (payload.request_body ?? {}) as Record<string, unknown>;
+  return {
+    ...action,
+    payload: {
+      ...payload,
+      request_body: { ...existingBody, ...values },
+    },
+  } as Action;
+}
+
+/**
+ * Minimal FormState contract — mirrored by FormContext at runtime.
+ * Exposed here for unit-testing FormContext-like behaviour without
+ * mounting the renderer.
+ */
+export interface FormState {
+  values: Record<string, unknown>;
+  setValue: (key: string, value: unknown) => void;
+  getValues: () => Record<string, unknown>;
+}
+
+/**
+ * Ref-backed FormState factory — the same logic FormInner uses, but
+ * decoupled from React hooks so we can unit-test the propagation
+ * contract (setValue writes, getValues reads back the latest snapshot).
+ */
+export function createFormState(): FormState {
+  const values: Record<string, unknown> = {};
+  return {
+    values,
+    setValue: (key, value) => {
+      values[key] = value;
+    },
+    getValues: () => values,
+  };
+}

--- a/packages/sdui-runtime/src/snippets/Form/index.ts
+++ b/packages/sdui-runtime/src/snippets/Form/index.ts
@@ -1,1 +1,8 @@
-export { FormRenderer, FormContext, useFormContext } from "./Form.renderer.js";
+export {
+  FormRenderer,
+  FormContext,
+  useFormContext,
+  FormSubmitWrapper,
+} from "./Form.renderer.js";
+export { mergeFormValuesIntoAction, createFormState } from "./form-values.js";
+export type { FormState } from "./form-values.js";

--- a/packages/sdui-runtime/src/ui_components/Input/Input.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Input/Input.renderer.tsx
@@ -1,10 +1,21 @@
-import React from "react";
+import React, { useState, useCallback } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { InputComponentSchema } from "@one-impression/sdk-native-sdui";
 import { Input as DSInput } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
+import { useFormContext } from "../../snippets/Form/Form.renderer.js";
 
 export function InputRenderer(node: Node): React.ReactElement {
+  // `field_name` is a runtime extension: not part of the strict zod
+  // schema (which strips unknown keys), so we read it off the raw node
+  // data before SduiNode validates. When the Input is inside a Form
+  // and `field_name` is set, its value is propagated to FormContext on
+  // every keystroke; otherwise it behaves as a stand-alone controlled
+  // input.
+  const fieldName = (node.data as { field_name?: unknown } | undefined)
+    ?.field_name;
+  const fieldNameStr = typeof fieldName === "string" ? fieldName : undefined;
+
   return (
     <SduiNode
       data={node.data}
@@ -17,16 +28,62 @@ export function InputRenderer(node: Node): React.ReactElement {
       view_events={node.view_events}
       load_events={node.load_events}
     >
-      {(v) => (
-        <DSInput
-          placeholder={v.placeholder}
-          value={v.value}
-          label={v.label ? v.label.data.text : undefined}
-          disabled={v.disabled}
-          maxLength={v.max_length}
-          multiline={v.multiline}
-        />
-      )}
+      {(v) => <InputInner fieldName={fieldNameStr} validated={v} />}
     </SduiNode>
+  );
+}
+
+interface InputInnerProps {
+  fieldName?: string;
+  validated: {
+    placeholder?: string;
+    value?: string;
+    label?: { data: { text: string } };
+    disabled?: boolean;
+    max_length?: number;
+    multiline?: boolean;
+  };
+}
+
+function InputInner({
+  fieldName,
+  validated: v,
+}: InputInnerProps): React.ReactElement {
+  // Local UI state — keeps the controlled component cursor-stable
+  // without re-rendering the whole Form on every keystroke.
+  const [localValue, setLocalValue] = useState<string>(v.value ?? "");
+  const formCtx = useFormContext();
+
+  // Seed FormContext with the initial value once on mount, so that
+  // submit-time merge sees the server-provided default if the user
+  // never edits the field.
+  React.useEffect(() => {
+    if (fieldName && v.value !== undefined) {
+      formCtx.setValue(fieldName, v.value);
+    }
+    // Run once on mount; we do not want to re-seed on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleChangeText = useCallback(
+    (next: string) => {
+      setLocalValue(next);
+      if (fieldName) {
+        formCtx.setValue(fieldName, next);
+      }
+    },
+    [fieldName, formCtx],
+  );
+
+  return (
+    <DSInput
+      placeholder={v.placeholder}
+      value={localValue}
+      onChangeText={handleChangeText}
+      label={v.label ? v.label.data.text : undefined}
+      disabled={v.disabled}
+      maxLength={v.max_length}
+      multiline={v.multiline}
+    />
   );
 }

--- a/packages/sdui-runtime/src/ui_components/Input/Input.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Input/Input.renderer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useRef } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { InputComponentSchema } from "@one-impression/sdk-native-sdui";
 import { Input as DSInput } from "@one-impression/ui-native";
@@ -54,15 +54,23 @@ function InputInner({
   const [localValue, setLocalValue] = useState<string>(v.value ?? "");
   const formCtx = useFormContext();
 
-  // Seed FormContext with the initial value once on mount, so that
-  // submit-time merge sees the server-provided default if the user
+  // Capture mount-time values in refs so the seed effect can read them
+  // without depending on potentially-changing fieldName / formCtx
+  // identities. Refs are stable across renders → empty deps are
+  // self-evident and require no eslint suppression.
+  const fieldNameRef = useRef(fieldName);
+  const formCtxRef = useRef(formCtx);
+  const initialValueRef = useRef(v.value);
+
+  // Seed FormContext with the server-provided initial value once on
+  // mount, so the submit-time merge sees the default even if the user
   // never edits the field.
   React.useEffect(() => {
-    if (fieldName && v.value !== undefined) {
-      formCtx.setValue(fieldName, v.value);
+    const fn = fieldNameRef.current;
+    const init = initialValueRef.current;
+    if (fn && init !== undefined) {
+      formCtxRef.current.setValue(fn, init);
     }
-    // Run once on mount; we do not want to re-seed on every render.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleChangeText = useCallback(


### PR DESCRIPTION
## Summary

Two connected changes in `packages/sdui-runtime/src`:

1. **Input** (`ui_components/Input/Input.renderer.tsx`)
   - Reads optional `data.field_name` off the raw node (runtime extension field; the strict zod schema strips unknown keys, so this is read pre-validation).
   - `InputInner` holds local `useState` for the controlled value (cursor-stable, avoids whole-Form re-renders) and forwards each keystroke to `formCtx.setValue(fieldName, value)`. When `fieldName` is undefined, the Input behaves as a stand-alone controlled input — nothing leaks into FormContext.
   - Seeds FormContext with the initial `data.value` on mount so server-provided defaults flow through when the user never edits the field.

2. **Form** (`snippets/Form/Form.renderer.tsx`)
   - Existing `FormContext` (ref-backed `setValue` + `getValues`) is now consumed by `InputInner`.
   - New `FormSubmitWrapper` around `submit_button`: strips the button's own `on_click`, owns its own `Pressable`, and **at click time** merges `getValues()` into the `bff_call` action's `payload.request_body` before dispatch. Non-`bff_call` submit actions pass through unchanged.

Also extracted `mergeFormValuesIntoAction` + `createFormState` into `form-values.ts` so the logic is unit-testable without booting React Native.

## Why

Without this wiring, every form in the app — OTP entry, KYC submission, profile updates — fires its submit `bff_call` with a stale or empty `request_body`. The Input renderer was emitting keystrokes nowhere; the Form renderer had a `FormContext` scaffold but nothing wrote to it and nothing read from it at submit time.

This patch closes that loop without changing the SDUI schema: `field_name` is read as a runtime extension on the Input node, and submit-time merge happens on the renderer side via FormSubmitWrapper.

## Test plan

- [x] `npm run -w @one-impression/sdui-runtime build` — clean
- [x] 8 new unit tests in `snippets/Form/__tests__/form-values.test.ts`:
  - Input inside Form propagates value to FormContext (setValue → getValues snapshot)
  - Input outside Form (no fieldName) leaves FormContext empty
  - Form submit merges current values into `bff_call` `request_body`
  - Existing `request_body` keys preserved; form values overlay
  - Empty values object leaves `request_body` untouched
  - Non-`bff_call` action passes through unchanged (same reference)
  - `bff_call` with no payload at all is tolerated
  - Latest `setValue` wins (snapshot read at click time, not render time)
- [ ] Manual: OTP screen — type 6 digits, tap Verify, confirm `request_body.otp` is the typed value.
- [ ] Manual: profile update form — change two fields, submit, confirm both keys land in `request_body`.
- [ ] Manual: stand-alone Input (no Form ancestor) — confirm normal controlled-input behaviour.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)