### PR TITLE
fix(changesets): only bump peer-dependents when out of range

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,6 +10,9 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": [
     "@one-impression/storybook",
     "@one-impression/templates",


### PR DESCRIPTION
## Summary
Adds `onlyUpdatePeerDependentsWhenOutOfRange: true` to the Changesets config — the same guard `amplify-schemas` already uses.

## Why
`sdui-runtime` and `ui-native` both declare `@one-impression/tokens-creator: ">=3.0.0"` as a **peerDependency**. Changesets' default behavior MAJOR-bumps every peer-dependent on *any* peer-dep version change — even when the new version still satisfies the dependent's range.

Concretely, the pending release showed:
- `tokens-creator`: 3.0.0 → 3.1.0 (minor — correct, a new additive gradient token)
- `sdui-runtime`: 2.2.0 → **3.0.0** (false major — only had patch changesets)
- `ui-native`: 2.0.2 → **3.0.0** (false major — had *no* changeset at all)

3.1.0 still satisfies `>=3.0.0`, so neither consumer is actually broken. Without this guard, **every additive token release would burn a major version across the entire design system** — unsustainable.

With the guard, peer-dependents only bump when the new peer version falls *outside* their declared range. After this lands, re-running the release produces honest bumps:
- `tokens-creator` → 3.1.0 (minor)
- `sdui-runtime` → 2.2.1 (patch, from its own changesets)
- `ui-native` → no bump

## Test plan
- [x] `config.json` is valid JSON
- [ ] Re-run publish workflow after merge → Version PR shows corrected (non-major) bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)