### PR TITLE
docs(zenith): update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,11 +50,15 @@ packages/
   tokens-foundation/  — Shared primitives (spacing, radii, shadows, typography, z-index, breakpoints)
   tokens-brand/       — Brand Platform tokens (purple primary, light/dark themes)
   tokens-atmosphere/  — Atmosphere tokens (gold accent, dark-first themes)
-  tokens-creator/     — Creator App tokens (SDUI mappings, mobile-optimized)
+  tokens-creator/     — Creator App tokens (SDUI mappings, mobile-optimized) · v3.2.0: adds `palette.state.*` token group for campaign/opportunity lifecycle banners (`state-neutral`, `state-action-required`, `state-success`, `state-urgent` — each with bg + text pair, AA contrast in light + dark). Distinct from `palette.status.*` (inline messaging). Do NOT alias state-banner tokens to existing `status.*` tokens — the four states require perceptually independent hues across both themes.
   ui/                 — Shared React components (Button, Badge, Card, EmptyState, Skeleton)
   storybook/          — Component documentation and visual testing
   eslint-config/      — Design system lint rules (no-hardcoded-colors, no-raw-spacing, prefer-token-import)
   feature-flags/      — Feature flag utilities
+  sdui-runtime/       — SDUI runtime: interpreter, action engine, bottom-sheet manager, loaders, providers · v2.4.0 changes:
+                          • CardRenderer now supports `data.header?`, `data.items[]`, `data.footer?` slots (sdk-native-sdui ≥2.8.0) and `config.footer_bg_color` (wraps footer in a Box with resolved bg color)
+                          • `SduiNode.on_view` is now **one-shot per instance** — `firedRef` prevents re-emission on scroll-back; new instances (pagination) get their own ref
+                          • `bff_call` injects `X-Active-Influencer-Id` header from new `useActiveSocialStore` (`activeInfluencerId: string | null`) — exported from package public surface; omitted (not nulled) when store is null
 ```
 
 ## Token File Format


### PR DESCRIPTION
## Summary
- **Trigger:** commit `3e8abef`
- **File updated:** `CLAUDE.md`
- **Confidence:** 🟡 0.70
- **Reason:** Two minor releases introduce significant new capabilities engineers need to know about: sdui-runtime 2.4.0 adds Card header/footer slot rendering, one-shot on_view impression guard, and X-Active-Influencer-Id header injection via useActiveSocialStore; tokens-creator 3.2.0 adds a new palette.state.* token group for campaign/opportunity lifecycle banners.

This is an automated documentation update by Zenith. Needs human review.

---
Generated by [Zenith AI CTO](https://github.com/one-impression/zenith-coding-agent)