### PR TITLE
fix(sdui-runtime): resolveRenderer returns null on unknown type (graceful degrade)

### DIFF
--- a/.changeset/sdui-resolve-renderer-graceful.md
+++ b/.changeset/sdui-resolve-renderer-graceful.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+`resolveRenderer` now returns `null` (not `undefined`, never throws) when a node type isn't registered, so one bad node degrades gracefully instead of taking down the page. The first occurrence of each unknown type emits `sdui.renderer.unknown_type` through the telemetry sink wired by `SduiRuntimeProvider`; subsequent occurrences are silenced via an internal `Set` to avoid flooding telemetry. Sibling pattern to `SduiNode`'s defensive `ZodError` handling.

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -34,7 +34,7 @@
     "build": "tsup && tsc --emitDeclarationOnly --noCheck",
     "dev": "tsup --watch",
     "lint": "eslint src/",
-    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/bottom-sheet/__tests__/*.test.ts src/snippets/_shared/__tests__/*.test.ts src/state/__tests__/*.test.ts src/snippets/Form/__tests__/*.test.ts src/sdui-node/__tests__/*.test.ts"
+    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/bottom-sheet/__tests__/*.test.ts src/snippets/_shared/__tests__/*.test.ts src/state/__tests__/*.test.ts src/snippets/Form/__tests__/*.test.ts src/sdui-node/__tests__/*.test.ts src/registries/__tests__/*.test.ts"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/sdui-runtime/src/SduiRuntimeProvider.tsx
+++ b/packages/sdui-runtime/src/SduiRuntimeProvider.tsx
@@ -5,6 +5,7 @@ import { ActionEngineContext } from "./action-engine/useActionEngine.js";
 import { TelemetryContext } from "./telemetry/useTelemetry.js";
 import type { TelemetryEmitter } from "./telemetry/useTelemetry.js";
 import type { ActionEngineConfig } from "./action-engine/types.js";
+import { setResolveRendererWarnSink } from "./registries/node-registry.js";
 
 interface BffConfig {
   baseUrl: string;
@@ -54,6 +55,15 @@ export function SduiRuntimeProvider({
     };
     return createActionEngine(config);
   }, [bffConfig.baseUrl, authConfig.getToken, onNavigate, onToast, onDeeplink]);
+
+  // Route unknown-type warnings from the renderer registry through the
+  // same telemetry emitter as the rest of the runtime. Memoised on the
+  // emitter so swapping it (e.g. test rigs) re-wires the sink.
+  useMemo(() => {
+    setResolveRendererWarnSink((type: string) => {
+      telemetryConfig.emitter.emit("sdui.renderer.unknown_type", { type });
+    });
+  }, [telemetryConfig.emitter]);
 
   return (
     <TelemetryContext.Provider value={telemetryConfig.emitter}>

--- a/packages/sdui-runtime/src/registries/__tests__/node-registry.test.ts
+++ b/packages/sdui-runtime/src/registries/__tests__/node-registry.test.ts
@@ -1,0 +1,71 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveRenderer,
+  setResolveRendererWarnSink,
+  _unknownTypesWarned,
+  _resetResolveRendererState,
+} from "../node-registry.ts";
+
+test("resolveRenderer — known ui_component type returns a renderer", () => {
+  _resetResolveRendererState();
+  const renderer = resolveRenderer("creator.ui_component.text");
+  // We don't assert on identity (the renderer is a React component
+  // function pulled in via the registry) — only that resolution
+  // succeeded and the return value is a function.
+  assert.equal(typeof renderer, "function");
+});
+
+test("resolveRenderer — known snippet type returns a renderer", () => {
+  _resetResolveRendererState();
+  const renderer = resolveRenderer("creator.snippet.steps");
+  assert.equal(typeof renderer, "function");
+});
+
+test("resolveRenderer — unknown type returns null (does not throw)", () => {
+  _resetResolveRendererState();
+  // The whole point: a totally bogus type degrades gracefully.
+  const renderer = resolveRenderer("creator.ui_component.does_not_exist");
+  assert.equal(renderer, null);
+});
+
+test("resolveRenderer — unknown bare type (no creator. prefix) returns null", () => {
+  _resetResolveRendererState();
+  // Types that don't match either prefix used to fall through to
+  // `return undefined`; we now explicitly return null.
+  const renderer = resolveRenderer("totally.unknown.type");
+  assert.equal(renderer, null);
+});
+
+test("resolveRenderer — warning fires once per unknown type", () => {
+  _resetResolveRendererState();
+  const calls: string[] = [];
+  setResolveRendererWarnSink((type: string) => {
+    calls.push(type);
+  });
+
+  resolveRenderer("creator.ui_component.ghost");
+  resolveRenderer("creator.ui_component.ghost");
+  resolveRenderer("creator.ui_component.ghost");
+
+  assert.deepEqual(calls, ["creator.ui_component.ghost"]);
+  assert.ok(_unknownTypesWarned.has("creator.ui_component.ghost"));
+});
+
+test("resolveRenderer — distinct unknown types each warn once", () => {
+  _resetResolveRendererState();
+  const calls: string[] = [];
+  setResolveRendererWarnSink((type: string) => {
+    calls.push(type);
+  });
+
+  resolveRenderer("creator.ui_component.alpha");
+  resolveRenderer("creator.ui_component.beta");
+  resolveRenderer("creator.ui_component.alpha");
+  resolveRenderer("creator.ui_component.beta");
+
+  assert.deepEqual(calls.sort(), [
+    "creator.ui_component.alpha",
+    "creator.ui_component.beta",
+  ]);
+});

--- a/packages/sdui-runtime/src/registries/node-registry.ts
+++ b/packages/sdui-runtime/src/registries/node-registry.ts
@@ -4,17 +4,75 @@ import { uiComponentRegistry } from "./ui-components.js";
 import { snippetRegistry } from "./snippets.js";
 
 /**
+ * Tracks unknown node types we've already warned about so a single
+ * recurring bad node in a feed doesn't spam telemetry every frame.
+ *
+ * Exported for tests only — production callers should treat this as
+ * an implementation detail.
+ */
+export const _unknownTypesWarned = new Set<string>();
+
+/**
+ * Optional sink for unknown-type warnings. The Interpreter wires this
+ * to `useTelemetry().emit` at startup; tests can swap it for a spy.
+ * Default is a noop so resolution stays a pure lookup with no side
+ * effects when telemetry isn't configured.
+ */
+let warnSink: (type: string) => void = () => {};
+
+/**
+ * Register the warning sink. Idempotent — last writer wins. Called by
+ * the SduiRuntimeProvider so the warning is routed through the same
+ * telemetry hook as the rest of the runtime.
+ */
+export function setResolveRendererWarnSink(
+  sink: (type: string) => void,
+): void {
+  warnSink = sink;
+}
+
+/**
+ * Reset the warned-set + sink — test helper, not part of the public
+ * runtime surface.
+ */
+export function _resetResolveRendererState(): void {
+  _unknownTypesWarned.clear();
+  warnSink = () => {};
+}
+
+/**
  * Composed registry the Interpreter consults.
- * Resolves a wire `type` string to the correct renderer.
+ *
+ * Resolves a wire `type` string to the correct renderer. Returns
+ * `null` (not `undefined`, not a throw) when the type is unknown so
+ * the page degrades gracefully — one bad node should never crash the
+ * whole tree. The first time an unknown type is seen, a warning is
+ * routed through the registered sink (see {@link setResolveRendererWarnSink}).
+ * Subsequent occurrences of the same type are silenced to avoid
+ * flooding telemetry.
+ *
+ * This is the sibling pattern to `SduiNode`'s defensive `ZodError`
+ * handling: surface the problem, keep the page alive.
  */
 export function resolveRenderer(
   type: string,
-): ComponentType<Node> | undefined {
+): ComponentType<Node> | null {
+  let renderer: ComponentType<Node> | undefined;
+
   if (type.startsWith("creator.ui_component.")) {
-    return uiComponentRegistry[type];
+    renderer = uiComponentRegistry[type];
+  } else if (type.startsWith("creator.snippet.")) {
+    renderer = snippetRegistry[type];
   }
-  if (type.startsWith("creator.snippet.")) {
-    return snippetRegistry[type];
+
+  if (renderer) {
+    return renderer;
   }
-  return undefined;
+
+  if (!_unknownTypesWarned.has(type)) {
+    _unknownTypesWarned.add(type);
+    warnSink(type);
+  }
+
+  return null;
 }


### PR DESCRIPTION
## Summary

`resolveRenderer` now returns `null` explicitly (not `undefined`, never throws) when a node type isn't registered. The first occurrence of each unknown type emits a `sdui.renderer.unknown_type` telemetry event through the sink wired by `SduiRuntimeProvider`; subsequent occurrences are silenced via an internal `Set` so a recurring bad node in a feed doesn't flood telemetry.

## Why

One bad node should never crash the whole page. Returning `undefined` from `resolveRenderer` worked as long as every caller did a truthy check before invoking — that contract was implicit and brittle. Tightening it to `null` makes the "no renderer" path explicit and gives us a single, throttled telemetry breadcrumb so stale or unmigrated handler types are easy to spot in dev. Sibling pattern to `SduiNode`'s defensive `ZodError` handling (#151).

## Test plan

- [x] 6 new `node:test` cases under `registries/__tests__/node-registry.test.ts`:
  - known `ui_component` type returns a renderer
  - known `snippet` type returns a renderer
  - unknown type returns `null` (does not throw)
  - unknown bare type (no `creator.` prefix) returns `null`
  - warning fires exactly once per unknown type (suppressed on repeat)
  - distinct unknown types each warn once
- [x] `npm run build -w packages/sdui-runtime` — clean
- [x] `npm test -w packages/sdui-runtime` — the new test file hits the same pre-existing peer-dep baseline failure (`@one-impression/sdk-native-sdui` unresolved at runtime in the workspace) as `branch.test.ts` / `compound.test.ts` / `set-local.test.ts` / `bff-call.test.ts`. That is a separate workspace issue, not introduced here. The logic is straightforward enough that the test asserts are reviewable inline.
- [ ] Manual: drop an unknown node type into a page in the creator-app simulator and confirm the page renders + the warning fires once

🤖 Generated with [Claude Code](https://claude.com/claude-code)