### PR TITLE
fix(ci): include Oportunities tokens in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           npm run build -w packages/tokens-brand
           npm run build -w packages/tokens-creator
           npm run build -w packages/tokens-atmosphere
+          npm run build -w packages/tokens-oportunities
           npm run build -w packages/tokens-marketing
 
       - name: Build @one-impression/ui
@@ -64,7 +65,7 @@ jobs:
       - name: Verify build outputs
         run: |
           MISSING=""
-          for pkg in tokens-foundation tokens-brand tokens-creator tokens-atmosphere tokens-marketing ui ui-native sdui-runtime mcp-server; do
+          for pkg in tokens-foundation tokens-brand tokens-creator tokens-atmosphere tokens-oportunities tokens-marketing ui ui-native sdui-runtime mcp-server; do
             DIR="packages/$pkg/dist"
             if [ ! -d "$DIR" ]; then
               MISSING="$MISSING\n  - packages/$pkg/dist/ (directory missing)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,7 @@ jobs:
           npm run build -w packages/tokens-brand
           npm run build -w packages/tokens-creator
           npm run build -w packages/tokens-atmosphere
+          npm run build -w packages/tokens-oportunities
           npm run build -w packages/tokens-marketing
           npm run build -w packages/ui
           npm run build -w packages/ui-native
@@ -97,7 +98,7 @@ jobs:
           set -e
           echo "@one-impression:registry=https://npm.pkg.github.com" > ~/.npmrc
           echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" >> ~/.npmrc
-          for pkg in tokens-foundation tokens-brand tokens-atmosphere tokens-creator ui ui-native sdui-runtime mcp-server eslint-config; do
+          for pkg in tokens-foundation tokens-brand tokens-atmosphere tokens-oportunities tokens-creator ui ui-native sdui-runtime mcp-server eslint-config; do
             EXPECTED=$(jq -r .version packages/$pkg/package.json)
             ACTUAL=$(npm view @one-impression/$pkg version 2>/dev/null || echo "MISSING")
             if [ "$EXPECTED" != "$ACTUAL" ]; then

--- a/scripts/validate-tokens.js
+++ b/scripts/validate-tokens.js
@@ -91,7 +91,7 @@ function findBrokenRefs(obj, root, prefix = '') {
 // ── Validation ──
 console.log('\n=== Token Package Validation (W3C DTCG) ===\n');
 
-const packages = ['tokens-foundation', 'tokens-brand', 'tokens-creator', 'tokens-atmosphere', 'tokens-studio'];
+const packages = ['tokens-foundation', 'tokens-brand', 'tokens-creator', 'tokens-atmosphere', 'tokens-oportunities', 'tokens-studio'];
 for (const pkg of packages) {
   const tokensDir = join(PACKAGES_DIR, pkg, 'tokens');
   if (!existsSync(tokensDir)) {
@@ -165,7 +165,7 @@ for (const theme of ['light', 'dark']) {
   }
 
   // Check each product's theme file against foundation
-  for (const pkg of ['tokens-brand', 'tokens-atmosphere', 'tokens-creator', 'tokens-studio']) {
+  for (const pkg of ['tokens-brand', 'tokens-atmosphere', 'tokens-creator', 'tokens-oportunities', 'tokens-studio']) {
     const themeFile = join(PACKAGES_DIR, pkg, 'tokens', `theme-${theme}.json`);
     if (!existsSync(themeFile)) continue;
 


### PR DESCRIPTION
## Summary

The `tokens-oportunities` package exists on main but was completely absent from all CI workflows — it was never built, validated, verified, or published.

**Changes across 3 files:**

- **`.github/workflows/ci.yml`** — added `tokens-oportunities` to the build step and the `for` loop that verifies `dist/` directories exist after build
- **`.github/workflows/publish.yml`** — added `tokens-oportunities` to the build step and the `for` loop that verifies published package versions match
- **`scripts/validate-tokens.js`** — added `tokens-oportunities` to both the token validation array (line 94) and the reference integrity check loop (line 168)

**No change needed** in `scripts/build-tokens.js` — it already had `'oportunities'` in `VALID_PACKAGES`.

## Test plan

- [ ] CI workflow builds `tokens-oportunities` without errors
- [ ] Verify build outputs step confirms `packages/tokens-oportunities/dist/` exists and is non-empty
- [ ] `validate-tokens.js` loads and validates Oportunities tokens
- [ ] Publish workflow includes `tokens-oportunities` in version verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)