### PR TITLE
fix(sdui-runtime): handleNavigate falls back to action.target for legacy emits

### DIFF
--- a/.changeset/sdui-navigate-target-fallback.md
+++ b/.changeset/sdui-navigate-target-fallback.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+`handleNavigate` now falls back to `action.target` when `payload.target` is undefined, with a deprecation warning routed through `config.logger.warn` (or `console.warn` if no logger is configured). New emits (with `target` inside `payload`, per [amplify-schemas#172](https://github.com/One-Impression/amplify-schemas/pull/172)) take precedence and never warn. Resilience aid for cached / third-party / pre-#172 emits that still place `target` at the action level — the page navigates correctly while the stale source surfaces in telemetry.

--- a/packages/sdui-runtime/src/action-engine/handlers/__tests__/navigate.test.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/__tests__/navigate.test.ts
@@ -1,0 +1,152 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { handleNavigate } from "../navigate.ts";
+import type {
+  ActionEngine,
+  ActionEngineConfig,
+  ActionEngineLogger,
+} from "../../types.ts";
+import type { Action } from "@one-impression/sdk-native-sdui";
+
+interface NavCall {
+  op: string;
+  target: string;
+  params: Record<string, unknown> | undefined;
+}
+
+interface WarnCall {
+  message: string;
+  context?: Record<string, unknown>;
+}
+
+function makeConfig(): {
+  config: ActionEngineConfig;
+  navCalls: NavCall[];
+  warnCalls: WarnCall[];
+} {
+  const navCalls: NavCall[] = [];
+  const warnCalls: WarnCall[] = [];
+  const logger: ActionEngineLogger = {
+    warn: (message, context) => {
+      warnCalls.push({ message, context });
+    },
+  };
+  const config: ActionEngineConfig = {
+    bffBaseUrl: "https://bff.example.test",
+    authToken: () => null,
+    onNavigate: (op, target, params) => {
+      navCalls.push({ op, target, params });
+    },
+    onToast: () => undefined,
+    onDeeplink: () => undefined,
+    logger,
+  };
+  return { config, navCalls, warnCalls };
+}
+
+const noopEngine: ActionEngine = { dispatch: async () => undefined };
+
+test("handleNavigate — new-style emit (target in payload) is forwarded as-is", async () => {
+  const { config, navCalls, warnCalls } = makeConfig();
+  const action: Action = {
+    type: "navigate",
+    payload: {
+      op: "push",
+      target: "/creator/earnings",
+      params: { tab: "withdrawals" },
+    },
+  };
+
+  await handleNavigate(action, config, noopEngine);
+
+  assert.equal(navCalls.length, 1);
+  assert.equal(navCalls[0].op, "push");
+  assert.equal(navCalls[0].target, "/creator/earnings");
+  assert.deepEqual(navCalls[0].params, { tab: "withdrawals" });
+  // No deprecation: the new shape never warns.
+  assert.equal(warnCalls.length, 0);
+});
+
+test("handleNavigate — legacy emit (action.target only) still works with deprecation warning", async () => {
+  const { config, navCalls, warnCalls } = makeConfig();
+  // Legacy shape — `target` sits at the action level, not in payload.
+  const action: Action = {
+    type: "navigate",
+    payload: { op: "push" },
+    target: "/legacy/route",
+  } as Action & { target: string };
+
+  await handleNavigate(action, config, noopEngine);
+
+  assert.equal(navCalls.length, 1);
+  assert.equal(navCalls[0].op, "push");
+  assert.equal(navCalls[0].target, "/legacy/route");
+  // Deprecation surfaced through the structured logger.
+  assert.equal(warnCalls.length, 1);
+  assert.match(warnCalls[0].message, /legacy action\.target/);
+  assert.equal(warnCalls[0].context?.target, "/legacy/route");
+});
+
+test("handleNavigate — both payload.target and action.target — payload wins, no warning", async () => {
+  const { config, navCalls, warnCalls } = makeConfig();
+  const action: Action = {
+    type: "navigate",
+    payload: { op: "push", target: "/from-payload" },
+    target: "/from-legacy",
+  } as Action & { target: string };
+
+  await handleNavigate(action, config, noopEngine);
+
+  assert.equal(navCalls.length, 1);
+  assert.equal(navCalls[0].target, "/from-payload");
+  // We must not warn when the new field is present — that's a healthy
+  // emit even if it also happens to have the legacy field.
+  assert.equal(warnCalls.length, 0);
+});
+
+test("handleNavigate — neither field present — empty target, no warning", async () => {
+  const { config, navCalls, warnCalls } = makeConfig();
+  const action: Action = {
+    type: "navigate",
+    payload: { op: "back" },
+  };
+
+  await handleNavigate(action, config, noopEngine);
+
+  assert.equal(navCalls.length, 1);
+  assert.equal(navCalls[0].target, "");
+  // Empty / pop-style navs are valid and shouldn't be flagged as legacy.
+  assert.equal(warnCalls.length, 0);
+});
+
+test("handleNavigate — missing logger falls back to console.warn for the deprecation", async () => {
+  const navCalls: NavCall[] = [];
+  // Same config as makeConfig() but with no logger field.
+  const config: ActionEngineConfig = {
+    bffBaseUrl: "https://bff.example.test",
+    authToken: () => null,
+    onNavigate: (op, target, params) => {
+      navCalls.push({ op, target, params });
+    },
+    onToast: () => undefined,
+    onDeeplink: () => undefined,
+  };
+  const consoleWarnCalls: unknown[][] = [];
+  const originalConsoleWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    consoleWarnCalls.push(args);
+  };
+  try {
+    const action: Action = {
+      type: "navigate",
+      payload: { op: "push" },
+      target: "/legacy/dev",
+    } as Action & { target: string };
+    await handleNavigate(action, config, noopEngine);
+  } finally {
+    console.warn = originalConsoleWarn;
+  }
+  assert.equal(navCalls.length, 1);
+  assert.equal(navCalls[0].target, "/legacy/dev");
+  assert.equal(consoleWarnCalls.length, 1);
+});

--- a/packages/sdui-runtime/src/action-engine/handlers/navigate.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/navigate.ts
@@ -4,6 +4,19 @@ import type { ActionEngineConfig, ActionEngine } from "../types.js";
 
 /**
  * navigate — delegates to config.onNavigate with the parsed op, target, and params.
+ *
+ * Target resolution order (matches the gradual migration off the
+ * legacy emit shape — see amplify-schemas#172):
+ *
+ *  1. `payload.target` — the new, schema-canonical location.
+ *  2. `action.target`  — legacy fallback. Cached / third-party / pre-#172
+ *                        emits put the destination one level up at the
+ *                        action level. When this branch fires, emit a
+ *                        deprecation warning through `config.logger` so
+ *                        the stale source is easy to identify.
+ *
+ * If neither is present we still call `onNavigate` with an empty string
+ * so existing call sites get the same behaviour as before.
  */
 export async function handleNavigate(
   action: Action,
@@ -11,5 +24,33 @@ export async function handleNavigate(
   _engine: ActionEngine,
 ): Promise<void> {
   const payload = NavigatePayloadSchema.parse(action.payload);
-  config.onNavigate(payload.op, payload.target ?? "", payload.params);
+
+  // Probe the action for the legacy action-level `target` without
+  // widening the schema-typed `Action`.
+  const legacyTarget = (action as Action & { target?: unknown }).target;
+  const legacyTargetIsString = typeof legacyTarget === "string";
+
+  let target: string;
+  if (payload.target !== undefined && payload.target !== null) {
+    // New-style emit wins — never log a deprecation when the payload
+    // already provides the canonical field, even if the legacy field
+    // also happens to be set.
+    target = payload.target;
+  } else if (legacyTargetIsString) {
+    target = legacyTarget;
+    const warn =
+      config.logger?.warn ??
+      ((message: string, context?: Record<string, unknown>) => {
+        // eslint-disable-next-line no-console
+        console.warn(message, context);
+      });
+    warn(
+      "[sdui-runtime] navigate action used legacy action.target — move target into payload (schemas#172)",
+      { op: payload.op, target: legacyTarget },
+    );
+  } else {
+    target = "";
+  }
+
+  config.onNavigate(payload.op, target, payload.params);
 }


### PR DESCRIPTION
## Summary

`handleNavigate` now reads `target` from `payload.target` first (the new, schema-canonical location after [amplify-schemas#172](https://github.com/One-Impression/amplify-schemas/pull/172)), and falls back to `action.target` when the payload field is undefined. The fallback path emits a deprecation warning through `config.logger.warn` (or `console.warn` when no logger is configured), with the op and resolved target as context so stale emits are easy to identify. The new-style flow is unchanged.

## Why

Cached, third-party, and pre-#172 SDUI emits still place `target` at the action level rather than inside the payload. Without a fallback, those navigations silently resolve to an empty string and tap-throughs land on a blank route — a confusing user-facing bug for what's actually a wire-format drift. This is the same gradual-migration resilience pattern as `SduiNode`'s `ZodError` fallback (#151) and the `Interpreter`'s `props→data` normaliser (in this batch): keep the app working, leave a telemetry breadcrumb.

Resolution order:

1. `payload.target` — preferred, never warns
2. `action.target`  — legacy fallback, warns once
3. `""`              — neither field; pop / back-style nav

## Test plan

- [x] 5 new `node:test` cases under `handlers/__tests__/navigate.test.ts`:
  - new-style emit (target in payload) forwarded as-is, no warning
  - legacy emit (`action.target` only) navigates correctly + deprecation warns through the logger
  - both fields present — payload wins, no warning
  - neither field — empty target, no warning (e.g. `op: "back"`)
  - missing logger falls back to `console.warn`
- [x] `npm run build -w packages/sdui-runtime` — clean
- [x] `npm test -w packages/sdui-runtime` — the new test file hits the same pre-existing peer-dep baseline as `branch.test.ts` / `compound.test.ts` / `set-local.test.ts` / `bff-call.test.ts` (`@one-impression/sdk-native-sdui` unresolved in the workspace, because `navigate.ts` imports `NavigatePayloadSchema` from it). Separate workspace issue, not introduced here.
- [ ] Manual: trigger a legacy navigate emit in the creator-app simulator and confirm the destination loads + the warning fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)