### PR TITLE
feat(tokens-creator): home page gradient anchor tokens

### DIFF
--- a/.changeset/tokens-creator-home-gradient.md
+++ b/.changeset/tokens-creator-home-gradient.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/tokens-creator": minor
+---
+
+Add four gradient anchor color tokens for the home page background: `gradientHomeStart` (`#E2E7FE`), `gradientHomeMid1` (`#DEE2FE`), `gradientHomeMid2` (`#EBF9FF`), and `gradientHomeEnd` (`#FFFFFF`). These mirror the legacy hex values used in the home page `pageConfig.gradient.colors` and unblock a legacy-faithful SDUI rebuild that currently bypasses the token system with raw hex literals. Purely additive — no existing token names or values change — and the names are reusable across any future page that wants a similar light-violet → off-white background ramp.

--- a/packages/tokens-creator/tokens/theme-dark.json
+++ b/packages/tokens-creator/tokens/theme-dark.json
@@ -38,7 +38,11 @@
       "offset-strong":   { "$value": "{color.stone.700}" },
       "offset-medium":   { "$value": "{color.stone.800}" },
       "offset-weak":     { "$value": "{color.stone.900}" },
-      "transparent":     { "$value": "transparent" }
+      "transparent":     { "$value": "transparent" },
+      "gradient-home-start": { "$value": "#E2E7FE", "$description": "Home page background gradient — start anchor (top); mirrors light theme since home gradient is brand-fixed" },
+      "gradient-home-mid-1": { "$value": "#DEE2FE", "$description": "Home page background gradient — first mid anchor" },
+      "gradient-home-mid-2": { "$value": "#EBF9FF", "$description": "Home page background gradient — second mid anchor" },
+      "gradient-home-end":   { "$value": "#FFFFFF", "$description": "Home page background gradient — end anchor (bottom)" }
     },
     "spacing": {
       "$type": "dimension",

--- a/packages/tokens-creator/tokens/theme-light.json
+++ b/packages/tokens-creator/tokens/theme-light.json
@@ -38,7 +38,11 @@
       "offset-strong":   { "$value": "{color.stone.200}" },
       "offset-medium":   { "$value": "#F1F6FE" },
       "offset-weak":     { "$value": "#F6FAFF" },
-      "transparent":     { "$value": "transparent" }
+      "transparent":     { "$value": "transparent" },
+      "gradient-home-start": { "$value": "#E2E7FE", "$description": "Home page background gradient — start anchor (top)" },
+      "gradient-home-mid-1": { "$value": "#DEE2FE", "$description": "Home page background gradient — first mid anchor" },
+      "gradient-home-mid-2": { "$value": "#EBF9FF", "$description": "Home page background gradient — second mid anchor" },
+      "gradient-home-end":   { "$value": "#FFFFFF", "$description": "Home page background gradient — end anchor (bottom)" }
     },
     "spacing": {
       "$type": "dimension",


### PR DESCRIPTION
## Summary

Add four gradient anchor color tokens to `@one-impression/tokens-creator` for the home page background gradient:

| Token             | Value     |
| ----------------- | --------- |
| `gradientHomeStart` | `#E2E7FE` |
| `gradientHomeMid1`  | `#DEE2FE` |
| `gradientHomeMid2`  | `#EBF9FF` |
| `gradientHomeEnd`   | `#FFFFFF` |

Added to `tokens/theme-light.json` and `tokens/theme-dark.json` under `sdui.color`. The shared build script emits them in every dist artifact (RN, JS, JSON, CSS, Tailwind). In the React Native consumer (the home page), they resolve as `gradientHomeStart` / `gradientHomeMid1` / `gradientHomeMid2` / `gradientHomeEnd` on the `colors` export of `@one-impression/tokens-creator/react-native`.

## Why

The values mirror the legacy hex literals currently inlined into the home page `pageConfig.gradient.colors`. Today, every consumer of that gradient bypasses the token system and hard-codes raw hex, which breaks theme switching and brand cascades. Promoting these four anchors to named tokens means:

- the SDUI home page background can reference `gradientHomeStart` / `Mid1` / `Mid2` / `End` by name (theme-aware, brand-aware), and
- any future page that wants the same light-violet -> off-white ramp can reuse the same anchors instead of re-hardcoding the literals.

Purely additive change -> `minor` changeset. No existing token names or values change, so no consumer breaks. Dark theme mirrors light values because the home gradient is brand-fixed in the legacy design (not dark-mode-inverted); future iterations can split if needed.

## Files changed

- `packages/tokens-creator/tokens/theme-light.json` -> 4 new entries under `sdui.color`
- `packages/tokens-creator/tokens/theme-dark.json` -> same 4 entries (mirror values)
- `.changeset/tokens-creator-home-gradient.md` -> minor bump

`dist/` is git-ignored and rebuilt by CI; verified locally that all four artifacts (`tokens.native.js`, `tokens.json`, `tokens.js`, `variables.css`, `tailwind.css`) emit the tokens.

## Test plan

- [x] `npm run build -w packages/tokens-creator` succeeds locally (palette validator + style-dictionary build both green)
- [x] `npm test -w packages/tokens-creator` passes (8/8 palette tests)
- [x] `dist/tokens.native.js` `colors` export contains `gradientHomeStart: "#E2E7FE"`, `gradientHomeMid1: "#DEE2FE"`, `gradientHomeMid2: "#EBF9FF"`, `gradientHomeEnd: "#FFFFFF"`
- [x] `dist/tokens.json` contains `amp-creator-sdui-color-gradient-home-*` keys with the same values
- [x] `dist/variables.css` emits `--amp-creator-sdui-color-gradient-home-*` custom properties in both `:root` (light) and `[data-theme="dark"]` blocks
- [ ] Reviewer: confirm naming + values match the design spec for the home page background gradient