### PR TITLE
feat(sdui-runtime): TabsFooter renderer — renders tab nodes, dispatches on_click, active-index styling

### DIFF
--- a/.changeset/sdui-tabs-footer-renderer.md
+++ b/.changeset/sdui-tabs-footer-renderer.md
@@ -1,0 +1,13 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+`TabsFooter` renderer is now legacy-faithful and supports active-index styling:
+
+- Renders each tab Node in an equal-width slot (`flex: 1` per tab), matching legacy `TabsFooterSnippetType1.styles.ts`.
+- Adds the top border + soft top-edge shadow from the legacy snippet so the footer reads as a pinned bottom navigation.
+- Reads `data.active_index` and overrides each tab Node's `data.active` flag accordingly — the inner `Tab` renderer (`creator.ui_component.tab`) already paints the active state via `data.active`, so the active tab gets the primary-color tint automatically.
+- `on_click` is dispatched per-tab via the existing Tab → `SduiNode` → `Clickable` chain — no extra wrapping layer here. Producers can therefore keep all per-tab navigation/state mutations on the Tab Node itself.
+- Active-index override is non-mutating: tabs without `active_index` keep their producer-supplied `data.active`.
+
+Designed to live inside the new `PageFeed` `data.footer` slot for the home page bottom-tabs use case.

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -34,7 +34,7 @@
     "build": "tsup && tsc --emitDeclarationOnly --noCheck",
     "dev": "tsup --watch",
     "lint": "eslint src/",
-    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/bottom-sheet/__tests__/*.test.ts src/snippets/_shared/__tests__/*.test.ts src/state/__tests__/*.test.ts src/snippets/Form/__tests__/*.test.ts src/sdui-node/__tests__/*.test.ts src/registries/__tests__/*.test.ts src/snippets/Steps/__tests__/*.test.ts"
+    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/bottom-sheet/__tests__/*.test.ts src/snippets/_shared/__tests__/*.test.ts src/state/__tests__/*.test.ts src/snippets/Form/__tests__/*.test.ts src/sdui-node/__tests__/*.test.ts src/registries/__tests__/*.test.ts src/snippets/Steps/__tests__/*.test.ts src/snippets/TabsFooter/__tests__/*.test.ts"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/sdui-runtime/src/snippets/TabsFooter/TabsFooter.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/TabsFooter/TabsFooter.renderer.tsx
@@ -1,10 +1,56 @@
 import React from "react";
+import { StyleSheet, View } from "react-native";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { TabsFooterSchema } from "@one-impression/sdk-native-sdui";
-import { Box, Stack } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
+import { applyActiveIndex } from "./applyActiveIndex.js";
 
+const styles = StyleSheet.create({
+  /**
+   * Top-level container — pinned-bottom row of tabs with a hairline top
+   * border and a soft top-edge shadow (matches legacy
+   * `TabsFooterSnippetType1.styles.ts` box shadow).
+   */
+  container: {
+    flexDirection: "row",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    backgroundColor: "#FFFFFF",
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: "#E0E0E0",
+    shadowColor: "rgba(0, 0, 0, 0.15)",
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 1,
+    shadowRadius: 4,
+    elevation: 4,
+  },
+  /**
+   * Each tab gets equal share of the row, matching legacy
+   * `styles.flexGrow: { flexGrow: 1 }`.
+   */
+  tabSlot: {
+    flex: 1,
+  },
+});
+
+/**
+ * TabsFooter — bottom navigation row.
+ *
+ * Renders an array of tab Nodes (each `creator.ui_component.tab`) as a
+ * horizontal flex row, with equal-width slots. Each tab Node is recursed
+ * through `<Interpreter />`, which means:
+ *
+ * - The tab's own `on_click` is dispatched via the Tab renderer's `SduiNode`
+ *   wrapper — no extra Clickable layer here.
+ * - The active-index tab is marked by overriding the child Node's
+ *   `data.active = true` (see {@link applyActiveIndex}). The Tab renderer
+ *   reads `data.active` and applies primary-color tint to icon + label.
+ *
+ * Legacy reference: `TabsFooterSnippetType1` in one_club_app. Legacy uses
+ * `useNavigationState` to discover the active tab from route params; we use
+ * the SDUI-native `active_index` field instead so layouts stay declarative.
+ */
 export function TabsFooterRenderer(node: Node): React.ReactElement {
   return (
     <SduiNode
@@ -18,15 +64,18 @@ export function TabsFooterRenderer(node: Node): React.ReactElement {
       view_events={node.view_events}
       load_events={node.load_events}
     >
-      {(v) => (
-        <Box borderTopWidth={1} borderColor="#E0E0E0">
-          <Stack direction="row" justify="space-around">
-            {v.items?.map((item: Node, i: number) => (
-              <Interpreter key={item.id || i} node={item} />
+      {(v) => {
+        const items = applyActiveIndex(v.items ?? [], v.active_index);
+        return (
+          <View style={styles.container}>
+            {items.map((item, i) => (
+              <View key={item.id || `tab-${i}`} style={styles.tabSlot}>
+                <Interpreter node={item} />
+              </View>
             ))}
-          </Stack>
-        </Box>
-      )}
+          </View>
+        );
+      }}
     </SduiNode>
   );
 }

--- a/packages/sdui-runtime/src/snippets/TabsFooter/__tests__/applyActiveIndex.test.ts
+++ b/packages/sdui-runtime/src/snippets/TabsFooter/__tests__/applyActiveIndex.test.ts
@@ -1,0 +1,79 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Node } from "@one-impression/sdk-native-sdui";
+import { applyActiveIndex } from "../applyActiveIndex.ts";
+
+function makeTab(id: string, active = false): Node {
+  return {
+    id,
+    type: "creator.ui_component.tab",
+    data: {
+      label: { text: id },
+      active,
+    },
+    on_click: { type: "navigate", payload: {} },
+  } as Node;
+}
+
+test("returns items unchanged when activeIndex is undefined", () => {
+  const items = [makeTab("a", true), makeTab("b")];
+  const out = applyActiveIndex(items, undefined);
+  assert.strictEqual(out, items);
+});
+
+test("marks the active-index tab as active and resets others", () => {
+  const items = [makeTab("a", true), makeTab("b"), makeTab("c")];
+  const out = applyActiveIndex(items, 1);
+
+  assert.equal(
+    (out[0].data as { active: boolean }).active,
+    false,
+    "previously active tab is reset",
+  );
+  assert.equal(
+    (out[1].data as { active: boolean }).active,
+    true,
+    "active_index tab is marked active",
+  );
+  assert.equal(
+    (out[2].data as { active: boolean }).active,
+    false,
+    "other tabs are inactive",
+  );
+});
+
+test("does not mutate input items", () => {
+  const items = [makeTab("a", true), makeTab("b")];
+  const before = JSON.stringify(items);
+  applyActiveIndex(items, 1);
+  assert.equal(JSON.stringify(items), before, "input untouched");
+});
+
+test("dispatches per-tab on_click (verified by interpreter — on_click is preserved on output)", () => {
+  const items = [makeTab("home"), makeTab("search")];
+  const out = applyActiveIndex(items, 1);
+  assert.ok(out[0].on_click, "home tab keeps on_click");
+  assert.ok(out[1].on_click, "search tab keeps on_click");
+});
+
+test("passes through Nodes whose data is not a plain object", () => {
+  // Defensive: producer ships a bogus tab — we must not crash.
+  const bogus = { id: "bogus", type: "creator.ui_component.tab", data: null } as unknown as Node;
+  const tab = makeTab("ok");
+  const out = applyActiveIndex([bogus, tab], 0);
+  assert.equal(out[0], bogus);
+  // tab at idx 1 isn't the active one
+  assert.equal((out[1].data as { active: boolean }).active, false);
+});
+
+test("handles empty items array", () => {
+  const out = applyActiveIndex([], 0);
+  assert.deepEqual(out, []);
+});
+
+test("activeIndex out of range marks all inactive", () => {
+  const items = [makeTab("a", true), makeTab("b", true)];
+  const out = applyActiveIndex(items, 99);
+  assert.equal((out[0].data as { active: boolean }).active, false);
+  assert.equal((out[1].data as { active: boolean }).active, false);
+});

--- a/packages/sdui-runtime/src/snippets/TabsFooter/applyActiveIndex.ts
+++ b/packages/sdui-runtime/src/snippets/TabsFooter/applyActiveIndex.ts
@@ -1,0 +1,34 @@
+import type { Node } from "@one-impression/sdk-native-sdui";
+
+/**
+ * Apply an `active_index` to a list of tab Nodes by overriding each Node's
+ * `data.active` flag.
+ *
+ * - The Node at `activeIndex` gets `data.active = true`.
+ * - All other Nodes get `data.active = false` so they reset to inactive
+ *   even if the producer pre-set them as active.
+ * - When `activeIndex` is `undefined`, items are returned unchanged so a
+ *   producer can opt out of selection management and rely on each tab's
+ *   own `data.active` value.
+ *
+ * Returns a new array of new Node objects — never mutates the inputs.
+ * Nodes with non-object `data` are passed through untouched.
+ */
+export function applyActiveIndex<T extends Node>(
+  items: T[],
+  activeIndex: number | undefined,
+): T[] {
+  if (activeIndex === undefined) return items;
+  return items.map((item, i) => {
+    if (!item || typeof item.data !== "object" || item.data === null) {
+      return item;
+    }
+    return {
+      ...item,
+      data: {
+        ...(item.data as Record<string, unknown>),
+        active: i === activeIndex,
+      },
+    } as T;
+  });
+}


### PR DESCRIPTION
## Summary

Brings the `TabsFooter` snippet (`creator.snippet.tabs_footer`) up to legacy parity with `TabsFooterSnippetType1` from the legacy app:

- Renders each tab Node in an equal-width slot (`flex: 1` per tab).
- Adds the top hairline border + soft top-edge box shadow from the legacy snippet so the footer reads as a pinned bottom navigation.
- Reads `data.active_index` and overrides each child tab Node's `data.active` flag — the inner `Tab` renderer (`creator.ui_component.tab`) already paints the active state via `data.active`, so the active tab gets the primary-color tint automatically.
- `on_click` is dispatched per-tab via the existing Tab → `SduiNode` → `Clickable` chain — no extra wrapping layer in `TabsFooter`.
- Active-index override is non-mutating; tabs without `active_index` keep their producer-supplied `data.active`.

The renderer was already registered for `creator.snippet.tabs_footer` — no registry changes needed.

## Why

The home page in Brief 264 ships a `tabs_footer` Node inside the new `PageFeed` `data.footer` slot (see [#177](https://github.com/One-Impression/amplify-design-system/pull/177)). The existing `TabsFooter` renderer was a placeholder that didn't:

- give each tab equal width
- support active-index selection
- apply the legacy top-edge shadow

This PR closes those gaps so home renders correctly without further patches.

## Notes

- `data.active_index` schema field already exists in `@one-impression/sdk-native-sdui` `TabsFooterSchema` (`active_index: z.number().int().optional()`), so no schema changes are required.
- The `applyActiveIndex` helper is factored out as a pure function so it can be unit-tested without a React Native runtime.

## Test plan

- [x] `npm run build -w packages/sdui-runtime` — clean tsup + tsc build
- [x] `npm test -w packages/sdui-runtime` — 7 new tests in `applyActiveIndex.test.ts` pass (pre-existing `branch.test.ts` / `compound.test.ts` / `bff-call.test.ts` / `set-local.test.ts` / `node-registry.test.ts` peer-dep failures unchanged — known issue)
- [ ] Manual: render a TabsFooter with 3 tabs, verify each renders in an equal-width slot
- [ ] Manual: set `data.active_index = 1`, verify middle tab gets primary tint and others reset
- [ ] Manual: tap an inactive tab, verify the tab's own `on_click` action dispatches