### PR TITLE
feat(sdui-runtime): bff_call injects X-Dev-Identity header on localhost

### DIFF
--- a/.changeset/sdui-bff-call-dev-identity-header.md
+++ b/.changeset/sdui-bff-call-dev-identity-header.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": minor
+---
+
+The `bff_call` action handler now injects an `X-Dev-Identity` request header when the BFF base URL targets `localhost` or `127.0.0.1`. The header value is sourced from a new `useDevConfigStore` (exposes `setDevIdentity(value: string | null)`); when unset the header is silently skipped, and the URL gate ensures production traffic is never augmented even if the value is accidentally populated. Replaces the manual creator-app patch that injected the header from outside the runtime.

--- a/packages/sdui-runtime/src/action-engine/handlers/__tests__/bff-call.test.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/__tests__/bff-call.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { handleBffCall } from "../bff-call.ts";
 import type { ActionEngine, ActionEngineConfig } from "../../types.ts";
 import type { Action } from "@one-impression/sdk-native-sdui";
+import { useDevConfigStore } from "../../../state/useDevConfigStore.ts";
 
 const noopConfig: ActionEngineConfig = {
   bffBaseUrl: "https://bff.example.test",
@@ -132,6 +133,82 @@ test("bff_call — 200 with empty / non-JSON body — nothing fires, no throw", 
   const engine = makeSpyEngine();
   await handleBffCall(bffAction(), noopConfig, engine);
   assert.equal(engine.log.length, 0);
+});
+
+test("bff_call — localhost BFF + devIdentity set → X-Dev-Identity header injected", async () => {
+  let capturedHeaders: Record<string, string> | undefined;
+  installFetch(async (_input, init) => {
+    capturedHeaders = (init as { headers?: Record<string, string> } | undefined)
+      ?.headers as Record<string, string> | undefined;
+    return jsonResponse({ ok: true });
+  });
+  useDevConfigStore.getState().setDevIdentity("base64-identity-payload");
+  try {
+    await handleBffCall(
+      bffAction(),
+      { ...noopConfig, bffBaseUrl: "http://localhost:3000" },
+      makeSpyEngine(),
+    );
+    assert.equal(capturedHeaders?.["X-Dev-Identity"], "base64-identity-payload");
+  } finally {
+    useDevConfigStore.getState().setDevIdentity(null);
+  }
+});
+
+test("bff_call — 127.0.0.1 BFF + devIdentity set → X-Dev-Identity header injected", async () => {
+  let capturedHeaders: Record<string, string> | undefined;
+  installFetch(async (_input, init) => {
+    capturedHeaders = (init as { headers?: Record<string, string> } | undefined)
+      ?.headers as Record<string, string> | undefined;
+    return jsonResponse({ ok: true });
+  });
+  useDevConfigStore.getState().setDevIdentity("loopback-identity");
+  try {
+    await handleBffCall(
+      bffAction(),
+      { ...noopConfig, bffBaseUrl: "http://127.0.0.1:3000" },
+      makeSpyEngine(),
+    );
+    assert.equal(capturedHeaders?.["X-Dev-Identity"], "loopback-identity");
+  } finally {
+    useDevConfigStore.getState().setDevIdentity(null);
+  }
+});
+
+test("bff_call — localhost BFF + devIdentity unset → no X-Dev-Identity header", async () => {
+  let capturedHeaders: Record<string, string> | undefined;
+  installFetch(async (_input, init) => {
+    capturedHeaders = (init as { headers?: Record<string, string> } | undefined)
+      ?.headers as Record<string, string> | undefined;
+    return jsonResponse({ ok: true });
+  });
+  useDevConfigStore.getState().setDevIdentity(null);
+  await handleBffCall(
+    bffAction(),
+    { ...noopConfig, bffBaseUrl: "http://localhost:3000" },
+    makeSpyEngine(),
+  );
+  assert.equal(capturedHeaders?.["X-Dev-Identity"], undefined);
+});
+
+test("bff_call — prod BFF + devIdentity set → no X-Dev-Identity header (defensive)", async () => {
+  let capturedHeaders: Record<string, string> | undefined;
+  installFetch(async (_input, init) => {
+    capturedHeaders = (init as { headers?: Record<string, string> } | undefined)
+      ?.headers as Record<string, string> | undefined;
+    return jsonResponse({ ok: true });
+  });
+  useDevConfigStore.getState().setDevIdentity("should-not-leak");
+  try {
+    await handleBffCall(
+      bffAction(),
+      { ...noopConfig, bffBaseUrl: "https://bff.example.test" },
+      makeSpyEngine(),
+    );
+    assert.equal(capturedHeaders?.["X-Dev-Identity"], undefined);
+  } finally {
+    useDevConfigStore.getState().setDevIdentity(null);
+  }
 });
 
 test("bff_call — 200 with body.action and on_success — both dispatched in order, with telemetry between", async () => {

--- a/packages/sdui-runtime/src/action-engine/handlers/bff-call.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/bff-call.ts
@@ -1,6 +1,16 @@
 import { BffCallPayloadSchema } from "@one-impression/sdk-native-sdui";
 import type { Action } from "@one-impression/sdk-native-sdui";
 import type { ActionEngineConfig, ActionEngine } from "../types.js";
+import { useDevConfigStore } from "../../state/useDevConfigStore.js";
+
+/**
+ * Returns true if the given BFF base URL targets a local development
+ * gateway (localhost / 127.0.0.1). Used to gate dev-only request
+ * augmentation such as the X-Dev-Identity header.
+ */
+function isLocalhostBffUrl(bffBaseUrl: string): boolean {
+  return bffBaseUrl.includes("localhost") || bffBaseUrl.includes("127.0.0.1");
+}
 
 /**
  * bff_call — fetches a BFF endpoint with auth, dispatches on_success/on_error
@@ -38,6 +48,19 @@ export async function handleBffCall(
   }
   if (payload.idempotency_key) {
     headers["Idempotency-Key"] = payload.idempotency_key;
+  }
+
+  // Dev-only: inject X-Dev-Identity header for requests against a local
+  // BFF (localhost / 127.0.0.1). The creator-app sets this via
+  // useDevConfigStore.setDevIdentity(...) at boot when running against
+  // a mocked / locally-running gateway. Silently skipped when unset
+  // or when the URL is non-localhost — production traffic is never
+  // augmented even if the value happens to be populated.
+  if (isLocalhostBffUrl(config.bffBaseUrl)) {
+    const devIdentity = useDevConfigStore.getState().devIdentity;
+    if (devIdentity) {
+      headers["X-Dev-Identity"] = devIdentity;
+    }
   }
 
   // Fire optimistic on_success before the network call.

--- a/packages/sdui-runtime/src/state/index.ts
+++ b/packages/sdui-runtime/src/state/index.ts
@@ -73,3 +73,7 @@ export type {
   TooltipStoreState,
   TooltipStoreActions,
 } from './useTooltipStore.js';
+
+// Dev config (localhost-only request augmentation, e.g. X-Dev-Identity header)
+export { useDevConfigStore } from './useDevConfigStore.js';
+export type { DevConfigState, DevConfigActions } from './useDevConfigStore.js';

--- a/packages/sdui-runtime/src/state/useDevConfigStore.ts
+++ b/packages/sdui-runtime/src/state/useDevConfigStore.ts
@@ -1,0 +1,36 @@
+/**
+ * useDevConfigStore — Zustand store for developer-only configuration.
+ *
+ * Holds values that should only ever influence requests against a local
+ * BFF (e.g. `http://localhost:3000` or `http://127.0.0.1:3000`). The
+ * canonical example is the `X-Dev-Identity` header — a base64-encoded
+ * identity payload the creator-app uses to authenticate against a
+ * mocked / locally-running gateway when the real auth flow is bypassed.
+ *
+ * The bff_call handler reads this store and ONLY injects the header
+ * when the BFF base URL points at localhost / 127.0.0.1. If the value
+ * is unset, the header is silently skipped. Nothing in this store is
+ * ever sent to a production BFF.
+ */
+import { create } from 'zustand';
+
+export interface DevConfigState {
+  /**
+   * Base64-encoded identity payload sent as the `X-Dev-Identity`
+   * request header when the BFF base URL is localhost / 127.0.0.1.
+   * `null` disables injection.
+   */
+  devIdentity: string | null;
+}
+
+export interface DevConfigActions {
+  /** Set (or clear with `null`) the dev identity header value. */
+  setDevIdentity: (value: string | null) => void;
+}
+
+export const useDevConfigStore = create<DevConfigState & DevConfigActions>(
+  (set) => ({
+    devIdentity: null,
+    setDevIdentity: (value) => set({ devIdentity: value }),
+  }),
+);


### PR DESCRIPTION
## Summary

- Adds `useDevConfigStore` (new Zustand store) with `setDevIdentity(value: string | null)` for dev-only request config.
- `bff_call` action handler now injects an `X-Dev-Identity` request header **only** when the BFF base URL contains `localhost` or `127.0.0.1` AND `devIdentity` is set.
- Silently skipped otherwise — production traffic is never augmented, even if `devIdentity` happens to be populated.

## Why

When the creator-app runs against a mocked / locally-running gateway (`http://localhost:3000`), the BFF needs a base64-encoded identity payload via the `X-Dev-Identity` header to authenticate the request. The real auth flow is bypassed in this mode. Until now, the creator-app was monkey-patching this header from outside the runtime — moving the injection into `bff_call` itself makes dev-tooling first-class, removes a fragile downstream patch, and keeps the URL gate close to the request site so the value can never leak to a production BFF.

The cleanest API surface is a separate `useDevConfigStore` (not bolted onto `useAuthStore`) so the dev-only concern stays clearly named and easy to grep.

## Test plan

- [x] Localhost BFF + `devIdentity` set → header injected (new test).
- [x] 127.0.0.1 BFF + `devIdentity` set → header injected (new test).
- [x] Localhost BFF + `devIdentity` unset → no header (new test).
- [x] Prod (`https://bff.example.test`) + `devIdentity` set → no header (defensive — new test).
- [x] `npm run build -w packages/sdui-runtime` — green.
- [x] Existing `bff_call` body-action / on_success / on_error tests still pass.

Note: the `bff-call`/`branch`/`compound`/`set-local` test files fail to load on `main` due to a pre-existing `@one-impression/sdk-native-sdui` ESM resolution issue when running via `tsx --test`. That's unrelated to this change.