### PR TITLE
fix(sdui-runtime): Interpreter normalises legacy props→data on render

### DIFF
--- a/.changeset/sdui-interpreter-props-normalize.md
+++ b/.changeset/sdui-interpreter-props-normalize.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+`Interpreter` now normalises legacy `props`-shaped wire payloads to the canonical `data` field before resolving the renderer. When a node arrives with `props` but no `data`, the props are copied into `data` and a `sdui.interpreter.props_normalized` telemetry event is emitted so stale BFF emits are easy to spot in dev. Nodes that already have `data` are passed through untouched — the helper never overwrites the canonical field. Defensive migration aid: matches the `data` contract from `@one-impression/sdui-primitives@1.0.0` while old handler emits are still being migrated.

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -34,7 +34,7 @@
     "build": "tsup && tsc --emitDeclarationOnly --noCheck",
     "dev": "tsup --watch",
     "lint": "eslint src/",
-    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/bottom-sheet/__tests__/*.test.ts src/snippets/_shared/__tests__/*.test.ts src/state/__tests__/*.test.ts src/snippets/Form/__tests__/*.test.ts src/sdui-node/__tests__/*.test.ts"
+    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/bottom-sheet/__tests__/*.test.ts src/snippets/_shared/__tests__/*.test.ts src/state/__tests__/*.test.ts src/snippets/Form/__tests__/*.test.ts src/sdui-node/__tests__/*.test.ts src/interpreter/__tests__/*.test.ts"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/sdui-runtime/src/interpreter/Interpreter.tsx
+++ b/packages/sdui-runtime/src/interpreter/Interpreter.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { resolveRenderer } from "../registries/node-registry.js";
+import { useTelemetry } from "../telemetry/index.js";
 import { Fallback } from "./Fallback.js";
+import { normalizeNode } from "./normalize-node.js";
 
 interface InterpreterProps {
   node: Node;
@@ -10,13 +12,27 @@ interface InterpreterProps {
 /**
  * The SDUI dispatcher. Reads node.type, looks up the renderer
  * from registries, falls back to <Fallback> on unknown types.
+ *
+ * Before resolving the renderer, the node passes through
+ * {@link normalizeNode} so legacy `props`-shaped payloads are rewritten
+ * to the canonical `data` field (per `@one-impression/sdui-primitives@1.0.0`).
  */
 export function Interpreter({ node }: InterpreterProps): React.ReactElement {
-  const Renderer = resolveRenderer(node.type);
+  const telemetry = useTelemetry();
+  const { normalized, didNormalize } = normalizeNode(node);
 
-  if (Renderer) {
-    return <Renderer {...node} />;
+  if (didNormalize) {
+    telemetry.emit("sdui.interpreter.props_normalized", {
+      type: normalized.type,
+      id: normalized.id,
+    });
   }
 
-  return <Fallback type={node.type} />;
+  const Renderer = resolveRenderer(normalized.type);
+
+  if (Renderer) {
+    return <Renderer {...normalized} />;
+  }
+
+  return <Fallback type={normalized.type} />;
 }

--- a/packages/sdui-runtime/src/interpreter/__tests__/normalize-node.test.ts
+++ b/packages/sdui-runtime/src/interpreter/__tests__/normalize-node.test.ts
@@ -1,0 +1,97 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { normalizeNode } from "../normalize-node.ts";
+import type { Node } from "@one-impression/sdk-native-sdui";
+
+/**
+ * The Node type from the schema package is strict about `data`, but the
+ * normalizer's whole job is to defend against payloads that violate it.
+ * We cast through `unknown` so the tests can construct the legacy shape.
+ */
+function asNode(value: unknown): Node {
+  return value as Node;
+}
+
+test("normalizeNode — node with valid data passes through unchanged", () => {
+  const node = asNode({
+    id: "n1",
+    type: "creator.ui_component.text",
+    data: { text: "hello" },
+  });
+
+  const result = normalizeNode(node);
+
+  assert.equal(result.didNormalize, false);
+  // Same reference — no clone needed on the happy path.
+  assert.equal(result.normalized, node);
+  assert.deepEqual(
+    (result.normalized as Node & { data?: unknown }).data,
+    { text: "hello" },
+  );
+});
+
+test("normalizeNode — node with only props gets normalized to data", () => {
+  const node = asNode({
+    id: "n2",
+    type: "creator.ui_component.text",
+    props: { text: "legacy emit" },
+  });
+
+  const result = normalizeNode(node);
+
+  assert.equal(result.didNormalize, true);
+  const out = result.normalized as Node & {
+    data?: unknown;
+    props?: unknown;
+  };
+  assert.deepEqual(out.data, { text: "legacy emit" });
+  // The legacy `props` key is stripped so downstream renderers don't see
+  // the stale shape and double-resolve it.
+  assert.equal(out.props, undefined);
+  assert.equal(out.id, "n2");
+  assert.equal(out.type, "creator.ui_component.text");
+});
+
+test("normalizeNode — node with both data and props keeps data (never overwrite)", () => {
+  const node = asNode({
+    id: "n3",
+    type: "creator.ui_component.text",
+    data: { text: "canonical" },
+    props: { text: "stale duplicate" },
+  });
+
+  const result = normalizeNode(node);
+
+  // didNormalize stays false: we never overwrite a valid `data`.
+  assert.equal(result.didNormalize, false);
+  assert.deepEqual(
+    (result.normalized as Node & { data?: unknown }).data,
+    { text: "canonical" },
+  );
+});
+
+test("normalizeNode — node with neither data nor props is untouched", () => {
+  const node = asNode({
+    id: "n4",
+    type: "creator.ui_component.separator",
+  });
+
+  const result = normalizeNode(node);
+
+  assert.equal(result.didNormalize, false);
+  assert.equal(result.normalized, node);
+});
+
+test("normalizeNode — input node is not mutated when normalizing", () => {
+  const node = asNode({
+    id: "n5",
+    type: "creator.ui_component.text",
+    props: { text: "legacy" },
+  });
+
+  const before = JSON.stringify(node);
+  normalizeNode(node);
+  const after = JSON.stringify(node);
+
+  assert.equal(before, after);
+});

--- a/packages/sdui-runtime/src/interpreter/normalize-node.ts
+++ b/packages/sdui-runtime/src/interpreter/normalize-node.ts
@@ -1,0 +1,44 @@
+import type { Node } from "@one-impression/sdk-native-sdui";
+
+/**
+ * Result of running {@link normalizeNode} against a wire payload.
+ *
+ * `normalized` is the (possibly rewritten) node ready for rendering.
+ * `didNormalize` is true when `props` was copied into `data` so the
+ * caller can emit a telemetry warning (legacy / stale emit detected).
+ */
+export interface NormalizeResult {
+  normalized: Node;
+  didNormalize: boolean;
+}
+
+/**
+ * Defensive normalization at the Interpreter boundary.
+ *
+ * The current wire contract (per `@one-impression/sdui-primitives@1.0.0`)
+ * places renderer payloads under `node.data`. Stale or legacy handler
+ * emits sometimes still ship them under `node.props`. To keep the page
+ * rendering correctly during the SDUI migration window, copy `props`
+ * into `data` when — and only when — `data` is undefined and `props`
+ * is present. Nodes that already have `data` are passed through
+ * untouched (we never overwrite the canonical field).
+ */
+export function normalizeNode(node: Node): NormalizeResult {
+  // Treat the node as a loose record so we can probe for the legacy
+  // `props` key without widening the Node type itself.
+  const raw = node as Node & { props?: unknown };
+  const hasData = raw.data !== undefined;
+  const hasProps = raw.props !== undefined;
+
+  if (!hasData && hasProps) {
+    // Clone so we never mutate the caller's input — Interpreter is a
+    // pure render boundary and the same node may be reused upstream.
+    const { props, ...rest } = raw;
+    return {
+      normalized: { ...rest, data: props } as Node,
+      didNormalize: true,
+    };
+  }
+
+  return { normalized: node, didNormalize: false };
+}


### PR DESCRIPTION
## Summary

The SDUI Interpreter now normalises `props`-shaped wire payloads to the canonical `data` field before resolving the renderer. When a node arrives with `props` but no `data`, the props are copied into `data` and a `sdui.interpreter.props_normalized` telemetry event is emitted so stale BFF emits are easy to spot in dev. Nodes that already have `data` are passed through untouched — the helper never overwrites the canonical field.

## Why

The wire contract per `@one-impression/sdui-primitives@1.0.0` places renderer payloads under `node.data`. Stale or legacy handler emits sometimes still ship them under `node.props`, which silently breaks rendering during the SDUI migration window. This is the sibling resilience pattern to `SduiNode`'s defensive `ZodError` handling (#151): one bad emit shouldn't take down the whole tree, and migration drift should leave a breadcrumb.

The normalizer is a pure function in `normalize-node.ts` so it's trivial to unit-test under `node:test` (no React, no jest harness).

## Test plan

- [x] 5 new `node:test` cases under `interpreter/__tests__/normalize-node.test.ts` cover:
  - valid `data` passes through unchanged (same reference, no clone)
  - only `props` gets rewritten to `data`, and `props` is stripped
  - both `data` and `props` keeps `data` (never overwrite)
  - neither field is untouched
  - input node is not mutated
- [x] `npm run build -w packages/sdui-runtime` — clean
- [x] `npm test -w packages/sdui-runtime` — 5/5 new tests pass; 4 pre-existing failures (`branch.test.ts` / `compound.test.ts` / `set-local.test.ts` / `bff-call.test.ts`) are the known peer-dep baseline issue, unrelated to this PR
- [ ] Manual: render a legacy node with `props` in the creator-app simulator and confirm it renders + telemetry fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)