### PR TITLE
feat(tokens-oportunities): V14 token gaps — tier bands, verification, shadows, motion

### DIFF
--- a/packages/tokens-oportunities/tokens/theme-dark.json
+++ b/packages/tokens-oportunities/tokens/theme-dark.json
@@ -21,7 +21,14 @@
       "text-tertiary":  { "$value": "#6A6258", "$description": "Tertiary / muted text on dark" },
 
       "border":         { "$value": "#2D2723", "$description": "Default border on dark" },
-      "border-soft":    { "$value": "#383028", "$description": "Subtle divider on dark" }
+      "border-soft":    { "$value": "#383028", "$description": "Subtle divider on dark" },
+
+      "gradient-inlet":   { "$value": "linear-gradient(135deg, #2A1F14 0%, #2A2440 100%)", "$description": "Peer-feed inlet gradient — dark warm to dark purple" },
+      "gradient-upgrade":  { "$value": "linear-gradient(135deg, #2A1F14 0%, #2A2440 100%)", "$description": "Auth upgrade banner gradient — dark" }
+    },
+    "letter-spacing": {
+      "tight": { "$value": "-0.02em", "$description": "Tight tracking for headlines and display text" },
+      "caps":  { "$value": "0.05em", "$description": "Wide tracking for uppercase badge labels" }
     }
   },
   "effort": {
@@ -39,5 +46,48 @@
     "warning":  { "$value": "#E0A84A", "$description": "Warning / needs attention — dark" },
     "danger":   { "$value": "#D5605E", "$description": "Error / blocked / rejected — dark" },
     "info":     { "$value": "#6090D2", "$description": "Informational — dark" }
+  },
+  "tier": {
+    "$type": "color",
+    "$description": "Creator tier band badge colors — dark variant. Adjusted for legibility on warm-black surfaces.",
+    "micro-bg":   { "$value": "#2A2440", "$description": "Micro tier badge background — dark purple" },
+    "micro-text": { "$value": "#9B82FF", "$description": "Micro tier badge text — brightened AI purple" },
+    "mid-bg":     { "$value": "#1A2A3D", "$description": "Mid tier badge background — dark blue" },
+    "mid-text":   { "$value": "#5AAFFF", "$description": "Mid tier badge text — brightened sky blue" },
+    "macro-bg":   { "$value": "#2A1F14", "$description": "Macro tier badge background — dark warm" },
+    "macro-text": { "$value": "#F0A668", "$description": "Macro tier badge text — brightened apricot" },
+    "mega-bg":    { "$value": "#FFC894", "$description": "Mega tier badge background — warm gold (inverted for dark)" },
+    "mega-text":  { "$value": "#1C1611", "$description": "Mega tier badge text — warm near-black (inverted for dark)" }
+  },
+  "verify": {
+    "$type": "color",
+    "$description": "Verification source badge colors — dark variant.",
+    "oauth-bg":   { "$value": "#1A2D1F", "$description": "OAuth verified badge background — dark green" },
+    "oauth-text": { "$value": "#6BC284", "$description": "OAuth verified badge text — brightened green" },
+    "dm-bg":      { "$value": "#2A2440", "$description": "DM verified badge background — dark purple" },
+    "dm-text":    { "$value": "#9B82FF", "$description": "DM verified badge text — brightened AI purple" },
+    "ops-bg":     { "$value": "#2A1F14", "$description": "Ops verified badge background — dark warm" },
+    "ops-text":   { "$value": "#E8A84C", "$description": "Ops verified badge text — brightened amber" }
+  },
+  "platform": {
+    "$type": "color",
+    "$description": "Social platform brand colors — same in dark mode (brand colors don't change per theme).",
+    "instagram": { "$value": "#E1306C", "$description": "Instagram brand pink" },
+    "youtube":   { "$value": "#FF0000", "$description": "YouTube brand red" }
+  },
+  "shadow": {
+    "$type": "shadow",
+    "$description": "Apricot accent shadows — dark variant. Stronger glow for visibility on dark surfaces.",
+    "accent-sm": { "$value": "0 1px 3px rgba(230, 143, 71, 0.25)", "$description": "Small apricot glow — dark" },
+    "accent-md": { "$value": "0 4px 12px rgba(230, 143, 71, 0.35)", "$description": "Medium apricot glow — dark" },
+    "accent-lg": { "$value": "0 8px 24px rgba(230, 143, 71, 0.45)", "$description": "Large apricot glow — dark" }
+  },
+  "motion": {
+    "$description": "Oportunities-specific animation tokens — same in dark mode (animation doesn't change per theme).",
+    "shimmer-duration":     { "$value": "1.8s", "$type": "duration", "$description": "Skeleton shimmer sweep duration — 1.8s linear" },
+    "shimmer-opacity":      { "$value": "0.75", "$description": "Skeleton shimmer opacity" },
+    "refresh-spin":         { "$value": "0.9s", "$type": "duration", "$description": "Pull-to-refresh spinner rotation cycle" },
+    "refresh-done-display": { "$value": "600ms", "$type": "duration", "$description": "Pull-to-refresh checkmark display duration" },
+    "refresh-done-fade":    { "$value": "200ms", "$type": "duration", "$description": "Pull-to-refresh checkmark fade-out" }
   }
 }

--- a/packages/tokens-oportunities/tokens/theme-light.json
+++ b/packages/tokens-oportunities/tokens/theme-light.json
@@ -21,7 +21,14 @@
       "text-tertiary":  { "$value": "#8A7F73", "$description": "Tertiary / muted text" },
 
       "border":         { "$value": "#EFE4D4", "$description": "Default border — warm cream" },
-      "border-soft":    { "$value": "#F5ECDE", "$description": "Subtle divider" }
+      "border-soft":    { "$value": "#F5ECDE", "$description": "Subtle divider" },
+
+      "gradient-inlet":   { "$value": "linear-gradient(135deg, #FFE9D2 0%, #EFEAFF 100%)", "$description": "Peer-feed inlet gradient — cream to AI purple soft" },
+      "gradient-upgrade":  { "$value": "linear-gradient(135deg, #FFE9D2 0%, #EFEAFF 100%)", "$description": "Auth upgrade banner gradient" }
+    },
+    "letter-spacing": {
+      "tight": { "$value": "-0.02em", "$description": "Tight tracking for headlines and display text" },
+      "caps":  { "$value": "0.05em", "$description": "Wide tracking for uppercase badge labels" }
     }
   },
   "effort": {
@@ -101,5 +108,48 @@
     "ai-tint":          { "$value": "rgba(123, 91, 255, 0.10)", "$description": "Marketing AI purple tint background" },
     "bg-2":             { "$value": "#FAF2DE", "$description": "Marketing secondary background — band sections, alternating stripes" },
     "bg-3":             { "$value": "#F5EBD9", "$description": "Marketing tertiary background — recessed panels, footer band" }
+  },
+  "tier": {
+    "$type": "color",
+    "$description": "Creator tier band badge colors — used on peer feed, profiles, brand search, mystery cards. Each tier has a bg (badge background) and text (badge foreground).",
+    "micro-bg":   { "$value": "#EFEAFF", "$description": "Micro tier badge background — AI purple soft" },
+    "micro-text": { "$value": "#7B5BFF", "$description": "Micro tier badge text — AI purple" },
+    "mid-bg":     { "$value": "#E0F0FE", "$description": "Mid tier badge background — sky blue soft" },
+    "mid-text":   { "$value": "#1C8DEE", "$description": "Mid tier badge text — sky blue" },
+    "macro-bg":   { "$value": "#FFE9D2", "$description": "Macro tier badge background — apricot soft" },
+    "macro-text": { "$value": "#D67A35", "$description": "Macro tier badge text — apricot hover" },
+    "mega-bg":    { "$value": "#1C1611", "$description": "Mega tier badge background — warm near-black" },
+    "mega-text":  { "$value": "#FFC894", "$description": "Mega tier badge text — warm gold" }
+  },
+  "verify": {
+    "$type": "color",
+    "$description": "Verification source badge colors — OAuth, DM, and Ops verification indicators on Connected Accounts and console.",
+    "oauth-bg":   { "$value": "#D6EBDE", "$description": "OAuth verified badge background — soft green" },
+    "oauth-text": { "$value": "#2F8A4F", "$description": "OAuth verified badge text — forest green" },
+    "dm-bg":      { "$value": "#EFEAFF", "$description": "DM verified badge background — AI purple soft" },
+    "dm-text":    { "$value": "#7B5BFF", "$description": "DM verified badge text — AI purple" },
+    "ops-bg":     { "$value": "#FFE9D2", "$description": "Ops verified badge background — apricot soft" },
+    "ops-text":   { "$value": "#C6892C", "$description": "Ops verified badge text — warm amber" }
+  },
+  "platform": {
+    "$type": "color",
+    "$description": "Social platform brand colors for Connected Accounts badges and platform selector chips.",
+    "instagram": { "$value": "#E1306C", "$description": "Instagram brand pink" },
+    "youtube":   { "$value": "#FF0000", "$description": "YouTube brand red" }
+  },
+  "shadow": {
+    "$type": "shadow",
+    "$description": "Apricot accent shadows for Oportunities primary actions — unlock cards, CTA buttons, rate-limit pills.",
+    "accent-sm": { "$value": "0 1px 3px rgba(230, 143, 71, 0.15)", "$description": "Small apricot glow" },
+    "accent-md": { "$value": "0 4px 12px rgba(230, 143, 71, 0.20)", "$description": "Medium apricot glow" },
+    "accent-lg": { "$value": "0 8px 24px rgba(230, 143, 71, 0.25)", "$description": "Large apricot glow" }
+  },
+  "motion": {
+    "$description": "Oportunities-specific animation tokens for loading and refresh interactions.",
+    "shimmer-duration":     { "$value": "1.8s", "$type": "duration", "$description": "Skeleton shimmer sweep duration — 1.8s linear" },
+    "shimmer-opacity":      { "$value": "0.75", "$description": "Skeleton shimmer opacity" },
+    "refresh-spin":         { "$value": "0.9s", "$type": "duration", "$description": "Pull-to-refresh spinner rotation cycle" },
+    "refresh-done-display": { "$value": "600ms", "$type": "duration", "$description": "Pull-to-refresh checkmark display duration" },
+    "refresh-done-fade":    { "$value": "200ms", "$type": "duration", "$description": "Pull-to-refresh checkmark fade-out" }
   }
 }


### PR DESCRIPTION
## Summary

- **tier**: 8 color tokens for creator tier band badges (micro/mid/macro/mega, each with bg + text) — used on peer feed, profiles, brand search, mystery cards
- **verify**: 6 color tokens for verification source badges (OAuth/DM/Ops, each with bg + text) — used on Connected Accounts and console
- **platform**: 2 color tokens for social platform brand colors (Instagram, YouTube) — used in Connected Accounts badges and platform selector chips
- **shadow**: 3 apricot accent shadow tokens (sm/md/lg) for unlock cards, CTA buttons, rate-limit pills
- **motion**: 5 animation tokens for skeleton shimmer and pull-to-refresh interactions
- **theme.color.gradient-inlet / gradient-upgrade**: 2 gradient tokens added to the existing theme color group for peer-feed inlet and auth upgrade banner
- **theme.letter-spacing**: 2 tracking tokens (tight for headlines, caps for uppercase badge labels) added inside the theme group

All tokens added to both `theme-light.json` and `theme-dark.json` with appropriate dark-mode adjustments (stronger shadow opacity, inverted mega tier, brightened colors for dark contrast). Platform brand colors and motion tokens are identical across themes. Both JSON files validated.

**Total**: 28 new tokens per theme file (56 total across light + dark).

## Test plan

- [ ] `python3 -c "import json; json.load(open('packages/tokens-oportunities/tokens/theme-light.json')); json.load(open('packages/tokens-oportunities/tokens/theme-dark.json')); print('Valid')"` passes
- [ ] `npm run build` succeeds with new tokens generating CSS variables
- [ ] `npm run validate` cross-package consistency check passes
- [ ] Verify dark-mode shadow tokens have higher opacity than light (0.25/0.35/0.45 vs 0.15/0.20/0.25)
- [ ] Verify mega tier is inverted in dark mode (bg=gold, text=near-black)

🤖 Generated with [Claude Code](https://claude.com/claude-code)