### PR TITLE
fix(sdui-runtime): PageFeedRenderer subscribes to usePageStore for reactive item updates

### DIFF
--- a/.changeset/sdui-page-feed-store-subscription.md
+++ b/.changeset/sdui-page-feed-store-subscription.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+`PageFeedRenderer` now subscribes to `usePageStore` for its `items` data so `replaceNode` and `appendItems` (added in #149) take effect end-to-end. On mount the renderer syncs the server-provided page tree into the store via `setPageTree(page)`; the FlatList then reads `items` reactively with a `useShallow` selector scoped by `page.id`, falling back to the prop value when the store hasn't been populated yet or holds a different page. Without this, infinite-scroll `append_items` and section reload were updating the store but never re-rendering the feed.

--- a/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
@@ -6,12 +6,14 @@ import {
   StyleSheet,
   View,
 } from "react-native";
+import { useShallow } from "zustand/react/shallow";
 import type { Page, Node, Action } from "@one-impression/sdk-native-sdui";
 import { Interpreter } from "../../interpreter/index.js";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";
 import { useBottomSheetStore } from "../../bottom-sheet/useBottomSheetStore.js";
 import { usePageRefresh } from "../../hooks/usePageRefresh.js";
 import { useAppStateSession } from "../../hooks/useAppStateSession.js";
+import { usePageStore } from "../../state/usePageStore.js";
 
 interface PageProps {
   page: Page;
@@ -63,6 +65,29 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
   const onLoadMore = pageData.on_load_more;
   const loader = pageData.loader;
   const emptyState = pageData.empty_state;
+
+  // Sync the server-provided page tree into usePageStore on mount / whenever
+  // the page prop reference changes. This makes `replaceNode` / `appendItems`
+  // (dispatched from action handlers like reload_section / append_items)
+  // reactively flow back into this renderer below.
+  useEffect(() => {
+    usePageStore.getState().setPageTree(page);
+  }, [page]);
+
+  // Subscribe to the store for live updates to items. We fall back to the
+  // prop value when the store hasn't been populated yet (first render before
+  // the setPageTree effect commits) or when the store currently holds a
+  // different page (e.g. during a navigation transition). useShallow keeps
+  // the read atomic — pageId + items together — so the renderer can't see a
+  // torn snapshot under React 18 concurrent rendering.
+  const items = usePageStore(
+    useShallow((s) => {
+      if (s.pageId === page.id && s.page) {
+        return s.page.items;
+      }
+      return page.items;
+    }),
+  );
 
   // Register inline bottom sheets (do not open) — see PageStandard for details.
   useEffect(() => {
@@ -170,7 +195,7 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
   return (
     <View style={styles.container}>
       <FlatList
-        data={page.items}
+        data={items}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
         ListHeaderComponent={renderHeader}

--- a/packages/sdui-runtime/src/state/__tests__/usePageStore.test.ts
+++ b/packages/sdui-runtime/src/state/__tests__/usePageStore.test.ts
@@ -239,3 +239,88 @@ test("usePageStore.appendItems is a no-op when target has no data.items (warns)"
     console.warn = origWarn;
   }
 });
+
+// ---------------------------------------------------------------------------
+// PageFeedRenderer selector contract
+//
+// PageFeedRenderer reads `items` reactively via:
+//   usePageStore(useShallow((s) =>
+//     s.pageId === page.id && s.page ? s.page.items : page.items
+//   ))
+// The tests below verify that contract end-to-end against the real store:
+// after setPageTree(page) commits, replaceNode and appendItems must produce
+// new items arrays that the selector returns.
+// ---------------------------------------------------------------------------
+
+/** Mirrors the selector PageFeedRenderer uses, for direct testing. */
+function selectItemsForPage(propPage: Page): Node[] {
+  const s = usePageStore.getState();
+  if (s.pageId === propPage.id && s.page) {
+    return s.page.items;
+  }
+  return propPage.items;
+}
+
+test("PageFeed selector — initial render returns prop items when store empty", () => {
+  resetStore();
+  const propPage = page([leaf("server-a"), leaf("server-b")]);
+  const items = selectItemsForPage(propPage);
+  assert.deepEqual(
+    items.map((n) => n.id),
+    ["server-a", "server-b"],
+  );
+});
+
+test("PageFeed selector — after setPageTree, returns store items (same content initially)", () => {
+  resetStore();
+  const propPage = page([leaf("a"), leaf("b")]);
+  usePageStore.getState().setPageTree(propPage);
+  const items = selectItemsForPage(propPage);
+  assert.deepEqual(
+    items.map((n) => n.id),
+    ["a", "b"],
+  );
+});
+
+test("PageFeed selector — replaceNode on a top-level item updates selector output", () => {
+  resetStore();
+  const propPage = page([leaf("a"), leaf("b")]);
+  usePageStore.getState().setPageTree(propPage);
+  usePageStore.getState().replaceNode("b", leaf("b-replaced"));
+  const items = selectItemsForPage(propPage);
+  assert.deepEqual(
+    items.map((n) => n.id),
+    ["a", "b-replaced"],
+  );
+});
+
+test("PageFeed selector — appendItems on a feed container updates selector output", () => {
+  resetStore();
+  const propPage = page([container("feed", [leaf("x")])]);
+  usePageStore.getState().setPageTree(propPage);
+  usePageStore
+    .getState()
+    .appendItems("feed", [leaf("y"), leaf("z")], { hasMore: false });
+  const items = selectItemsForPage(propPage);
+  const feed = items[0] as Node;
+  const feedChildren = (feed.data as { items: Node[] }).items;
+  assert.deepEqual(
+    feedChildren.map((n) => n.id),
+    ["x", "y", "z"],
+  );
+});
+
+test("PageFeed selector — different page in store falls back to prop items", () => {
+  resetStore();
+  // Store currently holds a different page (e.g. transitioning between routes).
+  usePageStore.getState().setPageTree(page([leaf("other-page-item")]));
+  const propPage = {
+    ...page([leaf("incoming-a")]),
+    id: "incoming-page",
+  } as Page;
+  const items = selectItemsForPage(propPage);
+  assert.deepEqual(
+    items.map((n) => n.id),
+    ["incoming-a"],
+  );
+});


### PR DESCRIPTION
## Summary

- `PageFeedRenderer` now syncs the server-provided page tree into `usePageStore` on mount via `setPageTree(page)`.
- The FlatList reads `items` reactively from the store with a `useShallow` selector scoped by `page.id`.
- Falls back to the `page.items` prop when the store hasn't been populated yet or currently holds a different page (e.g. mid-navigation), preserving correct initial-render behavior.

## Why

`replaceNode` / `appendItems` were added to `usePageStore` in #149 specifically so action handlers (`reload_section`, `replace_section`, `append_items`) could mutate page state without going through a full re-fetch. But `PageFeedRenderer` was reading `page.items` from props only — the store updated, no re-render fired, and the feed never reflected the new items.

That breaks end-to-end:
- Infinite scroll: `on_load_more` → `bff_call` → response carries `append_items` → store updates → **feed silently stale**.
- Section reload: `reload_section` → store `replaceNode` → **feed silently stale**.

The home-tabs section-reload pattern (the headline use case for #149) cannot work without this subscription. Closing the gap is a strict bug fix — additive, no API change.

## Test plan

- [x] `npm run build -w packages/sdui-runtime` — green.
- [x] 5 new tests in `usePageStore.test.ts` covering the exact selector PageFeedRenderer uses:
  - initial render returns prop items when store empty,
  - after `setPageTree`, returns store items,
  - `replaceNode` on a top-level item flows through,
  - `appendItems` on a container flows through,
  - different page id in store falls back to prop items (navigation transition guard).
- [x] Existing 73 store/handler tests still pass (77 → 82 total, +5 new).

Note: the `bff-call`/`branch`/`compound`/`set-local` test failures on `main` are pre-existing module-resolution issues unrelated to this change.