### PR TITLE
chore(release): publish @one-impression/{tokens,brand}-hexcoded@1.0.0

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -17,7 +17,6 @@
     "@one-impression/feature-flags",
     "@amplify/tokens-marketing",
     "@one-impression/tokens-oportunities",
-    "@one-impression/tokens-studio",
-    "@one-impression/tokens-hexcoded"
+    "@one-impression/tokens-studio"
   ]
 }

--- a/.changeset/hexcoded-brand-1-0-0.md
+++ b/.changeset/hexcoded-brand-1-0-0.md
@@ -1,0 +1,7 @@
+---
+"@one-impression/brand-hexcoded": minor
+---
+
+First release of `@one-impression/brand-hexcoded` — brand asset package for the **Hexcoded** AI content platform. Locked to Brand Book v1.0 Final (2026-05-22).
+
+Ships 29 ready-to-use SVG/HTML assets: 6 wordmark variants (incl. Phantom-animated), 6 HEX-monogram app icons (light + dark + PWA maskable + spec), 7 favicon sources (SVG + per-size PNG sources + safari pinned tab + webmanifest), 6 social templates (LinkedIn cover/post, IG post/story, X banner, OG image), business cards at print spec, full + minimal HTML email signatures. Includes `BRAND-DECISIONS.md` (24 locked decisions + 1 parked) and `ENGINEER-HANDOFF.md`. Mirrors the `@one-impression/brand-oportunities` pattern.

--- a/.changeset/hexcoded-tokens-1-0-0.md
+++ b/.changeset/hexcoded-tokens-1-0-0.md
@@ -1,0 +1,7 @@
+---
+"@one-impression/tokens-hexcoded": minor
+---
+
+First release of `@one-impression/tokens-hexcoded` — design tokens for the **Hexcoded** AI content platform. Locked to Brand Book v1.0 Final (2026-05-22).
+
+Ships W3C DTCG-format light + dark theme tokens (Tech Green `#22C55E` accent, Outfit display + Inter body + JetBrains Mono code, Phantom motion durations, status palette) and emits CSS variables, SCSS, Tailwind preset, JSON, and ES-module outputs via `scripts/build-tokens.js`. Mirrors the `@one-impression/tokens-oportunities` pattern.


### PR DESCRIPTION
## Summary

First public release of the Hexcoded design-system packages on GitHub Packages.

## What this PR does

1. **Removes** `@one-impression/tokens-hexcoded` from the `.changeset/config.json` ignore list (was added in #142 so the package wouldn't auto-publish before we were ready)
2. **Adds** two minor-bump changesets — one for each Hexcoded package — to trigger the first `@1.0.0` release

## After merge

The changesets release workflow will open a "Release packages" PR. When that PR merges, both packages publish to GitHub Packages:

- `@one-impression/tokens-hexcoded@1.0.0` — DTCG tokens (CSS, SCSS, Tailwind v4, JSON, JS outputs)
- `@one-impression/brand-hexcoded@1.0.0` — 29 SVG/HTML brand assets

## Note on brand-hexcoded

`@one-impression/brand-hexcoded` was never in the ignore list (added cleanly in #143 with no prior version), so it'll publish on the first changeset that targets it — which this PR is.

## Sequence

- #142 ✅ `tokens-hexcoded` package created
- #143 ✅ `brand-hexcoded` package created
- #144 ✅ Storybook section
- **#NNN** (this PR) — flip the publish switch
- ➡️ landing-page tokens.css swap (separate PR on `hexcoded-landing` after publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)