### PR TITLE
docs(zenith): update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,11 +51,19 @@ packages/
   tokens-brand/       — Brand Platform tokens (purple primary, light/dark themes)
   tokens-atmosphere/  — Atmosphere tokens (gold accent, dark-first themes)
   tokens-creator/     — Creator App tokens (SDUI mappings, mobile-optimized)
+    tokens/theme-light.json & theme-dark.json — sdui.color namespace includes:
+      gradient-home-start (#E2E7FE), gradient-home-mid-1 (#DEE2FE),
+      gradient-home-mid-2 (#EBF9FF), gradient-home-end (#FFFFFF)
+      Dark theme mirrors light values (home gradient is brand-fixed, not dark-mode-inverted).
+      CSS vars: --amp-creator-sdui-color-gradient-home-{start,mid-1,mid-2,end}
+      Native (camelCase): gradientHomeStart, gradientHomeMid1, gradientHomeMid2, gradientHomeEnd
   ui/                 — Shared React components (Button, Badge, Card, EmptyState, Skeleton)
   storybook/          — Component documentation and visual testing
   eslint-config/      — Design system lint rules (no-hardcoded-colors, no-raw-spacing, prefer-token-import)
   feature-flags/      — Feature flag utilities
 ```
+
+**Pattern**: When a consumer hardcodes raw hex literals for a repeating UI motif (e.g. page background gradients), promote the values to named tokens in `tokens-creator` (both `theme-light.json` and `theme-dark.json`) so brand cascades and theme switching work correctly. Do not add new primitives to `tokens-foundation` unless the value is truly theme-agnostic.
 
 ## Token File Format
 


### PR DESCRIPTION
## Summary
- **Trigger:** commit `44895cc`
- **File updated:** `CLAUDE.md`
- **Confidence:** 🟡 0.63
- **Reason:** New named design tokens (`gradientHomeStart/Mid1/Mid2/End`) are added to the token system, which engineers consuming or extending the design system need to know about — specifically their token names, emitted CSS variables, and the pattern of promoting raw hex literals to named tokens for brand/theme-awareness.

This is an automated documentation update by Zenith. Needs human review.

---
Generated by [Zenith AI CTO](https://github.com/one-impression/zenith-coding-agent)