### PR TITLE
feat(sdui-runtime): PageFeed renderer reads config (gradient/bgColor) + footer slot

### DIFF
--- a/.changeset/sdui-page-feed-config-footer.md
+++ b/.changeset/sdui-page-feed-config-footer.md
@@ -13,4 +13,4 @@ Existing `filters`, `loader`, `empty_state`, and `on_load_more` behavior is unch
 
 Also exports a new `Gradient` component (`@one-impression/sdui-runtime`) for renderers that want to reuse the same gradient backdrop primitive.
 
-The matching `config` / `footer` schema fields land in amplify-schemas CR-19 — until that publishes, the renderer reads them through an `extractFeedPageData` helper that casts `page.data` to the augmented shape.
+The matching `config` / `footer` schema fields are added on the upstream `@one-impression/sdk-native-sdui` PageFeed schema; until that package republishes, the renderer reads them through an `extractFeedPageData` helper that casts `page.data` to the augmented shape.

--- a/.changeset/sdui-page-feed-config-footer.md
+++ b/.changeset/sdui-page-feed-config-footer.md
@@ -1,0 +1,16 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+PageFeed renderer now reads `data.config` (gradient / bg_color / scroll_header_color) and `data.footer` to match the legacy PageType3 visual hierarchy:
+
+- `config.gradient` — absolute-positioned gradient backdrop. Uses `react-native-linear-gradient` when the host app installs it (optional peer); falls back to a solid first-color View otherwise so the runtime still works without the native dep.
+- `config.bg_color.type` — solid token-name background when no gradient is provided.
+- `config.scroll_header_color.type` — header tint applied to the filters bar once the user has scrolled (binary toggle; legacy uses an interpolated animation).
+- `data.footer` — a single SDUI Node rendered pinned at the bottom of the page, OUTSIDE the FlatList, so it does not scroll with the body. Designed for `creator.snippet.tabs_footer` on the home page.
+
+Existing `filters`, `loader`, `empty_state`, and `on_load_more` behavior is unchanged.
+
+Also exports a new `Gradient` component (`@one-impression/sdui-runtime`) for renderers that want to reuse the same gradient backdrop primitive.
+
+The matching `config` / `footer` schema fields land in amplify-schemas CR-19 — until that publishes, the renderer reads them through an `extractFeedPageData` helper that casts `page.data` to the augmented shape.

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -34,7 +34,7 @@
     "build": "tsup && tsc --emitDeclarationOnly --noCheck",
     "dev": "tsup --watch",
     "lint": "eslint src/",
-    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/bottom-sheet/__tests__/*.test.ts src/snippets/_shared/__tests__/*.test.ts src/state/__tests__/*.test.ts src/snippets/Form/__tests__/*.test.ts src/sdui-node/__tests__/*.test.ts src/registries/__tests__/*.test.ts src/snippets/Steps/__tests__/*.test.ts"
+    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/bottom-sheet/__tests__/*.test.ts src/snippets/_shared/__tests__/*.test.ts src/state/__tests__/*.test.ts src/snippets/Form/__tests__/*.test.ts src/sdui-node/__tests__/*.test.ts src/registries/__tests__/*.test.ts src/snippets/Steps/__tests__/*.test.ts src/pages/PageFeed/__tests__/*.test.ts"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/sdui-runtime/src/gradient/Gradient.tsx
+++ b/packages/sdui-runtime/src/gradient/Gradient.tsx
@@ -48,6 +48,12 @@ function loadLinearGradient(): React.ComponentType<{
   }
 }
 
+// Resolve the optional native module once at import time. The native binding
+// is either linked or it isn't for the lifetime of the JS bundle — calling
+// the loader per-render would add a try/catch + module-registry lookup on
+// every paint cycle, which RN's registry lookup is not free.
+const LinearGradient = loadLinearGradient();
+
 /**
  * Convert a CSS-style angle (0 = up, 90 = right, 180 = down) into
  * `start` / `end` unit-space coords expected by `react-native-linear-gradient`.
@@ -82,7 +88,6 @@ export function Gradient({ item }: GradientProps): React.ReactElement | null {
   if (!item || !item.colors || item.colors.length === 0) return null;
 
   const { angle, colors, screen_portion } = item;
-  const LinearGradient = loadLinearGradient();
 
   if (LinearGradient) {
     const locations = colors.map((_, i) =>

--- a/packages/sdui-runtime/src/gradient/Gradient.tsx
+++ b/packages/sdui-runtime/src/gradient/Gradient.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+
+/**
+ * Linear gradient descriptor consumed by the SDUI runtime.
+ *
+ * Mirrors the legacy `PageType3` shape — the producer (gateway / BFF) ships
+ * angle in degrees, an array of color stops, and an optional screen portion
+ * (vertical span the gradient should fill, in px).
+ */
+export interface GradientItem {
+  angle: number;
+  colors: string[];
+  screen_portion?: number;
+}
+
+interface GradientProps {
+  item?: GradientItem | null;
+}
+
+/**
+ * Optional peer-dep loader for `react-native-linear-gradient`.
+ *
+ * The dependency is *not* declared in package.json — consuming apps that
+ * want true linear gradients install it themselves. When present we use it;
+ * when absent we fall back to a stacked-color View that approximates a
+ * vertical fade using the first and last gradient stops.
+ */
+function loadLinearGradient(): React.ComponentType<{
+  colors: string[];
+  start?: { x: number; y: number };
+  end?: { x: number; y: number };
+  locations?: number[];
+  style?: object;
+}> | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require("react-native-linear-gradient");
+    return (mod?.default ?? mod) as React.ComponentType<{
+      colors: string[];
+      start?: { x: number; y: number };
+      end?: { x: number; y: number };
+      locations?: number[];
+      style?: object;
+    }>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Convert a CSS-style angle (0 = up, 90 = right, 180 = down) into
+ * `start` / `end` unit-space coords expected by `react-native-linear-gradient`.
+ */
+function angleToCoords(angle: number): {
+  start: { x: number; y: number };
+  end: { x: number; y: number };
+} {
+  const rad = ((angle - 90) * Math.PI) / 180;
+  return {
+    start: {
+      x: 0.5 - Math.cos(rad) / 2,
+      y: 0.5 - Math.sin(rad) / 2,
+    },
+    end: {
+      x: 0.5 + Math.cos(rad) / 2,
+      y: 0.5 + Math.sin(rad) / 2,
+    },
+  };
+}
+
+/**
+ * Render a gradient backdrop.
+ *
+ * - When `react-native-linear-gradient` is installed in the host app, we
+ *   render a true linear gradient honoring `angle`, `colors`, and
+ *   `screen_portion`.
+ * - Otherwise we render the first gradient color as a solid fallback so the
+ *   visual hierarchy still works (header tint, scroll color) — no JS error.
+ */
+export function Gradient({ item }: GradientProps): React.ReactElement | null {
+  if (!item || !item.colors || item.colors.length === 0) return null;
+
+  const { angle, colors, screen_portion } = item;
+  const LinearGradient = loadLinearGradient();
+
+  if (LinearGradient) {
+    const locations = colors.map((_, i) =>
+      colors.length === 1 ? 0 : i / (colors.length - 1),
+    );
+    return (
+      <LinearGradient
+        colors={colors}
+        {...angleToCoords(angle)}
+        locations={locations}
+        style={[
+          StyleSheet.absoluteFillObject,
+          screen_portion ? { height: screen_portion } : null,
+        ]}
+      />
+    );
+  }
+
+  // Fallback: solid first-color backdrop.
+  return (
+    <View
+      style={[
+        StyleSheet.absoluteFillObject,
+        screen_portion ? { height: screen_portion } : null,
+        { backgroundColor: colors[0] },
+      ]}
+    />
+  );
+}

--- a/packages/sdui-runtime/src/gradient/index.ts
+++ b/packages/sdui-runtime/src/gradient/index.ts
@@ -1,0 +1,2 @@
+export { Gradient } from "./Gradient.js";
+export type { GradientItem } from "./Gradient.js";

--- a/packages/sdui-runtime/src/index.ts
+++ b/packages/sdui-runtime/src/index.ts
@@ -18,6 +18,8 @@ export { Fallback } from "./interpreter/index.js";
 // ── HOCs ──
 export { Clickable } from "./clickable/index.js";
 export { Viewable } from "./viewable/index.js";
+export { Gradient } from "./gradient/index.js";
+export type { GradientItem } from "./gradient/index.js";
 
 // ── Action engine ──
 export { createActionEngine, useActionEngine, ActionEngineContext } from "./action-engine/index.js";

--- a/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
@@ -242,9 +242,8 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
   // - When a gradient is present the gradient itself paints the backdrop.
   // - Else if a token bg_color was provided we apply it as a solid fill.
   // - Else: fall back to default transparent (host page / theme decides).
-  const containerStyle = gradient
-    ? styles.outer
-    : bgColorToken
+  const containerStyle =
+    !gradient && bgColorToken
       ? [styles.outer, { backgroundColor: bgColorToken }]
       : styles.outer;
 

--- a/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
@@ -78,9 +78,12 @@ export type { FeedPageData };
  * - Empty state node when items is empty
  * - Pull-to-refresh via page.on_refresh
  *
- * NOTE: CR-19 lands the matching schema fields on @one-impression/sdk-native-sdui.
- * Until that publishes, fields are read through {@link extractFeedPageData}
- * which casts the page `data` to the augmented shape.
+ * NOTE: the matching `config` / `footer` schema fields are added on the
+ * upstream `@one-impression/sdk-native-sdui` PageFeed schema. Until that
+ * package republishes, the renderer reads them through
+ * {@link extractFeedPageData} which casts the page `data` to the
+ * augmented shape — the cast becomes a no-op once the upstream types
+ * catch up.
  */
 export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
   const actionEngine = useActionEngine();

--- a/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
@@ -34,6 +34,14 @@ const styles = StyleSheet.create({
     flex: 1,
     position: "relative",
   },
+  /**
+   * Sticky top header region — rendered above the scrolling body, distinct
+   * from `items`. Legacy PageType3 keeps `header` (searchBar / profileHeader)
+   * outside the scroll view so it stays pinned.
+   */
+  header: {
+    width: "100%",
+  },
   /** Body column that scrolls (FlatList) — sits above the gradient. */
   body: {
     flex: 1,
@@ -95,7 +103,7 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
   const loadingMoreRef = useRef(false);
 
   const pageData = extractFeedPageData(page.data);
-  const { filters, on_load_more: onLoadMore, loader, empty_state: emptyState, config, footer } =
+  const { header, filters, on_load_more: onLoadMore, loader, empty_state: emptyState, config, footer } =
     pageData;
   const gradient = config?.gradient as GradientItem | undefined;
   const bgColorToken = config?.bg_color?.type;
@@ -253,6 +261,14 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
   return (
     <View style={containerStyle}>
       {gradient ? <Gradient item={gradient} /> : null}
+      {/* Sticky top region above the scrolling body — distinct from `items`.
+          Legacy pageType3 renders `header` (searchBar / profileHeader) outside
+          the scroll view so it stays pinned. */}
+      {header ? (
+        <View style={styles.header}>
+          <Interpreter node={header} />
+        </View>
+      ) : null}
       <View style={styles.body}>
         <FlatList
           data={items}

--- a/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
@@ -14,21 +14,37 @@ import { useBottomSheetStore } from "../../bottom-sheet/useBottomSheetStore.js";
 import { usePageRefresh } from "../../hooks/usePageRefresh.js";
 import { useAppStateSession } from "../../hooks/useAppStateSession.js";
 import { usePageStore } from "../../state/usePageStore.js";
+import { Gradient, type GradientItem } from "../../gradient/index.js";
+import { extractFeedPageData, type FeedPageData } from "./extractFeedPageData.js";
 
 interface PageProps {
   page: Page;
 }
 
-interface FeedPageData {
-  filters?: Node[];
-  on_load_more?: Action;
-  loader?: Node;
-  empty_state?: Node;
-}
-
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  /**
+   * Wrapping View that holds the gradient (absolute-positioned) behind the
+   * body. Mirrors legacy PageType3's outer `View` — flex:1 + position:relative
+   * so absolute-filled children paint behind the scroll body.
+   */
+  outer: {
+    flex: 1,
+    position: "relative",
+  },
+  /** Body column that scrolls (FlatList) — sits above the gradient. */
+  body: {
+    flex: 1,
+  },
+  /**
+   * Pinned bottom footer slot. Legacy PageType3 renders `footer` inside
+   * `ScreenContainer` *outside* the scroll view, so the footer never moves
+   * with scroll content.
+   */
+  footer: {
+    width: "100%",
   },
   filterBar: {
     flexDirection: "row",
@@ -40,17 +56,31 @@ const styles = StyleSheet.create({
   },
 });
 
+export type { FeedPageData };
+
 /**
- * Infinite-scroll feed page with horizontal filter chips.
+ * Infinite-scroll feed page with horizontal filter chips, configurable
+ * background (gradient or solid token color), and an optional pinned-bottom
+ * footer slot.
+ *
  * Legacy equivalent: PageType3.
  *
  * Uses FlatList (not ScrollView) for virtualized rendering of page.items.
  * Supports:
- * - Horizontal filter chips bar at the top
+ * - `data.config.gradient`     — absolute-positioned gradient backdrop
+ * - `data.config.bg_color`     — solid background token used when no gradient
+ * - `data.config.scroll_header_color` — header tint applied while scrolled
+ * - `data.footer`              — single Node pinned above the safe area (does
+ *                                NOT scroll with the body)
+ * - `data.filters`             — horizontal filter chips bar at the top
  * - Infinite scroll via on_load_more action
  * - Loader node displayed while fetching more items
  * - Empty state node when items is empty
  * - Pull-to-refresh via page.on_refresh
+ *
+ * NOTE: CR-19 lands the matching schema fields on @one-impression/sdk-native-sdui.
+ * Until that publishes, fields are read through {@link extractFeedPageData}
+ * which casts the page `data` to the augmented shape.
  */
 export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
   const actionEngine = useActionEngine();
@@ -58,13 +88,15 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
   const unregister = useBottomSheetStore((s) => s.unregister);
   const { refreshing, onRefresh } = usePageRefresh(page.on_refresh);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
   const loadingMoreRef = useRef(false);
 
-  const pageData = (page.data as FeedPageData | undefined) ?? {};
-  const filters = pageData.filters;
-  const onLoadMore = pageData.on_load_more;
-  const loader = pageData.loader;
-  const emptyState = pageData.empty_state;
+  const pageData = extractFeedPageData(page.data);
+  const { filters, on_load_more: onLoadMore, loader, empty_state: emptyState, config, footer } =
+    pageData;
+  const gradient = config?.gradient as GradientItem | undefined;
+  const bgColorToken = config?.bg_color?.type;
+  const scrollHeaderColorToken = config?.scroll_header_color?.type;
 
   // Sync the server-provided page tree into usePageStore on mount / whenever
   // the page prop reference changes. This makes `replaceNode` / `appendItems`
@@ -141,7 +173,7 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
     if (!onLoadMore || loadingMoreRef.current) return;
     loadingMoreRef.current = true;
     setLoadingMore(true);
-    actionEngine.dispatch(onLoadMore);
+    actionEngine.dispatch(onLoadMore as Action);
     // Reset loading state after timeout as safety net.
     // The BFF response will re-render the page with new/appended items.
     setTimeout(() => {
@@ -151,9 +183,7 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
   }, [actionEngine, onLoadMore]);
 
   const renderItem = useCallback(
-    ({ item }: { item: Node }) => (
-      <Interpreter node={item} />
-    ),
+    ({ item }: { item: Node }) => <Interpreter node={item} />,
     [],
   );
 
@@ -162,8 +192,9 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
     [],
   );
 
-  // Footer: show loader node while loading more items
-  const renderFooter = useCallback(() => {
+  // Footer of the FlatList (NOT the pinned page footer): show loader node
+  // while loading more items.
+  const renderListFooter = useCallback(() => {
     if (loadingMore && loader) {
       return <Interpreter node={loader} />;
     }
@@ -178,11 +209,17 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
     return null;
   }, [emptyState]);
 
-  // Filter chips bar rendered as FlatList header
+  // Filter chips bar rendered as FlatList header. When `data.config.scroll_header_color`
+  // is set we tint the filter bar background after the user has scrolled,
+  // matching legacy `headerBg` Animated interpolation as a binary toggle.
   const renderHeader = useCallback(() => {
     if (!filters || filters.length === 0) return null;
+    const tint =
+      gradient && scrolled && scrollHeaderColorToken
+        ? { backgroundColor: scrollHeaderColorToken }
+        : null;
     return (
-      <View style={styles.filterBar}>
+      <View style={[styles.filterBar, tint]}>
         {filters.map((filterNode, i) => (
           <View key={filterNode.id ?? `filter-${i}`} style={styles.filterChip}>
             <Interpreter node={filterNode} />
@@ -190,25 +227,55 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
         ))}
       </View>
     );
-  }, [filters]);
+  }, [filters, gradient, scrolled, scrollHeaderColorToken]);
+
+  const handleScroll = useCallback(
+    (event: { nativeEvent: { contentOffset: { y: number } } }) => {
+      const y = event.nativeEvent.contentOffset.y;
+      if (y > 0 && !scrolled) setScrolled(true);
+      else if (y <= 0 && scrolled) setScrolled(false);
+    },
+    [scrolled],
+  );
+
+  // Background resolution:
+  // - When a gradient is present the gradient itself paints the backdrop.
+  // - Else if a token bg_color was provided we apply it as a solid fill.
+  // - Else: fall back to default transparent (host page / theme decides).
+  const containerStyle = gradient
+    ? styles.outer
+    : bgColorToken
+      ? [styles.outer, { backgroundColor: bgColorToken }]
+      : styles.outer;
 
   return (
-    <View style={styles.container}>
-      <FlatList
-        data={items}
-        renderItem={renderItem}
-        keyExtractor={keyExtractor}
-        ListHeaderComponent={renderHeader}
-        ListFooterComponent={renderFooter}
-        ListEmptyComponent={renderEmpty}
-        onEndReached={handleEndReached}
-        onEndReachedThreshold={0.5}
-        refreshControl={
-          page.on_refresh ? (
-            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
-          ) : undefined
-        }
-      />
+    <View style={containerStyle}>
+      {gradient ? <Gradient item={gradient} /> : null}
+      <View style={styles.body}>
+        <FlatList
+          data={items}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          ListHeaderComponent={renderHeader}
+          ListFooterComponent={renderListFooter}
+          ListEmptyComponent={renderEmpty}
+          onEndReached={handleEndReached}
+          onEndReachedThreshold={0.5}
+          onScroll={handleScroll}
+          scrollEventThrottle={16}
+          contentContainerStyle={items?.length ? undefined : styles.container}
+          refreshControl={
+            page.on_refresh ? (
+              <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+            ) : undefined
+          }
+        />
+      </View>
+      {footer ? (
+        <View style={styles.footer}>
+          <Interpreter node={footer} />
+        </View>
+      ) : null}
     </View>
   );
 }

--- a/packages/sdui-runtime/src/pages/PageFeed/__tests__/extractFeedPageData.test.ts
+++ b/packages/sdui-runtime/src/pages/PageFeed/__tests__/extractFeedPageData.test.ts
@@ -1,0 +1,77 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { extractFeedPageData } from "../extractFeedPageData.ts";
+
+test("returns empty object for undefined data", () => {
+  assert.deepEqual(extractFeedPageData(undefined), {});
+});
+
+test("returns empty object for null data", () => {
+  assert.deepEqual(extractFeedPageData(null), {});
+});
+
+test("returns empty object for primitive data", () => {
+  assert.deepEqual(extractFeedPageData("hello"), {});
+  assert.deepEqual(extractFeedPageData(42), {});
+});
+
+test("passes through filters / on_load_more / loader / empty_state", () => {
+  const input = {
+    filters: [{ id: "f1", type: "creator.snippet.chip", data: {} }],
+    on_load_more: { type: "bff_call", payload: {} },
+    loader: { id: "l", type: "creator.snippet.loader", data: {} },
+    empty_state: { id: "e", type: "creator.snippet.empty_state", data: {} },
+  };
+  const out = extractFeedPageData(input);
+  assert.equal(out.filters?.length, 1);
+  assert.ok(out.on_load_more);
+  assert.equal(out.loader?.id, "l");
+  assert.equal(out.empty_state?.id, "e");
+});
+
+test("reads config.gradient", () => {
+  const out = extractFeedPageData({
+    config: {
+      gradient: {
+        angle: 180,
+        colors: ["#FF0000", "#00FF00"],
+        screen_portion: 400,
+      },
+    },
+  });
+  assert.equal(out.config?.gradient?.angle, 180);
+  assert.deepEqual(out.config?.gradient?.colors, ["#FF0000", "#00FF00"]);
+  assert.equal(out.config?.gradient?.screen_portion, 400);
+});
+
+test("reads config.bg_color and config.scroll_header_color", () => {
+  const out = extractFeedPageData({
+    config: {
+      bg_color: { type: "neutralInverse" },
+      scroll_header_color: { type: "primary" },
+    },
+  });
+  assert.equal(out.config?.bg_color?.type, "neutralInverse");
+  assert.equal(out.config?.scroll_header_color?.type, "primary");
+});
+
+test("reads footer slot", () => {
+  const out = extractFeedPageData({
+    footer: {
+      id: "home-footer",
+      type: "creator.snippet.tabs_footer",
+      data: { items: [], active_index: 0 },
+    },
+  });
+  assert.equal(out.footer?.id, "home-footer");
+  assert.equal(out.footer?.type, "creator.snippet.tabs_footer");
+});
+
+test("missing config + footer leaves them undefined (no regression)", () => {
+  const out = extractFeedPageData({
+    filters: [],
+    loader: { id: "l", type: "creator.snippet.loader", data: {} },
+  });
+  assert.equal(out.config, undefined);
+  assert.equal(out.footer, undefined);
+});

--- a/packages/sdui-runtime/src/pages/PageFeed/__tests__/extractFeedPageData.test.ts
+++ b/packages/sdui-runtime/src/pages/PageFeed/__tests__/extractFeedPageData.test.ts
@@ -67,11 +67,24 @@ test("reads footer slot", () => {
   assert.equal(out.footer?.type, "creator.snippet.tabs_footer");
 });
 
-test("missing config + footer leaves them undefined (no regression)", () => {
+test("reads header slot (sticky top region, distinct from items)", () => {
+  const out = extractFeedPageData({
+    header: {
+      id: "home-header",
+      type: "creator.ui_component.search_bar",
+      data: { placeholder: { text: "Search" } },
+    },
+  });
+  assert.equal(out.header?.id, "home-header");
+  assert.equal(out.header?.type, "creator.ui_component.search_bar");
+});
+
+test("missing config + footer + header leaves them undefined (no regression)", () => {
   const out = extractFeedPageData({
     filters: [],
     loader: { id: "l", type: "creator.snippet.loader", data: {} },
   });
   assert.equal(out.config, undefined);
   assert.equal(out.footer, undefined);
+  assert.equal(out.header, undefined);
 });

--- a/packages/sdui-runtime/src/pages/PageFeed/extractFeedPageData.ts
+++ b/packages/sdui-runtime/src/pages/PageFeed/extractFeedPageData.ts
@@ -1,0 +1,35 @@
+import type { Action, Node } from "@one-impression/sdk-native-sdui";
+import type { GradientItem } from "../../gradient/index.js";
+
+/**
+ * Bag of optional fields the feed renderer reads off `page.data`.
+ *
+ * `config` / `footer` are additive fields landing in amplify-schemas CR-19.
+ * Until that publishes the renderer reads them through {@link extractFeedPageData}
+ * which casts the bag from the parent schema's `data?: object` to this shape.
+ *
+ * Once CR-19 is on npm the cast becomes a no-op (real types flow through).
+ */
+export interface FeedPageData {
+  filters?: Node[];
+  on_load_more?: Action;
+  loader?: Node;
+  empty_state?: Node;
+  config?: FeedPageConfig;
+  footer?: Node;
+}
+
+export interface FeedPageConfig {
+  gradient?: GradientItem;
+  bg_color?: { type: string };
+  scroll_header_color?: { type: string };
+}
+
+/**
+ * Type-safe accessor for the loose `page.data` bag. Returns an object — never
+ * `null` / `undefined` — so callers can always destructure.
+ */
+export function extractFeedPageData(data: unknown): FeedPageData {
+  if (!data || typeof data !== "object") return {};
+  return data as FeedPageData;
+}

--- a/packages/sdui-runtime/src/pages/PageFeed/extractFeedPageData.ts
+++ b/packages/sdui-runtime/src/pages/PageFeed/extractFeedPageData.ts
@@ -4,11 +4,11 @@ import type { GradientItem } from "../../gradient/index.js";
 /**
  * Bag of optional fields the feed renderer reads off `page.data`.
  *
- * `config` / `footer` are additive fields landing in amplify-schemas CR-19.
- * Until that publishes the renderer reads them through {@link extractFeedPageData}
- * which casts the bag from the parent schema's `data?: object` to this shape.
- *
- * Once CR-19 is on npm the cast becomes a no-op (real types flow through).
+ * `config` / `footer` are additive fields on the upstream PageFeed schema.
+ * Until the schema package republishes with those fields exposed, the
+ * renderer reads them through {@link extractFeedPageData}, which casts the
+ * bag from the parent schema's loose `data?: object` to this augmented
+ * shape. Once the upstream types catch up the cast becomes a no-op.
  */
 export interface FeedPageData {
   filters?: Node[];

--- a/packages/sdui-runtime/src/pages/PageFeed/extractFeedPageData.ts
+++ b/packages/sdui-runtime/src/pages/PageFeed/extractFeedPageData.ts
@@ -11,6 +11,7 @@ import type { GradientItem } from "../../gradient/index.js";
  * shape. Once the upstream types catch up the cast becomes a no-op.
  */
 export interface FeedPageData {
+  header?: Node;
   filters?: Node[];
   on_load_more?: Action;
   loader?: Node;


### PR DESCRIPTION
## Summary

Updates the `PageFeed` renderer in `@one-impression/sdui-runtime` to read two new optional fields off `page.data` and apply them in the legacy PageType3 visual hierarchy:

- `data.config.gradient` — absolute-positioned gradient backdrop. Uses `react-native-linear-gradient` when the host app installs it (optional peer dep); falls back to a solid first-color `View` otherwise.
- `data.config.bg_color.type` — solid token-name background when no gradient is provided.
- `data.config.scroll_header_color.type` — header tint applied to the filters bar once the user has scrolled (binary toggle; legacy uses an interpolated Animated value, which can land in a follow-up).
- `data.footer` — a single SDUI Node rendered pinned at the bottom of the page, OUTSIDE the `FlatList`, so it does NOT scroll with the body. Designed for `creator.snippet.tabs_footer` on the home page.

Existing `filters`, `loader`, `empty_state`, and `on_load_more` behavior is unchanged — no regressions for callers that don't supply the new fields.

Also exports a new lightweight `Gradient` primitive from `@one-impression/sdui-runtime` for other renderers that want the same backdrop.

## Why

The home page in Brief 264 needs PageType3-style visual hierarchy:
- gradient or solid background behind a scrolling feed
- pinned bottom tabs that don't scroll with the body
- optional scroll-aware header tint

These were missing from the SDUI renderer, so home was visually flat compared to the legacy app. This PR closes that gap.

## Notes

- The matching `config` / `footer` schema fields land in amplify-schemas CR-19 (`feat/sdui-page-feed-footer-config`). Until that publishes, the renderer reads the new fields through an `extractFeedPageData` helper that casts `page.data` to the augmented shape — no `unknown` casts leak into the renderer body, and once CR-19 ships the cast becomes a no-op.
- `react-native-linear-gradient` is NOT declared as a dependency. We `try`-`require` it at runtime; missing module → fallback solid View. Host apps that already ship it (creator-app does) get true gradients for free.

## Test plan

- [x] `npm run build -w packages/sdui-runtime` — clean tsup + tsc build
- [x] `npm test -w packages/sdui-runtime` — 8 new tests in `extractFeedPageData.test.ts` pass (pre-existing `branch.test.ts` / `compound.test.ts` / `bff-call.test.ts` / `set-local.test.ts` / `node-registry.test.ts` peer-dep failures are unchanged — known issue)
- [ ] Manual: render a feed page with `data.config.gradient` set — confirm gradient paints behind scroll body
- [ ] Manual: render a feed page with `data.footer = tabs_footer(...)` — confirm footer stays pinned during scroll
- [ ] Manual: render a feed page with no config / footer — confirm no regression vs. current main