### PR TITLE
fix(sdui-runtime): read flat label, resolve bff_call via EndpointPaths, lock sdk peer-dep

### DIFF
--- a/.changeset/sdui-runtime-wire-contract.md
+++ b/.changeset/sdui-runtime-wire-contract.md
@@ -1,0 +1,14 @@
+---
+"@one-impression/sdui-runtime": minor
+---
+
+fix(sdui-runtime): read flat label, resolve bff_call via EndpointPaths, lock sdk peer-dep
+
+Align the runtime with the `@one-impression/sdk-native-sdui` wire contract (the source of truth), fixing two on-device home-page crashes and closing the version gap that let the drift go uncaught:
+
+- **Flat label reads (crash fix):** the `label` (and `subtitle`) fields are declared as a flat `TextSchema` (`{ text, ... }`), but the `Tab`, `Tag`, `Chip`, `Checkbox`, `Radio`, `SelectableItem`, and `Input` ui_component renderers read them as nested nodes (`v.label.data.text`), throwing "Cannot read property 'text' of undefined". They now read `v.label.text` / `v.subtitle.text`.
+- **bff_call endpoint resolution (404 fix):** `bff_call` previously treated the logical endpoint id (e.g. `creator.home.tab`) as a literal path, requesting `/creator.home.tab`. It now resolves the id through `EndpointPaths` (id → `/v1/...`), substitutes path params into the resolved path, trims a trailing slash off the base URL to avoid a double slash, and throws if an id is unregistered.
+- **Peer-dep tightened:** `@one-impression/sdk-native-sdui` peerDependency raised from `>=1.0.0` to `^2.6.0` (the contract version that ships `EndpointPaths`), so this whole class of schema/renderer drift surfaces at install time instead of on the simulator. Added as a devDependency at `^2.6.0` so the `EndpointPaths` import resolves at build/test time.
+- **Anti-regression test:** added an emit→render contract test that round-trips the home node set against their `sdk-native-sdui` schemas and asserts `tab`/`chip`/`tag`/`info_breakdown_row` built nodes expose a flat `data.label.text` (not `data.label.data`).
+
+Bump level is `minor`: the renderer and resolver changes are behavior fixes, and the peer-dependency range change is the notable surface (per this repo's feat=minor convention; consumers already on a 2.x sdk are unaffected).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,13 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          registry-url: https://npm.pkg.github.com
+          scope: '@one-impression'
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build token packages
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1036,6 +1036,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1053,6 +1054,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1070,6 +1072,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1087,6 +1090,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1104,6 +1108,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1121,6 +1126,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1138,6 +1144,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1155,6 +1162,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1172,6 +1180,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1189,6 +1198,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1206,6 +1216,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1223,6 +1234,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1240,6 +1252,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1257,6 +1270,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1274,6 +1288,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1291,6 +1306,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1308,6 +1324,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1325,6 +1342,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1342,6 +1360,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1359,6 +1378,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1376,6 +1396,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1393,6 +1414,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1410,6 +1432,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1427,6 +1450,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1444,6 +1468,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1461,6 +1486,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2591,6 +2617,15 @@
     "node_modules/@one-impression/mcp-server": {
       "resolved": "packages/mcp-server",
       "link": true
+    },
+    "node_modules/@one-impression/sdk-native-sdui": {
+      "version": "2.6.0",
+      "resolved": "https://npm.pkg.github.com/download/@one-impression/sdk-native-sdui/2.6.0/dfb2b1f447758cc0f89bcf3bba653e6f89b92186",
+      "integrity": "sha512-x44vMfLAiZt+bKVQwcHMN485mPD4wDSHSST4zNWRBkhx527wkguXsQQ6D2Qam5eJu8VQQflptAGy2BxIpmVmjQ==",
+      "dev": true,
+      "dependencies": {
+        "zod": "^3.23.0"
+      }
     },
     "node_modules/@one-impression/sdui-runtime": {
       "resolved": "packages/sdui-runtime",
@@ -11386,6 +11421,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11403,6 +11439,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11420,6 +11457,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11437,6 +11475,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11454,6 +11493,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11471,6 +11511,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11488,6 +11529,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11505,6 +11547,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11522,6 +11565,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11539,6 +11583,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11556,6 +11601,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11573,6 +11619,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11590,6 +11637,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11607,6 +11655,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11624,6 +11673,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11641,6 +11691,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11658,6 +11709,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11675,6 +11727,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11692,6 +11745,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11709,6 +11763,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11726,6 +11781,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11743,6 +11799,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11760,6 +11817,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11777,6 +11835,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11794,6 +11853,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11811,6 +11871,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13740,7 +13801,7 @@
     },
     "packages/brand-hexcoded": {
       "name": "@one-impression/brand-hexcoded",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "packages/brand-oportunities": {
       "name": "@one-impression/brand-oportunities",
@@ -13783,21 +13844,22 @@
     },
     "packages/sdui-runtime": {
       "name": "@one-impression/sdui-runtime",
-      "version": "2.0.0",
+      "version": "2.2.1",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "zod": "^3.22.0",
         "zustand": "^4.5.0"
       },
       "devDependencies": {
+        "@one-impression/sdk-native-sdui": "^2.6.0",
         "tsup": "^8.0.0",
         "typescript": "^5.5.0"
       },
       "peerDependencies": {
         "@gorhom/bottom-sheet": "^5.0.0",
-        "@one-impression/sdk-native-sdui": ">=1.0.0",
+        "@one-impression/sdk-native-sdui": "^2.6.0",
         "@one-impression/tokens-creator": ">=3.0.0",
-        "@one-impression/ui-native": ">=2.0.0",
+        "@one-impression/ui-native": ">=2.0.2",
         "react": ">=18.0.0",
         "react-native": ">=0.72.0",
         "react-native-webview": ">=13.0.0"
@@ -13888,7 +13950,7 @@
     },
     "packages/tokens-creator": {
       "name": "@one-impression/tokens-creator",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dependencies": {
         "@one-impression/tokens-foundation": "^3.0.0"
       },
@@ -13905,7 +13967,7 @@
     },
     "packages/tokens-hexcoded": {
       "name": "@one-impression/tokens-hexcoded",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@one-impression/tokens-foundation": "^3.0.0"
       },
@@ -13966,7 +14028,7 @@
     },
     "packages/ui-native": {
       "name": "@one-impression/ui-native",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "devDependencies": {
         "@types/react": "^18.2.0",
         "tsup": "^8.0.0",

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -34,12 +34,12 @@
     "build": "tsup && tsc --emitDeclarationOnly --noCheck",
     "dev": "tsup --watch",
     "lint": "eslint src/",
-    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/bottom-sheet/__tests__/*.test.ts src/snippets/_shared/__tests__/*.test.ts src/state/__tests__/*.test.ts src/snippets/Form/__tests__/*.test.ts src/sdui-node/__tests__/*.test.ts src/registries/__tests__/*.test.ts src/snippets/Steps/__tests__/*.test.ts src/pages/PageFeed/__tests__/*.test.ts src/snippets/TabsFooter/__tests__/*.test.ts"
+    "test": "tsx --test src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/bottom-sheet/__tests__/*.test.ts src/snippets/_shared/__tests__/*.test.ts src/state/__tests__/*.test.ts src/snippets/Form/__tests__/*.test.ts src/sdui-node/__tests__/*.test.ts src/registries/__tests__/*.test.ts src/snippets/Steps/__tests__/*.test.ts src/pages/PageFeed/__tests__/*.test.ts src/snippets/TabsFooter/__tests__/*.test.ts src/__tests__/*.test.ts"
   },
   "peerDependencies": {
     "react": ">=18.0.0",
     "react-native": ">=0.72.0",
-    "@one-impression/sdk-native-sdui": ">=1.0.0",
+    "@one-impression/sdk-native-sdui": "^2.6.0",
     "@one-impression/ui-native": ">=2.0.2",
     "@one-impression/tokens-creator": ">=3.0.0",
     "@gorhom/bottom-sheet": "^5.0.0",
@@ -62,6 +62,7 @@
     }
   },
   "devDependencies": {
+    "@one-impression/sdk-native-sdui": "^2.6.0",
     "tsup": "^8.0.0",
     "typescript": "^5.5.0"
   },

--- a/packages/sdui-runtime/src/__tests__/emit-render-contract.test.ts
+++ b/packages/sdui-runtime/src/__tests__/emit-render-contract.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Emit→render contract test (CR-WF3).
+ *
+ * Catches builder↔renderer drift in CI instead of on the simulator. The gateway
+ * BFF builds SDUI wire payloads with `@one-impression/sdk-native-sdui` builders;
+ * the runtime renderers in this package read fields off those built shapes. When
+ * the two disagree (e.g. a renderer reads `data.label.data.text` while the schema
+ * declares `data.label` as a flat `TextSchema`), the home page crashes on-device.
+ *
+ * Scope (pragmatic — the SDUI node types the home page uses): for each home node
+ * type we (a) build a node via the sdk-native-sdui builder, (b) assert it parses
+ * against its sdk-native-sdui schema (round-trip), and (c) for the label-bearing
+ * components assert the exact field the renderer reads exists on the built shape —
+ * specifically that `data.label` is a flat `TextSchema` (`data.label.text` is a
+ * string) and NOT a nested node (`data.label.data` must be undefined).
+ *
+ * NOTE: this is intentionally a contract/shape test, not a full render harness.
+ * The renderers import `@one-impression/ui-native` (React Native), which the
+ * `node:test` + esbuild runner cannot transform, so we cannot mount renderers
+ * here. This test should expand to per-renderer field coverage (e.g. via a
+ * jsdom/RN preset) for the remaining node types; today it locks the label-shape
+ * regression (FIX 1) plus a schema round-trip for the full home node set.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  // builders
+  tab,
+  chip,
+  tagComponent,
+  card,
+  section,
+  loader,
+  pageHeader,
+  groupChips,
+  infoRow,
+  bannerImage,
+  infoBreakdownRow,
+  emptyState,
+  tabsFooter,
+  pageFeed,
+  // schemas
+  TabComponentSchema,
+  ChipComponentSchema,
+  TagComponentSchema,
+  CardComponentSchema,
+  SectionComponentSchema,
+  LoaderSchema,
+  PageHeaderSchema,
+  GroupChipsSchema,
+  InfoRowSchema,
+  BannerImageSchema,
+  InfoBreakdownRowSchema,
+  EmptyStateSchema,
+  TabsFooterSchema,
+  PageSchema,
+} from "@one-impression/sdk-native-sdui";
+
+// ---------------------------------------------------------------------------
+// (b) Schema round-trip — every home node builder emits a shape that parses
+// against its own schema. If a builder drifts from its schema, this fails.
+// ---------------------------------------------------------------------------
+
+test("contract: home node builders round-trip through their schemas", () => {
+  const builtTab = tab({ label: { text: "Explore" } });
+  assert.equal(TabComponentSchema.safeParse(builtTab).success, true);
+
+  const builtChip = chip({ label: { text: "All" } });
+  assert.equal(ChipComponentSchema.safeParse(builtChip).success, true);
+
+  const builtTag = tagComponent({ label: { text: "New" } });
+  assert.equal(TagComponentSchema.safeParse(builtTag).success, true);
+
+  const builtSection = section({ items: [builtChip] });
+  assert.equal(SectionComponentSchema.safeParse(builtSection).success, true);
+
+  const builtCard = card({ items: [builtTag] });
+  assert.equal(CardComponentSchema.safeParse(builtCard).success, true);
+
+  const builtLoader = loader({ variant: "circular" });
+  assert.equal(LoaderSchema.safeParse(builtLoader).success, true);
+
+  const builtHeader = pageHeader({ title: { text: "Home" } });
+  assert.equal(PageHeaderSchema.safeParse(builtHeader).success, true);
+
+  const builtGroupChips = groupChips({ items: [builtChip] });
+  assert.equal(GroupChipsSchema.safeParse(builtGroupChips).success, true);
+
+  const builtInfoRow = infoRow({ title: { text: "Earnings" } });
+  assert.equal(InfoRowSchema.safeParse(builtInfoRow).success, true);
+
+  const builtBanner = bannerImage({ image: { src: "https://x/y.png" } });
+  assert.equal(BannerImageSchema.safeParse(builtBanner).success, true);
+
+  const builtBreakdown = infoBreakdownRow({
+    label: { text: "Total" },
+    value: { text: "$100" },
+  });
+  assert.equal(InfoBreakdownRowSchema.safeParse(builtBreakdown).success, true);
+
+  const builtEmpty = emptyState({ title: { text: "Nothing here" } });
+  assert.equal(EmptyStateSchema.safeParse(builtEmpty).success, true);
+
+  const builtTabsFooter = tabsFooter({ items: [builtTab] });
+  assert.equal(TabsFooterSchema.safeParse(builtTabsFooter).success, true);
+});
+
+test("contract: page envelope (feed) round-trips through PageSchema", () => {
+  const response = pageFeed({ id: "home", title: "Home" })
+    .body(section({ items: [chip({ label: { text: "All" } })] }))
+    .build();
+  // The envelope the runtime renders is response.page.
+  assert.equal(PageSchema.safeParse(response.page).success, true);
+});
+
+// ---------------------------------------------------------------------------
+// (c) Label-shape regression (FIX 1) — the renderers read `v.label.text`.
+// The schema declares `data.label` as a flat `TextSchema` ({ text, ... }), so
+// the built node MUST expose `data.label.text` as a string and MUST NOT nest
+// it under `data.label.data` (the old, crashing assumption).
+// ---------------------------------------------------------------------------
+
+test("contract: tab/chip/tag emit a FLAT data.label (label.text, NOT label.data)", () => {
+  const builtTab = tab({ label: { text: "Explore" } });
+  const builtChip = chip({ label: { text: "All" } });
+  const builtTag = tagComponent({ label: { text: "New" } });
+
+  for (const [name, node] of [
+    ["tab", builtTab],
+    ["chip", builtChip],
+    ["tag", builtTag],
+  ] as const) {
+    const label = (node.data as { label: unknown }).label as Record<string, unknown>;
+    assert.equal(
+      typeof label.text,
+      "string",
+      `${name}: data.label.text must be a string (flat TextSchema)`,
+    );
+    assert.equal(
+      "data" in label,
+      false,
+      `${name}: data.label must be flat — it must NOT have a nested .data (renderers read v.label.text)`,
+    );
+  }
+});
+
+test("contract: infoBreakdownRow emits flat data.label and data.value", () => {
+  const node = infoBreakdownRow({ label: { text: "Total" }, value: { text: "$100" } });
+  const data = node.data as { label: Record<string, unknown>; value: Record<string, unknown> };
+  assert.equal(typeof data.label.text, "string");
+  assert.equal("data" in data.label, false);
+  assert.equal(typeof data.value.text, "string");
+  assert.equal("data" in data.value, false);
+});

--- a/packages/sdui-runtime/src/__tests__/emit-render-contract.test.ts
+++ b/packages/sdui-runtime/src/__tests__/emit-render-contract.test.ts
@@ -1,5 +1,5 @@
 /**
- * Emit→render contract test (CR-WF3).
+ * Emit→render contract test.
  *
  * Catches builder↔renderer drift in CI instead of on the simulator. The gateway
  * BFF builds SDUI wire payloads with `@one-impression/sdk-native-sdui` builders;

--- a/packages/sdui-runtime/src/action-engine/handlers/__tests__/bff-call.test.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/__tests__/bff-call.test.ts
@@ -251,6 +251,19 @@ test("bff_call — substitutes path params into the resolved path", async () => 
   assert.equal(capturedUrl, "https://bff.example.test/v1/creator/campaigns/abc-123");
 });
 
+test("bff_call — throws on an unsubstituted path param (template declares {id}, action omits it)", async () => {
+  installFetch(async () => jsonResponse({ ok: true }));
+  // creator.campaigns.detail → /v1/creator/campaigns/{id}; no path_params supplied.
+  await assert.rejects(
+    handleBffCall(
+      bffAction({ method: "GET", endpoint: "creator.campaigns.detail" }),
+      noopConfig,
+      makeSpyEngine(),
+    ),
+    /unsubstituted path param \{id\}/,
+  );
+});
+
 test("bff_call — appends query params to the resolved path", async () => {
   let capturedUrl: string | undefined;
   installFetch(async (input) => {

--- a/packages/sdui-runtime/src/action-engine/handlers/__tests__/bff-call.test.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/__tests__/bff-call.test.ts
@@ -211,6 +211,78 @@ test("bff_call — prod BFF + devIdentity set → no X-Dev-Identity header (defe
   }
 });
 
+// ---------------------------------------------------------------------------
+// URL resolution (FIX 2): the endpoint id is a LOGICAL id, not a path. It must
+// be resolved through EndpointPaths (id → "/v1/..."), with no double slash and
+// path-param substitution applied to the resolved path.
+// ---------------------------------------------------------------------------
+
+test("bff_call — resolves logical endpoint id to its path via EndpointPaths (no double slash)", async () => {
+  let capturedUrl: string | undefined;
+  installFetch(async (input) => {
+    capturedUrl = input as string;
+    return jsonResponse({ ok: true });
+  });
+  // creator.events.track → /v1/creator/events/track
+  await handleBffCall(
+    bffAction({ endpoint: "creator.events.track" }),
+    noopConfig,
+    makeSpyEngine(),
+  );
+  assert.equal(capturedUrl, "https://bff.example.test/v1/creator/events/track");
+});
+
+test("bff_call — substitutes path params into the resolved path", async () => {
+  let capturedUrl: string | undefined;
+  installFetch(async (input) => {
+    capturedUrl = input as string;
+    return jsonResponse({ ok: true });
+  });
+  // creator.campaigns.detail → /v1/creator/campaigns/{id}
+  await handleBffCall(
+    bffAction({
+      method: "GET",
+      endpoint: "creator.campaigns.detail",
+      path_params: { id: "abc-123" },
+    }),
+    noopConfig,
+    makeSpyEngine(),
+  );
+  assert.equal(capturedUrl, "https://bff.example.test/v1/creator/campaigns/abc-123");
+});
+
+test("bff_call — appends query params to the resolved path", async () => {
+  let capturedUrl: string | undefined;
+  installFetch(async (input) => {
+    capturedUrl = input as string;
+    return jsonResponse({ ok: true });
+  });
+  await handleBffCall(
+    bffAction({
+      method: "GET",
+      endpoint: "creator.campaigns.list",
+      query_params: { status: "open" },
+    }),
+    noopConfig,
+    makeSpyEngine(),
+  );
+  assert.equal(capturedUrl, "https://bff.example.test/v1/creator/campaigns?status=open");
+});
+
+test("bff_call — trims a trailing slash off bffBaseUrl (no double slash)", async () => {
+  let capturedUrl: string | undefined;
+  installFetch(async (input) => {
+    capturedUrl = input as string;
+    return jsonResponse({ ok: true });
+  });
+  await handleBffCall(
+    bffAction({ endpoint: "creator.events.track" }),
+    { ...noopConfig, bffBaseUrl: "https://bff.example.test/" },
+    makeSpyEngine(),
+  );
+  assert.equal(capturedUrl, "https://bff.example.test/v1/creator/events/track");
+});
+
 test("bff_call — 200 with body.action and on_success — both dispatched in order, with telemetry between", async () => {
   installFetch(async () =>
     jsonResponse({

--- a/packages/sdui-runtime/src/action-engine/handlers/bff-call.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/bff-call.ts
@@ -1,4 +1,4 @@
-import { BffCallPayloadSchema } from "@one-impression/sdk-native-sdui";
+import { BffCallPayloadSchema, EndpointPaths } from "@one-impression/sdk-native-sdui";
 import type { Action } from "@one-impression/sdk-native-sdui";
 import type { ActionEngineConfig, ActionEngine } from "../types.js";
 import { useDevConfigStore } from "../../state/useDevConfigStore.js";
@@ -23,16 +23,29 @@ export async function handleBffCall(
 ): Promise<void> {
   const payload = BffCallPayloadSchema.parse(action.payload);
 
-  // Build the URL, substituting path params.
-  let endpointPath = payload.endpoint as string;
+  // Resolve the logical endpoint id (e.g. "creator.home.tab") to its request
+  // path (e.g. "/v1/creator/home/tab") via the EndpointPaths map — the single
+  // source of truth shared with the gateway. The id is NOT a path; treating it
+  // as one would request "/creator.home.tab" and 404.
+  const path = EndpointPaths[payload.endpoint];
+  if (!path) {
+    // Should never happen — endpoint is a typed EndpointId. Fail loudly rather
+    // than silently constructing a wrong URL.
+    throw new Error(`bff_call: no path registered for endpoint id "${payload.endpoint}"`);
+  }
+
+  // Substitute path params into the resolved path (e.g. "/v1/.../{id}").
+  let endpointPath = path;
   if (payload.path_params) {
     for (const [key, value] of Object.entries(payload.path_params)) {
       endpointPath = endpointPath.replace(`{${key}}`, encodeURIComponent(value));
     }
   }
 
-  // Build query string.
-  let url = `${config.bffBaseUrl}/${endpointPath}`;
+  // Build query string. The resolved path has a leading slash; trim a trailing
+  // slash off bffBaseUrl to avoid a double slash.
+  const base = config.bffBaseUrl.replace(/\/$/, "");
+  let url = `${base}${endpointPath}`;
   if (payload.query_params) {
     const qs = new URLSearchParams(payload.query_params).toString();
     if (qs) url += `?${qs}`;

--- a/packages/sdui-runtime/src/action-engine/handlers/bff-call.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/bff-call.ts
@@ -42,6 +42,17 @@ export async function handleBffCall(
     }
   }
 
+  // Fail loudly on any path param the template declared but the action didn't
+  // supply — otherwise a literal "{id}" would be sent and the server would
+  // 404/400 with no useful client signal. Same posture as the unregistered-id
+  // guard above.
+  const unsubstituted = endpointPath.match(/\{[^}]+\}/);
+  if (unsubstituted) {
+    throw new Error(
+      `bff_call: unsubstituted path param ${unsubstituted[0]} in "${path}" for endpoint "${payload.endpoint}"`,
+    );
+  }
+
   // Build query string. The resolved path has a leading slash; trim a trailing
   // slash off bffBaseUrl to avoid a double slash.
   const base = config.bffBaseUrl.replace(/\/$/, "");

--- a/packages/sdui-runtime/src/ui_components/Checkbox/Checkbox.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Checkbox/Checkbox.renderer.tsx
@@ -22,7 +22,7 @@ export function CheckboxRenderer(node: Node): React.ReactElement {
         <DSCheckbox
           checked={v.checked}
           disabled={v.disabled}
-          label={v.label ? v.label.data.text : undefined}
+          label={v.label ? v.label.text : undefined}
         />
       )}
     </SduiNode>

--- a/packages/sdui-runtime/src/ui_components/Chip/Chip.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Chip/Chip.renderer.tsx
@@ -20,7 +20,7 @@ export function ChipRenderer(node: Node): React.ReactElement {
     >
       {(v) => (
         <DSChip
-          label={v.label.data.text}
+          label={v.label.text}
           selected={v.selected}
           disabled={v.disabled}
           icon={v.icon ? <Interpreter node={v.icon} /> : undefined}

--- a/packages/sdui-runtime/src/ui_components/Input/Input.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Input/Input.renderer.tsx
@@ -88,7 +88,7 @@ function InputInner({
       placeholder={v.placeholder}
       value={localValue}
       onChangeText={handleChangeText}
-      label={v.label ? v.label.data.text : undefined}
+      label={v.label ? v.label.text : undefined}
       disabled={v.disabled}
       maxLength={v.max_length}
       multiline={v.multiline}

--- a/packages/sdui-runtime/src/ui_components/Radio/Radio.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Radio/Radio.renderer.tsx
@@ -22,7 +22,7 @@ export function RadioRenderer(node: Node): React.ReactElement {
         <DSRadio
           selected={v.selected}
           disabled={v.disabled}
-          label={v.label ? v.label.data.text : undefined}
+          label={v.label ? v.label.text : undefined}
         />
       )}
     </SduiNode>

--- a/packages/sdui-runtime/src/ui_components/SelectableItem/SelectableItem.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/SelectableItem/SelectableItem.renderer.tsx
@@ -20,8 +20,8 @@ export function SelectableItemRenderer(node: Node): React.ReactElement {
     >
       {(v) => (
         <DSSelectableItem
-          label={v.label.data.text}
-          description={v.subtitle ? v.subtitle.data.text : undefined}
+          label={v.label.text}
+          description={v.subtitle ? v.subtitle.text : undefined}
           selected={v.selected}
           disabled={v.disabled}
           leading={

--- a/packages/sdui-runtime/src/ui_components/Tab/Tab.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Tab/Tab.renderer.tsx
@@ -20,7 +20,7 @@ export function TabRenderer(node: Node): React.ReactElement {
     >
       {(v) => (
         <DSTab
-          label={v.label.data.text}
+          label={v.label.text}
           active={v.active}
           icon={v.icon ? <Interpreter node={v.icon} /> : undefined}
         />

--- a/packages/sdui-runtime/src/ui_components/Tag/Tag.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Tag/Tag.renderer.tsx
@@ -20,7 +20,7 @@ export function TagRenderer(node: Node): React.ReactElement {
     >
       {(v) => (
         <DSTag
-          label={v.label.data.text}
+          label={v.label.text}
           variant={v.variant ?? "default"}
           icon={v.icon ? <Interpreter node={v.icon} /> : undefined}
         />


### PR DESCRIPTION
## Summary

Aligns `@one-impression/sdui-runtime` with the `@one-impression/sdk-native-sdui` wire contract (the source of truth), fixing two on-device home-page crashes and closing the version gap that let the drift go uncaught.

- **FIX 1 — flat label reads (crash):** `label`/`subtitle` are declared as flat `TextSchema` (`{ text, ... }`), but 7 ui_component renderers read them as nested nodes (`v.label.data.text`), throwing "Cannot read property 'text' of undefined". Now read `v.label.text` / `v.subtitle.text`. Files: `Tab`, `Tag`, `Chip`, `Checkbox`, `Radio`, `SelectableItem`, `Input` renderers (and `SelectableItem` subtitle).
- **FIX 2 — bff_call endpoint resolution (404):** the logical endpoint id (e.g. `creator.home.tab`) was treated as a literal path → `/creator.home.tab` → 404. Now resolved through `EndpointPaths` (id → `/v1/...`), with path-param substitution on the resolved path, a trailing-slash trim on the base URL to avoid a double slash, and a loud throw if an id is unregistered.
- **FIX 3 — peer-dep lock:** `@one-impression/sdk-native-sdui` peerDependency raised `>=1.0.0` → `^2.6.0` (the version that ships `EndpointPaths`); added as a devDependency at `^2.6.0` so the import resolves at build/test time. This surfaces schema/renderer drift at install instead of on the simulator.
- **FIX 4 — anti-regression:** new emit→render contract test round-trips the home node set against their `sdk-native-sdui` schemas and asserts `tab`/`chip`/`tag`/`info_breakdown_row` built nodes expose a flat `data.label.text` (NOT `data.label.data`). Plus 4 new `bff_call` URL-resolution tests.

Changeset: `minor` for `@one-impression/sdui-runtime`.

## Test plan

- [x] `npm run build` (tsup + tsc) — 0 errors
- [x] `npm test` — 137/138 pass; the 1 failure (`node-registry.test.ts`) is a pre-existing RN-transform issue in the test harness, unrelated to this change (confirmed failing on clean `origin/main`)
- [x] New `emit-render-contract` test (4 cases) green
- [x] New `bff_call` URL-resolution tests (4 cases) green
- [ ] On-device home page renders + tab/chip taps hit the correct BFF paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)