### PR TITLE
fix(sdui-runtime): StepsRenderer uses primary/neutralWeak tokens, not hex literals

### DIFF
--- a/.changeset/sdui-steps-renderer-tokens.md
+++ b/.changeset/sdui-steps-renderer-tokens.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+`StepsRenderer` no longer hardcodes `#6531FF` / `#E0E0E0` for the active and inactive step bars. It now passes the semantic tokens `"primary"` and `"neutralWeak"` (from `@one-impression/tokens-creator`) to the `Box` `bg` prop, so the step indicator respects theme switching and brand cascades instead of bypassing the token system.

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -34,7 +34,7 @@
     "build": "tsup && tsc --emitDeclarationOnly --noCheck",
     "dev": "tsup --watch",
     "lint": "eslint src/",
-    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/bottom-sheet/__tests__/*.test.ts src/snippets/_shared/__tests__/*.test.ts src/state/__tests__/*.test.ts src/snippets/Form/__tests__/*.test.ts src/sdui-node/__tests__/*.test.ts"
+    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/bottom-sheet/__tests__/*.test.ts src/snippets/_shared/__tests__/*.test.ts src/state/__tests__/*.test.ts src/snippets/Form/__tests__/*.test.ts src/sdui-node/__tests__/*.test.ts src/snippets/Steps/__tests__/*.test.ts"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/sdui-runtime/src/snippets/Steps/Steps.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/Steps/Steps.renderer.tsx
@@ -24,7 +24,7 @@ export function StepsRenderer(node: Node): React.ReactElement {
               <Box
                 height={4}
                 rounded={2}
-                bg={i < v.current ? "#6531FF" : "#E0E0E0"}
+                bg={i < v.current ? "primary" : "neutralWeak"}
               />
               {v.labels?.[i] && (
                 <Text

--- a/packages/sdui-runtime/src/snippets/Steps/__tests__/Steps.renderer.test.ts
+++ b/packages/sdui-runtime/src/snippets/Steps/__tests__/Steps.renderer.test.ts
@@ -1,0 +1,65 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+/**
+ * Source-text regression: StepsRenderer must use the semantic tokens
+ * (`"primary"` / `"neutralWeak"`) supplied by `@one-impression/tokens-creator`
+ * rather than hex literals. We can't render the component under
+ * `node:test` (it transitively imports the React Native renderer chain
+ * which isn't available in the workspace), so we assert against the
+ * compiled-but-not-yet-built source text.
+ *
+ * If you change this file, also update the snippet renderer to keep
+ * the contract in sync.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const rendererPath = resolve(here, "../Steps.renderer.tsx");
+const source = readFileSync(rendererPath, "utf8");
+
+test("StepsRenderer — uses `primary` token for active step (not #6531FF / #7C3AED)", () => {
+  assert.ok(
+    source.includes('"primary"'),
+    "Steps.renderer.tsx should reference the `primary` token by name",
+  );
+  // Either of the historical hex values would defeat dark-mode /
+  // brand-switching support — block both.
+  assert.equal(
+    source.includes("#6531FF"),
+    false,
+    "Steps.renderer.tsx must not contain the raw hex #6531FF",
+  );
+  assert.equal(
+    source.includes("#7C3AED"),
+    false,
+    "Steps.renderer.tsx must not contain the raw hex #7C3AED",
+  );
+});
+
+test("StepsRenderer — uses `neutralWeak` token for inactive step (not #E0E0E0 / #D6D3D1)", () => {
+  assert.ok(
+    source.includes('"neutralWeak"'),
+    "Steps.renderer.tsx should reference the `neutralWeak` token by name",
+  );
+  assert.equal(
+    source.includes("#E0E0E0"),
+    false,
+    "Steps.renderer.tsx must not contain the raw hex #E0E0E0",
+  );
+  assert.equal(
+    source.includes("#D6D3D1"),
+    false,
+    "Steps.renderer.tsx must not contain the raw hex #D6D3D1",
+  );
+});
+
+test("StepsRenderer — bg expression chooses between the two tokens by step index", () => {
+  // The exact line: bg={i < v.current ? "primary" : "neutralWeak"}
+  // We don't pin spacing, just the conditional shape.
+  const expr =
+    /bg=\{\s*i\s*<\s*v\.current\s*\?\s*"primary"\s*:\s*"neutralWeak"\s*\}/;
+  assert.match(source, expr);
+});


### PR DESCRIPTION
## Summary

`StepsRenderer` now passes the semantic tokens `"primary"` and `"neutralWeak"` (from `@one-impression/tokens-creator`) to the `Box` `bg` prop instead of the hex literals `"#6531FF"` and `"#E0E0E0"`.

## Why

Hex literals in renderer code bypass the token system and break dark-mode + brand-switching for every product that consumes the runtime. `tokens-creator@3.0.0`'s `dist/tokens.native.js` defines:
- `primary` → `#7C3AED`
- `neutralWeak` → `#D6D3D1`

So the rendered shade shifts slightly (from `#6531FF` purple to `#7C3AED` violet for active; from `#E0E0E0` to `#D6D3D1` for inactive), but the new values are the design-system-approved sources of truth. The previous hex values were unmaintained drift from the token spec.

Verified token names exist in `packages/tokens-creator/dist/tokens.native.js`.

## Test plan

- [x] 3 new `node:test` cases under `snippets/Steps/__tests__/Steps.renderer.test.ts` (source-text regression — the runtime has no jest harness and rendering this component pulls in the full RN chain):
  - file references `"primary"` and `"neutralWeak"` by name
  - file contains none of `#6531FF`, `#7C3AED`, `#E0E0E0`, `#D6D3D1`
  - the conditional `bg=` expression matches `bg={i < v.current ? "primary" : "neutralWeak"}`
- [x] `npm run build -w packages/sdui-runtime` — clean
- [x] `npm test -w packages/sdui-runtime` — 3/3 new tests pass; same pre-existing baseline failures as the other PRs in this batch (peer-dep issue)
- [ ] Manual: render a Steps node in the creator-app simulator and confirm the colors match the active token values

🤖 Generated with [Claude Code](https://claude.com/claude-code)