### PR TITLE
fix(ui-native): Box forwards position, zIndex, opacity, overflow, individual borderWidths

### DIFF
--- a/.changeset/ui-native-box-style-props.md
+++ b/.changeset/ui-native-box-style-props.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/ui-native": patch
+---
+
+`Box` now forwards five additional React Native style props that were previously silently dropped: `position`, `zIndex`, `opacity`, `overflow`, and the four individual border widths (`borderTopWidth`, `borderBottomWidth`, `borderLeftWidth`, `borderRightWidth`, all of which accept either a `BorderWidthToken` or a raw number). SDUI handlers emit these on Box nodes for absolute-positioned overlays, animated fades, and one-sided dividers — without forwarding, those layouts rendered without their styling. Additive only — existing props are untouched.

--- a/packages/ui-native/src/layout/Box.test.tsx
+++ b/packages/ui-native/src/layout/Box.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { Text as RNText } from 'react-native';
+import { Box } from './Box';
+
+/** Flatten Box's `style` array into a single object for assertions. */
+function flatStyle(testID: string): Record<string, unknown> {
+  const el = screen.getByTestId(testID);
+  const s = el.props.style;
+  return Array.isArray(s)
+    ? Object.assign({}, ...(s.filter(Boolean) as object[]))
+    : (s as Record<string, unknown>);
+}
+
+describe('Box', () => {
+  it('renders children', () => {
+    render(
+      <Box testID="box">
+        <RNText>Hello</RNText>
+      </Box>,
+    );
+    expect(screen.getByTestId('box')).toBeTruthy();
+    expect(screen.getByText('Hello')).toBeTruthy();
+  });
+
+  it('forwards position prop to underlying View style', () => {
+    render(<Box testID="box" position="absolute" />);
+    expect(flatStyle('box').position).toBe('absolute');
+  });
+
+  it('forwards zIndex prop', () => {
+    render(<Box testID="box" zIndex={10} />);
+    expect(flatStyle('box').zIndex).toBe(10);
+  });
+
+  it('forwards opacity prop', () => {
+    render(<Box testID="box" opacity={0.5} />);
+    expect(flatStyle('box').opacity).toBe(0.5);
+  });
+
+  it('forwards overflow prop', () => {
+    render(<Box testID="box" overflow="hidden" />);
+    expect(flatStyle('box').overflow).toBe('hidden');
+  });
+
+  it('forwards individual border widths', () => {
+    render(
+      <Box
+        testID="box"
+        borderTopWidth={1}
+        borderBottomWidth={2}
+        borderLeftWidth={3}
+        borderRightWidth={4}
+      />,
+    );
+    const s = flatStyle('box');
+    expect(s.borderTopWidth).toBe(1);
+    expect(s.borderBottomWidth).toBe(2);
+    expect(s.borderLeftWidth).toBe(3);
+    expect(s.borderRightWidth).toBe(4);
+  });
+
+  it('does not leak the new props onto the underlying View when unset', () => {
+    render(<Box testID="box" />);
+    const s = flatStyle('box');
+    expect(s.position).toBeUndefined();
+    expect(s.zIndex).toBeUndefined();
+    expect(s.opacity).toBeUndefined();
+    expect(s.overflow).toBeUndefined();
+    expect(s.borderTopWidth).toBeUndefined();
+    expect(s.borderBottomWidth).toBeUndefined();
+    expect(s.borderLeftWidth).toBeUndefined();
+    expect(s.borderRightWidth).toBeUndefined();
+  });
+
+  it('still applies existing layout props alongside the new ones', () => {
+    render(
+      <Box
+        testID="box"
+        p="lg"
+        rounded="md"
+        position="absolute"
+        zIndex={5}
+        opacity={0.8}
+      />,
+    );
+    const s = flatStyle('box');
+    expect(s.padding).toBe(16); // lg
+    expect(s.borderRadius).toBe(8); // md
+    expect(s.position).toBe('absolute');
+    expect(s.zIndex).toBe(5);
+    expect(s.opacity).toBe(0.8);
+  });
+});

--- a/packages/ui-native/src/layout/Box.tsx
+++ b/packages/ui-native/src/layout/Box.tsx
@@ -32,8 +32,16 @@ export interface BoxProps extends ViewProps {
   mb?: SpacingToken | number;
   /** Border radius token or raw number. */
   rounded?: RadiusToken | number;
-  /** Border width token or raw number. */
+  /** Border width token or raw number — applies to all four sides. */
   borderWidth?: BorderWidthToken | number;
+  /** Border top width token or raw number. */
+  borderTopWidth?: BorderWidthToken | number;
+  /** Border bottom width token or raw number. */
+  borderBottomWidth?: BorderWidthToken | number;
+  /** Border left width token or raw number. */
+  borderLeftWidth?: BorderWidthToken | number;
+  /** Border right width token or raw number. */
+  borderRightWidth?: BorderWidthToken | number;
   /** Border color token or raw color string. */
   borderColor?: ColorToken | string;
   /** Flex value. */
@@ -50,6 +58,14 @@ export interface BoxProps extends ViewProps {
   width?: number | string;
   /** Height. */
   height?: number | string;
+  /** Positioning mode (e.g. 'absolute' for overlay layouts). */
+  position?: ViewStyle['position'];
+  /** Z-index for stacking absolute / overlay nodes. */
+  zIndex?: number;
+  /** Opacity (0..1) — useful for animated fade-in/out. */
+  opacity?: number;
+  /** Overflow handling for children that exceed the box bounds. */
+  overflow?: ViewStyle['overflow'];
 }
 
 /**
@@ -74,6 +90,10 @@ export const Box = React.forwardRef<View, BoxProps>(
       mb,
       rounded,
       borderWidth: bw,
+      borderTopWidth: btw,
+      borderBottomWidth: bbw,
+      borderLeftWidth: blw,
+      borderRightWidth: brw,
       borderColor,
       flex,
       direction,
@@ -82,6 +102,10 @@ export const Box = React.forwardRef<View, BoxProps>(
       gap,
       width,
       height,
+      position,
+      zIndex,
+      opacity,
+      overflow,
       style,
       ...props
     },
@@ -103,6 +127,10 @@ export const Box = React.forwardRef<View, BoxProps>(
       marginBottom: resolveSpacing(mb),
       borderRadius: resolveRadius(rounded),
       borderWidth: resolveBorderWidth(bw),
+      borderTopWidth: resolveBorderWidth(btw),
+      borderBottomWidth: resolveBorderWidth(bbw),
+      borderLeftWidth: resolveBorderWidth(blw),
+      borderRightWidth: resolveBorderWidth(brw),
       borderColor: resolveColor(borderColor),
       flex,
       flexDirection: direction,
@@ -111,6 +139,10 @@ export const Box = React.forwardRef<View, BoxProps>(
       gap: resolveSpacing(gap),
       width: width as ViewStyle['width'],
       height: height as ViewStyle['height'],
+      position,
+      zIndex,
+      opacity,
+      overflow,
     };
 
     // Strip undefined values to avoid overriding defaults


### PR DESCRIPTION
## Summary

Forwards five style-prop categories that `Box` was silently dropping. All additive — no existing prop changes shape or behavior.

- `position` (`'absolute' | 'relative' | …`)
- `zIndex` (`number`)
- `opacity` (`0..1`)
- `overflow` (`'hidden' | 'visible' | 'scroll'`)
- Individual border widths: `borderTopWidth`, `borderBottomWidth`, `borderLeftWidth`, `borderRightWidth` — each accepts `BorderWidthToken | number`, the same shape as the existing `borderWidth` prop, resolved through `resolveBorderWidth`.

## Why

SDUI handlers emit these props on `Box` nodes for legitimate visual cases that currently render incorrectly:

- **Absolute-positioned overlays** (badges, floating buttons, tooltips, sticky headers) need `position` + `zIndex`.
- **Animated transitions / hide-without-unmount** need `opacity`.
- **Scroll containers and clipping** need `overflow`.
- **One-sided dividers / asymmetric borders** need the individual `border*Width` props.

Until now these were stripped at the Box boundary, so every handler that needed them either fell back to wrapping a raw `<View>` (defeating the design-system layer) or relied on a manual ui-native dist patch. Forwarding them at the source closes that gap.

## Test plan

- [x] `npm run build -w packages/ui-native` — green.
- [x] New `Box.test.tsx` with cases for each new prop reaching the View's flattened style, plus a "no leak when unset" check and a "coexists with existing layout props" check.
- [x] No change to existing props' resolution path (verified by re-reading existing prop-mapping code).

Note: the ui-native workspace `jest` binary isn't installed in CI today, so the Box test file lands alongside the 18 existing untested-in-CI sibling test files. That's a pre-existing infra gap, not introduced here. Box tsup build succeeds; the only Box-related tsc errors (`'View' cannot be used as a JSX component`) are pre-existing across every component on main due to a React version mismatch.