### PR TITLE
ci: cross-repo read:packages PAT for npm ci (unblocks sdui-runtime publish)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # sdk-native-sdui lives in a different repo (amplify-schemas); the
+          # default GITHUB_TOKEN can't read its private GitHub Packages, so
+          # prefer a fine-grained read:packages PAT (NPM_AUTH_TOKEN) when set.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Build token packages
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,12 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          # sdui-runtime now depends on @one-impression/sdk-native-sdui, which
+          # lives in a DIFFERENT repo (amplify-schemas). The default
+          # GITHUB_TOKEN can't read another repo's private GitHub Packages, so
+          # prefer a fine-grained read:packages PAT (NPM_AUTH_TOKEN) when set.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Build packages
         run: |


### PR DESCRIPTION
## Why
`sdui-runtime` now has a real dependency on `@one-impression/sdk-native-sdui` (the `EndpointPaths` resolver), which is published from **amplify-schemas**, a different repo. The default `GITHUB_TOKEN` cannot read another repo's private GitHub Packages, so `npm ci` in both the CI build job and the Changesets release/publish job now 401s — which blocked the sdui-runtime publish (the release job died before opening the Version PR).

## What
Mirrors amplify-gateway's established pattern: the install steps prefer a fine-grained `read:packages` PAT (`secrets.NPM_AUTH_TOKEN`) and fall back to `GITHUB_TOKEN`.

- `publish.yml` — Release (Changesets) install step
- `ci.yml` — Build & Validate Tokens install step

## ⚠️ Required before this works
Add an **`NPM_AUTH_TOKEN`** secret to this repo (or org-scope it) — a fine-grained PAT with `read:packages` on the org. amplify-gateway already has exactly this secret; the same token works here. Until the secret exists, the fallback keeps current behavior (GITHUB_TOKEN), so this PR is safe to merge but the publish stays blocked until the secret is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)