### PR TITLE
fix(sdui-runtime): home BC renderer bugs + optimistic tab-bar active state

### DIFF
--- a/.changeset/sdui-runtime-home-bc-renderer-bugs.md
+++ b/.changeset/sdui-runtime-home-bc-renderer-bugs.md
@@ -2,9 +2,9 @@
 "@one-impression/sdui-runtime": patch
 ---
 
-fix(sdui-runtime): home BC renderer bugs — Tab icon + tap dispatch, InfoRow flat status_tag label
+fix(sdui-runtime): home BC renderer fixes — Tab icon + tap dispatch, InfoRow flat status_tag label, optimistic tab-bar active state
 
-Two renderer-level bugs found by on-device E2E of the home BC against `sdk-native-sdui@^2.6.0`. Each broke a visible piece of the home page; both are caught by `SduiErrorBoundary` so they render as fallback boxes rather than crash the screen.
+Renderer-level bugs and a UX gap found by on-device E2E of the home BC against `sdk-native-sdui@^2.6.0`. Visible bugs are caught by `SduiErrorBoundary` so they render as fallback boxes rather than crash the screen.
 
 - **`TabRenderer` — icon crash.** The renderer wrapped `v.icon` in `<Interpreter node={v.icon} />`, but `icon` is a flat `IconSchema` (`{ name, size?, color? }`), not an SDUI node — so `Interpreter` called `resolveRenderer(undefined)` and crashed on `.startsWith()`. The footer's 3 tabs rendered as fallback boxes. Fix: render `<DSIcon name={v.icon.name} size={v.icon.size} color={v.icon.color} />`, matching the established pattern in `ChipRenderer`, `PageHeader`, `InfoIconRow`, and 6 other renderers that consume `IconSchema`.
 
@@ -12,4 +12,6 @@ Two renderer-level bugs found by on-device E2E of the home BC against `sdk-nativ
 
 - **`InfoRow` — status_tag label flat-text bug.** The renderer passed the whole `v.status_tag.label` object to `DSTag.label`, but `status_tag.label` is a flat `TextSchema` (`{ text, color?, font_size?, font_weight? }`), not a string. React rendered it as a child and threw "Objects are not valid as a React child (found: object with keys {text})." Every `info_row` on the home Explore feed rendered as a fallback box (no title/subtitle/status tag). Fix: `label={v.status_tag.label.text}`, same pattern title/subtitle/badge already use in this renderer.
 
-Verified on iPhone 15 Pro simulator: footer tabs render with correct labels and the active-underline indicator, tapping a tab fires the BFF's `on_click` and the gateway's `replace_section` action is applied, and campaign cards render full title / subtitle / status tag.
+- **Tab-bar optimistic active state.** "Which tab is highlighted" is intrinsically a client-UI concern: the user just touched the button, the indicator should follow the finger — not wait for the BFF round-trip that loads the new tab's content. Previously the active indicator was driven only by `data.active_index` from the server, which meant every tab switch had a perceptible lag (the highlight only moved once the new tab's `replace_section` response arrived). Fix: added a generic `TabBarActiveContext` (exported from `state/`) that a parent tab-bar renderer provides and child Tabs consume. `TabsFooterRenderer` now owns a `useState<string | null>` for the optimistic active tab id and provides it; `TabRenderer` updates it on press *before* dispatching `on_click`. The effective active index is `local override ?? data.active_index` — the server still seeds selection at mount and can drive it via re-renders, but the local override wins until the next tap. Zero wire cost, zero gateway changes, no remount of the footer. Reusable for future tab bars (top tabs, segmented controls, etc.) since the context is generic.
+
+Verified on iPhone 15 Pro simulator: footer tabs render with correct labels, tapping a tab flips the active indicator **instantly** (no round-trip wait) while the BFF's `on_click` fires asynchronously and the gateway's `replace_section` action swaps the page sections, and campaign cards render full title / subtitle / status tag.

--- a/.changeset/sdui-runtime-home-bc-renderer-bugs.md
+++ b/.changeset/sdui-runtime-home-bc-renderer-bugs.md
@@ -1,0 +1,15 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+fix(sdui-runtime): home BC renderer bugs — Tab icon + tap dispatch, InfoRow flat status_tag label
+
+Two renderer-level bugs found by on-device E2E of the home BC against `sdk-native-sdui@^2.6.0`. Each broke a visible piece of the home page; both are caught by `SduiErrorBoundary` so they render as fallback boxes rather than crash the screen.
+
+- **`TabRenderer` — icon crash.** The renderer wrapped `v.icon` in `<Interpreter node={v.icon} />`, but `icon` is a flat `IconSchema` (`{ name, size?, color? }`), not an SDUI node — so `Interpreter` called `resolveRenderer(undefined)` and crashed on `.startsWith()`. The footer's 3 tabs rendered as fallback boxes. Fix: render `<DSIcon name={v.icon.name} size={v.icon.size} color={v.icon.color} />`, matching the established pattern in `ChipRenderer`, `PageHeader`, `InfoIconRow`, and 6 other renderers that consume `IconSchema`.
+
+- **`TabRenderer` — tap swallowed.** `DSTab` is itself a `Pressable`. Passing `on_click` to `SduiNode` wrapped the tab in an outer `Clickable` Pressable, but in RN the deepest Pressable under the touch point wins — so the inner DSTab Pressable swallowed the tap and the outer handler never fired. (`DSTab.types.ts` already documents this expectation.) Fix: dispatch `on_click` locally via `useActionEngine` and pass the press handler directly as `DSTab.onPress`; intentionally do not forward `on_click` to `SduiNode` (so no outer Clickable wraps). `on_load` / `on_view` / `on_dismount` continue to flow through `SduiNode` unchanged.
+
+- **`InfoRow` — status_tag label flat-text bug.** The renderer passed the whole `v.status_tag.label` object to `DSTag.label`, but `status_tag.label` is a flat `TextSchema` (`{ text, color?, font_size?, font_weight? }`), not a string. React rendered it as a child and threw "Objects are not valid as a React child (found: object with keys {text})." Every `info_row` on the home Explore feed rendered as a fallback box (no title/subtitle/status tag). Fix: `label={v.status_tag.label.text}`, same pattern title/subtitle/badge already use in this renderer.
+
+Verified on iPhone 15 Pro simulator: footer tabs render with correct labels and the active-underline indicator, tapping a tab fires the BFF's `on_click` and the gateway's `replace_section` action is applied, and campaign cards render full title / subtitle / status tag.

--- a/packages/sdui-runtime/src/snippets/InfoRow/InfoRow.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/InfoRow/InfoRow.renderer.tsx
@@ -61,7 +61,7 @@ export function InfoRowRenderer(node: Node): React.ReactElement {
             <Stack direction="row" align="center" gap={8}>
               {v.status_tag && (
                 <DSTag
-                  label={v.status_tag.label}
+                  label={v.status_tag.label.text}
                   variant={v.status_tag.variant}
                   color={v.status_tag.color}
                 />

--- a/packages/sdui-runtime/src/snippets/TabsFooter/TabsFooter.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/TabsFooter/TabsFooter.renderer.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { TabsFooterSchema } from "@one-impression/sdk-native-sdui";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 import { applyActiveIndex } from "./applyActiveIndex.js";
+import { TabBarActiveContext } from "../../state/TabBarActiveContext.js";
 
 const styles = StyleSheet.create({
   /**
@@ -52,6 +53,17 @@ const styles = StyleSheet.create({
  * the SDUI-native `active_index` field instead so layouts stay declarative.
  */
 export function TabsFooterRenderer(node: Node): React.ReactElement {
+  // Optimistic active state. `null` until the user taps; once set, takes
+  // priority over the BFF's `data.active_index` so the underline indicator
+  // follows the finger instead of waiting for the BFF round-trip that
+  // loads the new tab's content. The server can still seed selection at
+  // mount via `data.active_index` (used until the first tap).
+  const [localActiveTabId, setLocalActiveTabId] = useState<string | null>(null);
+  const ctxValue = useMemo(
+    () => ({ activeTabId: localActiveTabId, setActiveTabId: setLocalActiveTabId }),
+    [localActiveTabId],
+  );
+
   return (
     <SduiNode
       data={node.data}
@@ -65,15 +77,27 @@ export function TabsFooterRenderer(node: Node): React.ReactElement {
       load_events={node.load_events}
     >
       {(v) => {
-        const items = applyActiveIndex(v.items ?? [], v.active_index);
+        const rawItems = v.items ?? [];
+        // Resolve effective active index: a local tap wins, otherwise fall
+        // back to the BFF-supplied `active_index`.
+        const localIndex =
+          localActiveTabId != null
+            ? rawItems.findIndex((it) => it.id === localActiveTabId)
+            : -1;
+        const effectiveActiveIndex =
+          localIndex >= 0 ? localIndex : v.active_index;
+        const items = applyActiveIndex(rawItems, effectiveActiveIndex);
+
         return (
-          <View style={styles.container}>
-            {items.map((item, i) => (
-              <View key={item.id || `tab-${i}`} style={styles.tabSlot}>
-                <Interpreter node={item} />
-              </View>
-            ))}
-          </View>
+          <TabBarActiveContext.Provider value={ctxValue}>
+            <View style={styles.container}>
+              {items.map((item, i) => (
+                <View key={item.id || `tab-${i}`} style={styles.tabSlot}>
+                  <Interpreter node={item} />
+                </View>
+              ))}
+            </View>
+          </TabBarActiveContext.Provider>
         );
       }}
     </SduiNode>

--- a/packages/sdui-runtime/src/state/TabBarActiveContext.ts
+++ b/packages/sdui-runtime/src/state/TabBarActiveContext.ts
@@ -1,0 +1,51 @@
+/**
+ * Optimistic tab-bar active state.
+ *
+ * Tab bars (e.g. `creator.snippet.tabs_footer`) are inherently mutually-
+ * exclusive selectables: the user taps one, the indicator should follow
+ * the finger *immediately* — not after a BFF round-trip. If the
+ * `active_index` only updated on a server response, the highlight would
+ * lag every load of the new tab's content.
+ *
+ * This context lets the **parent tab bar** own a local, optimistic
+ * "which tab was just tapped" value, and lets the **Tab renderer** both
+ * report a tap (so the parent re-renders all sibling tabs) and read the
+ * current value (so its `active` flag follows local state instead of
+ * waiting for the server).
+ *
+ * Semantics:
+ *
+ * - The parent provides the context with its `setActiveTabId` mutator.
+ *   It seeds `activeTabId` to `null`; on first tap it becomes the
+ *   tapped node's id and overrides the server-driven `data.active_index`
+ *   until the next tap.
+ * - A child `Tab` calls `setActiveTabId(node.id)` *before* dispatching
+ *   its `on_click` action. The state update is synchronous; the BFF
+ *   call is fire-and-forget from the indicator's perspective.
+ * - If a child Tab is rendered outside a tab bar (no provider), the
+ *   context is `null` and the Tab falls back to the BFF-supplied
+ *   `data.active` flag — no behaviour change for non-tab-bar usage.
+ * - The server can still drive selection by re-rendering the tab bar
+ *   with a new `data.active_index`; the parent's `useState` resets to
+ *   `null` on mount, so an authoritative server update is honoured on
+ *   the first render and any subsequent tap overrides it again.
+ *
+ * Generic over any tab bar shape (footer, top tabs, etc.) so future
+ * tab-bar snippets can reuse it without duplicating the pattern.
+ */
+import { createContext } from "react";
+
+export interface TabBarActiveContextValue {
+  /**
+   * Locally-overridden active tab node id. `null` until the user
+   * interacts; once set, takes priority over the BFF's
+   * `data.active_index` so the indicator does not wait on a
+   * round-trip.
+   */
+  activeTabId: string | null;
+  /** Mutator the child Tab calls in its `onPress`. */
+  setActiveTabId: (id: string) => void;
+}
+
+export const TabBarActiveContext =
+  createContext<TabBarActiveContextValue | null>(null);

--- a/packages/sdui-runtime/src/state/index.ts
+++ b/packages/sdui-runtime/src/state/index.ts
@@ -77,3 +77,8 @@ export type {
 // Dev config (localhost-only request augmentation, e.g. X-Dev-Identity header)
 export { useDevConfigStore } from './useDevConfigStore.js';
 export type { DevConfigState, DevConfigActions } from './useDevConfigStore.js';
+
+// Tab-bar optimistic active state (lets the indicator follow user taps
+// without waiting for the BFF round-trip).
+export { TabBarActiveContext } from './TabBarActiveContext.js';
+export type { TabBarActiveContextValue } from './TabBarActiveContext.js';

--- a/packages/sdui-runtime/src/ui_components/Tab/Tab.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Tab/Tab.renderer.tsx
@@ -1,20 +1,34 @@
-import React from "react";
+import React, { useContext } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { TabComponentSchema } from "@one-impression/sdk-native-sdui";
 import { Tab as DSTab, Icon as DSIcon } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";
+import { TabBarActiveContext } from "../../state/TabBarActiveContext.js";
 
 export function TabRenderer(node: Node): React.ReactElement {
   const actionEngine = useActionEngine();
+  // Optional parent tab bar (e.g. TabsFooter). When present, taps update
+  // its optimistic active state synchronously so the indicator follows
+  // the finger without waiting for the BFF round-trip; the BFF call then
+  // proceeds and loads the new tab's content. When absent, the Tab still
+  // works standalone — only the `on_click` dispatch happens.
+  const tabBar = useContext(TabBarActiveContext);
   // DSTab is itself a Pressable, so a wrapping <Clickable> in SduiNode would
   // be swallowed by the inner Pressable (taps land on the deepest Pressable
   // first). Dispatch on_click here and pass it directly as DSTab.onPress;
   // intentionally do NOT forward on_click to SduiNode so the outer wrap is
   // skipped. on_load / on_view / on_dismount still go through SduiNode.
-  const onPress = node.on_click
-    ? () => actionEngine.dispatch(node.on_click!)
-    : undefined;
+  const onPress =
+    node.on_click || tabBar
+      ? () => {
+          // 1. Optimistic visual: parent tab bar updates active state
+          //    synchronously (no-op if not inside one).
+          tabBar?.setActiveTabId(node.id);
+          // 2. Server-driven content: fire the BFF action.
+          if (node.on_click) actionEngine.dispatch(node.on_click);
+        }
+      : undefined;
   return (
     <SduiNode
       data={node.data}

--- a/packages/sdui-runtime/src/ui_components/Tab/Tab.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Tab/Tab.renderer.tsx
@@ -1,17 +1,25 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { TabComponentSchema } from "@one-impression/sdk-native-sdui";
-import { Tab as DSTab } from "@one-impression/ui-native";
+import { Tab as DSTab, Icon as DSIcon } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
-import { Interpreter } from "../../interpreter/index.js";
+import { useActionEngine } from "../../action-engine/useActionEngine.js";
 
 export function TabRenderer(node: Node): React.ReactElement {
+  const actionEngine = useActionEngine();
+  // DSTab is itself a Pressable, so a wrapping <Clickable> in SduiNode would
+  // be swallowed by the inner Pressable (taps land on the deepest Pressable
+  // first). Dispatch on_click here and pass it directly as DSTab.onPress;
+  // intentionally do NOT forward on_click to SduiNode so the outer wrap is
+  // skipped. on_load / on_view / on_dismount still go through SduiNode.
+  const onPress = node.on_click
+    ? () => actionEngine.dispatch(node.on_click!)
+    : undefined;
   return (
     <SduiNode
       data={node.data}
       schema={TabComponentSchema.shape.data}
       id={node.id}
-      on_click={node.on_click}
       on_load={node.on_load}
       on_view={node.on_view}
       on_dismount={node.on_dismount}
@@ -22,7 +30,16 @@ export function TabRenderer(node: Node): React.ReactElement {
         <DSTab
           label={v.label.text}
           active={v.active}
-          icon={v.icon ? <Interpreter node={v.icon} /> : undefined}
+          onPress={onPress}
+          icon={
+            v.icon ? (
+              <DSIcon
+                name={v.icon.name}
+                size={v.icon.size}
+                color={v.icon.color}
+              />
+            ) : undefined
+          }
         />
       )}
     </SduiNode>

--- a/packages/sdui-runtime/src/ui_components/Tab/Tab.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Tab/Tab.renderer.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from "react";
+import React, { useCallback, useContext } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { TabComponentSchema } from "@one-impression/sdk-native-sdui";
 import { Tab as DSTab, Icon as DSIcon } from "@one-impression/ui-native";
@@ -14,27 +14,28 @@ export function TabRenderer(node: Node): React.ReactElement {
   // proceeds and loads the new tab's content. When absent, the Tab still
   // works standalone — only the `on_click` dispatch happens.
   const tabBar = useContext(TabBarActiveContext);
+  // Pull out the setter (a React useState setter — referentially stable
+  // across renders) so the callback dependency list doesn't churn when
+  // the parent's `activeTabId` changes. Depending on the whole `tabBar`
+  // context value would cause every sibling Tab's handler to be re-
+  // allocated on every tap; depending only on the setter keeps it
+  // stable for the lifetime of the parent tab bar.
+  const setActiveTabId = tabBar?.setActiveTabId;
   // DSTab is itself a Pressable, so a wrapping <Clickable> in SduiNode would
   // be swallowed by the inner Pressable (taps land on the deepest Pressable
   // first). Dispatch on_click here and pass it directly as DSTab.onPress;
   // intentionally do NOT forward on_click to SduiNode so the outer wrap is
   // skipped. on_load / on_view / on_dismount still go through SduiNode.
-  // Memoize the handler so DSTab receives a stable reference across
-  // re-renders — important for any future React.memo on DSTab and for
-  // keeping the Pressable's internal gesture state from churning. The
-  // handler is `undefined` when there's nothing for it to do, so the
-  // memo returns the value (not a function); useMemo (not useCallback)
-  // is the right hook here.
-  const onPress = useMemo<(() => void) | undefined>(() => {
-    if (!node.on_click && !tabBar) return undefined;
-    return () => {
-      // 1. Optimistic visual: parent tab bar updates active state
-      //    synchronously (no-op if not inside one).
-      tabBar?.setActiveTabId(node.id);
-      // 2. Server-driven content: fire the BFF action.
-      if (node.on_click) actionEngine.dispatch(node.on_click);
-    };
-  }, [node.id, node.on_click, tabBar, actionEngine]);
+  const handlePress = useCallback(() => {
+    // 1. Optimistic visual: parent tab bar updates active state
+    //    synchronously (no-op if not inside one).
+    setActiveTabId?.(node.id);
+    // 2. Server-driven content: fire the BFF action.
+    if (node.on_click) actionEngine.dispatch(node.on_click);
+  }, [node.id, node.on_click, setActiveTabId, actionEngine]);
+  // Only attach a handler when there's actually work to do; otherwise let
+  // DSTab render without an `onPress` so its Pressable doesn't claim taps.
+  const onPress = node.on_click || setActiveTabId ? handlePress : undefined;
   return (
     <SduiNode
       data={node.data}

--- a/packages/sdui-runtime/src/ui_components/Tab/Tab.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Tab/Tab.renderer.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useMemo } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { TabComponentSchema } from "@one-impression/sdk-native-sdui";
 import { Tab as DSTab, Icon as DSIcon } from "@one-impression/ui-native";
@@ -19,16 +19,22 @@ export function TabRenderer(node: Node): React.ReactElement {
   // first). Dispatch on_click here and pass it directly as DSTab.onPress;
   // intentionally do NOT forward on_click to SduiNode so the outer wrap is
   // skipped. on_load / on_view / on_dismount still go through SduiNode.
-  const onPress =
-    node.on_click || tabBar
-      ? () => {
-          // 1. Optimistic visual: parent tab bar updates active state
-          //    synchronously (no-op if not inside one).
-          tabBar?.setActiveTabId(node.id);
-          // 2. Server-driven content: fire the BFF action.
-          if (node.on_click) actionEngine.dispatch(node.on_click);
-        }
-      : undefined;
+  // Memoize the handler so DSTab receives a stable reference across
+  // re-renders — important for any future React.memo on DSTab and for
+  // keeping the Pressable's internal gesture state from churning. The
+  // handler is `undefined` when there's nothing for it to do, so the
+  // memo returns the value (not a function); useMemo (not useCallback)
+  // is the right hook here.
+  const onPress = useMemo<(() => void) | undefined>(() => {
+    if (!node.on_click && !tabBar) return undefined;
+    return () => {
+      // 1. Optimistic visual: parent tab bar updates active state
+      //    synchronously (no-op if not inside one).
+      tabBar?.setActiveTabId(node.id);
+      // 2. Server-driven content: fire the BFF action.
+      if (node.on_click) actionEngine.dispatch(node.on_click);
+    };
+  }, [node.id, node.on_click, tabBar, actionEngine]);
   return (
     <SduiNode
       data={node.data}


### PR DESCRIPTION
## Summary

Renderer-level bugs and a UX gap in the home BC found by on-device E2E against `sdk-native-sdui@^2.6.0` (which ships `IconSchema`, flat `TextSchema` `label`, and `EndpointPaths`). Each visible bug was caught by `SduiErrorBoundary` so the page rendered as fallback boxes rather than crashing — but every campaign card showed a fallback box where its title/subtitle should be, and the 3-tab footer rendered as 3 fallback boxes.

After fixing those, the tab-bar still had a UX gap: the active indicator only moved when the BFF's `replace_section` response arrived, so every tab tap had a perceptible lag before the highlight flipped. Added a generic `TabBarActiveContext` to make that visual instant while keeping content server-driven.

## Fixes

### 1. `TabRenderer` — icon crash _(visible)_
The renderer wrapped `v.icon` in `<Interpreter node={v.icon} />`, but `icon` is a flat `IconSchema` (`{ name, size?, color? }`), not an SDUI node — so `Interpreter` called `resolveRenderer(undefined)` and crashed on `.startsWith()`. The footer's 3 tabs rendered as fallback boxes.

**Fix:** render `<DSIcon name={v.icon.name} size={v.icon.size} color={v.icon.color} />`, matching the established pattern in `ChipRenderer`, `PageHeader`, `InfoIconRow`, and 6 other renderers that consume `IconSchema`.

### 2. `TabRenderer` — tap swallowed _(visible)_
`DSTab` is itself a `Pressable`. Passing `on_click` to `SduiNode` wrapped the tab in an outer `Clickable` Pressable, but in RN the deepest Pressable under the touch point wins — so the inner DSTab Pressable swallowed the tap and the outer handler never fired. (`DSTab.types.ts` already documents this expectation: _"taps land on the inner Pressable first and would otherwise be swallowed"_.)

**Fix:** hold the action engine in TabRenderer, build the press handler locally, and pass it directly as `DSTab.onPress`. Intentionally do **not** forward `on_click` to `SduiNode` (so no outer Clickable wraps). `on_load` / `on_view` / `on_dismount` continue to flow through `SduiNode` unchanged.

### 3. `InfoRow` — `status_tag` flat-text bug _(visible)_
The renderer passed the whole `v.status_tag.label` object to `DSTag.label`, but `status_tag.label` is a flat `TextSchema` (`{ text, color?, font_size?, font_weight? }`), not a string. React rendered it as a child and threw _"Objects are not valid as a React child (found: object with keys {text})"_. Every `info_row` on the home Explore feed rendered as a fallback box (no title / subtitle / status tag).

**Fix:** `label={v.status_tag.label.text}` — same pattern title/subtitle/badge already use in this renderer.

### 4. Optimistic tab-bar active state _(UX gap)_
"Which tab is highlighted" is intrinsically a client-UI concern: the user just touched the button, the indicator should follow the finger — not wait for the BFF round-trip that loads the new tab's content. Previously the active indicator was driven only by `data.active_index` from the server, so every tab switch had a perceptible lag.

**Fix:** added a generic `TabBarActiveContext` (exported from `state/`). `TabsFooterRenderer` owns a `useState<string | null>` for the optimistic active tab id and provides it via the context. `TabRenderer` consumes the context and on press calls `setActiveTabId(node.id)` **before** dispatching `on_click`. The effective active index resolves to `local override ?? data.active_index` — the server still seeds selection at mount and can drive it via re-renders, but the local override wins until the next tap.

- **Zero wire cost** (no payload growth, no extra round-trip).
- **Zero gateway changes** — the home tab dispatcher still emits the same 3 `replace_section` actions; it never has to ship the footer to update the indicator.
- **No remount of the footer.**
- The context is generic so future tab-bar shapes (top tabs, segmented controls, etc.) can reuse it without duplicating the pattern.

## Verified on iPhone 15 Pro simulator

- Footer tabs render with correct labels and the active-underline indicator.
- Tapping a tab flips the active indicator **instantly** while the BFF's `on_click` fires asynchronously — gateway log shows `/v1/creator/home/tab` hit immediately after each tap, and the new tab's `replace_section` swaps the page sections.
- Campaign cards render full title / subtitle / status tag (no more fallback boxes).
- Pull-to-refresh re-fires the explore tab fetch.

## Notes

- One pre-existing test failure in `node-registry.test.ts` (tsx can't parse `react-native/index.js`) is on `main` already — not from these changes. Worth a separate cleanup issue if not already tracked.
- Changeset bumps `@one-impression/sdui-runtime` as `patch`. The optimistic-active addition is technically a small feature, but the home-BC bug fixes dominate; the `state/TabBarActiveContext` export is additive and non-breaking.
