### PR TITLE
docs(zenith): update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ packages/
   tokens-brand/       — Brand Platform tokens (purple primary, light/dark themes)
   tokens-atmosphere/  — Atmosphere tokens (gold accent, dark-first themes)
   tokens-creator/     — Creator App tokens (SDUI mappings, mobile-optimized)
+  tokens-hexcoded/    — Hexcoded tokens (Tech Green #22C55E, Outfit+Inter+JBM, light/dark) — AI content platform
   ui/                 — Shared React components (Button, Badge, Card, EmptyState, Skeleton)
   storybook/          — Component documentation and visual testing
   eslint-config/      — Design system lint rules (no-hardcoded-colors, no-raw-spacing, prefer-token-import)


### PR DESCRIPTION
## Summary
- **Trigger:** commit `09c6084`
- **File updated:** `CLAUDE.md`
- **Confidence:** 🟡 0.50
- **Reason:** A new token package `@one-impression/tokens-hexcoded` has been added to the monorepo with its own build script, DTCG-format tokens, and changeset config — engineers working in this repo need to know about this new package, its Tech Green brand direction, build command, and how it fits the existing tokens pattern.

This is an automated documentation update by Zenith. Needs human review.

---
Generated by [Zenith AI CTO](https://github.com/one-impression/zenith-coding-agent)