### PR TITLE
fix(sdui-runtime): dead buttons, Button label crash, root exports, dev-identity on document fetches

### DIFF
--- a/.changeset/sdui-runtime-button-exports-devid.md
+++ b/.changeset/sdui-runtime-button-exports-devid.md
@@ -1,0 +1,11 @@
+---
+"@one-impression/sdui-runtime": minor
+---
+
+Fix dead SDUI buttons, broken Button label rendering, missing root exports, and local-dev identity on document fetches
+
+- ButtonRenderer forwards `on_click` to the design-system Button's `onPress` — the inner Pressable was capturing every tap, so no SDUI button dispatched its action
+- ButtonRenderer renders `label` as the `TextSchema` value the Button schema declares, instead of routing it through the Interpreter (which requires a wire `type` and crashed every button render)
+- `useLocalStore` (+ its types) exported from the package root — consuming apps bridge `set_local` writes into app stores
+- Document-fetch client now sends `X-Dev-Identity` for localhost BFF URLs, mirroring the action engine, so local-dev identity applies to page loads and not only actions
+- `getEndpoint` falls back to the codegen'd `EndpointPaths` catalog from the contracts package — page-document endpoint ids no longer need hand-maintained registry entries

--- a/packages/sdui-runtime/src/action-engine/handlers/bff-call.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/bff-call.ts
@@ -1,4 +1,5 @@
 import { BffCallPayloadSchema, EndpointPaths } from "@one-impression/sdk-native-sdui";
+import { isLocalhostBffUrl } from "../../bff/is-localhost.js";
 import type { Action } from "@one-impression/sdk-native-sdui";
 import type { ActionEngineConfig, ActionEngine } from "../types.js";
 import { useDevConfigStore } from "../../state/useDevConfigStore.js";
@@ -9,9 +10,6 @@ import { useActiveSocialStore } from "../../state/useActiveSocialStore.js";
  * gateway (localhost / 127.0.0.1). Used to gate dev-only request
  * augmentation such as the X-Dev-Identity header.
  */
-function isLocalhostBffUrl(bffBaseUrl: string): boolean {
-  return bffBaseUrl.includes("localhost") || bffBaseUrl.includes("127.0.0.1");
-}
 
 /**
  * bff_call — fetches a BFF endpoint with auth, dispatches on_success/on_error

--- a/packages/sdui-runtime/src/bff/client.ts
+++ b/packages/sdui-runtime/src/bff/client.ts
@@ -76,6 +76,7 @@ export function createBffClient(config: BffClientConfig) {
   const authConfig: AuthInterceptorConfig = {
     getAuthToken: config.getAuthToken,
     appVersion: config.appVersion,
+    bffBaseUrl: config.bffBaseUrl,
   };
 
   const retryConfig: RetryConfig = {

--- a/packages/sdui-runtime/src/bff/client.ts
+++ b/packages/sdui-runtime/src/bff/client.ts
@@ -12,6 +12,8 @@
  *   5. Extract onLoadAction if present (on-load-action interceptor)
  */
 import { getEndpoint, resolvePath, type HttpMethod } from './endpoint-registry.js';
+import { isLocalhostBffUrl } from './is-localhost.js';
+import { useDevConfigStore } from '../state/useDevConfigStore.js';
 import { applyAuthHeaders, type AuthInterceptorConfig } from './interceptors/auth.js';
 import { fetchWithRetry, type RetryConfig } from './interceptors/retry.js';
 import { throwOnError, networkError } from './interceptors/error.js';
@@ -76,7 +78,6 @@ export function createBffClient(config: BffClientConfig) {
   const authConfig: AuthInterceptorConfig = {
     getAuthToken: config.getAuthToken,
     appVersion: config.appVersion,
-    bffBaseUrl: config.bffBaseUrl,
   };
 
   const retryConfig: RetryConfig = {
@@ -130,8 +131,13 @@ export function createBffClient(config: BffClientConfig) {
       };
     }
 
-    // Apply auth headers
-    init = applyAuthHeaders(init, authConfig);
+    // Apply auth headers. The dev identity is read here at the call site
+    // (not inside the interceptor) and only for localhost BFF URLs —
+    // mirrors the action engine's bff_call.
+    const devIdentity = isLocalhostBffUrl(config.bffBaseUrl)
+      ? useDevConfigStore.getState().devIdentity
+      : undefined;
+    init = applyAuthHeaders(init, authConfig, devIdentity);
 
     // Execute with retry
     let response: Response;

--- a/packages/sdui-runtime/src/bff/endpoint-registry.ts
+++ b/packages/sdui-runtime/src/bff/endpoint-registry.ts
@@ -1,3 +1,4 @@
+import { EndpointPaths } from '@one-impression/sdk-native-sdui';
 /**
  * endpoint-registry — maps EndpointId strings to concrete HTTP
  * method + path templates.
@@ -90,8 +91,16 @@ export const endpointRegistry: Record<string, EndpointDefinition> = {
  */
 export function getEndpoint(endpointId: string): EndpointDefinition {
   const def = endpointRegistry[endpointId];
-  if (!def) {
-    throw new Error(`[BFF] Unknown endpoint: "${endpointId}"`);
+  if (def) return def;
+
+  // Fall back to the codegen'd catalog from the contracts package
+  // (EndpointPaths is generated from the creator-bff OpenAPI spec and
+  // covers the full endpoint surface). The catalog carries paths only,
+  // so non-GET endpoints that documents fetch directly must keep an
+  // explicit method entry in endpointRegistry above.
+  const catalogPath = (EndpointPaths as Record<string, string>)[endpointId];
+  if (catalogPath) {
+    return { method: 'GET', path: catalogPath };
   }
-  return def;
+  throw new Error(`[BFF] Unknown endpoint: "${endpointId}"`);
 }

--- a/packages/sdui-runtime/src/bff/interceptors/auth.ts
+++ b/packages/sdui-runtime/src/bff/interceptors/auth.ts
@@ -9,20 +9,12 @@
  *   - X-UTM-Source / X-UTM-Medium / X-UTM-Campaign (when present)
  */
 import { buildHeaders, type HeaderContext } from '../header-builders.js';
-import { isLocalhostBffUrl } from '../is-localhost.js';
-import { useDevConfigStore } from '../../state/useDevConfigStore.js';
 
 export interface AuthInterceptorConfig {
   /** Returns the current JWT token (may be null if not authenticated). */
   getAuthToken: () => string | null;
   /** App version string. */
   appVersion: string;
-  /**
-   * BFF base URL — used only to gate the localhost-only X-Dev-Identity
-   * header (mirrors the action engine's bff_call behaviour so document
-   * fetches and action calls present the same identity in local dev).
-   */
-  bffBaseUrl?: string;
   /** Optional UTM parameters for the current session. */
   getUtm?: () => HeaderContext['utm'];
 }
@@ -37,6 +29,13 @@ export interface AuthInterceptorConfig {
 export function applyAuthHeaders(
   init: RequestInit,
   config: AuthInterceptorConfig,
+  /**
+   * Local-dev identity value, read by the CALLER (keeping this function a
+   * stateless transformer — same pattern as the action engine's bff_call,
+   * which reads the dev-config store at its call site). Only ever set for
+   * localhost BFF URLs.
+   */
+  devIdentity?: string | null,
 ): RequestInit {
   const ctx: HeaderContext = {
     authToken: config.getAuthToken(),
@@ -46,11 +45,8 @@ export function applyAuthHeaders(
 
   const authHeaders = buildHeaders(ctx);
 
-  if (config.bffBaseUrl && isLocalhostBffUrl(config.bffBaseUrl)) {
-    const devIdentity = useDevConfigStore.getState().devIdentity;
-    if (devIdentity) {
-      (authHeaders as Record<string, string>)['X-Dev-Identity'] = devIdentity;
-    }
+  if (devIdentity) {
+    (authHeaders as Record<string, string>)['X-Dev-Identity'] = devIdentity;
   }
   const existingHeaders = init.headers as Record<string, string> | undefined;
 

--- a/packages/sdui-runtime/src/bff/interceptors/auth.ts
+++ b/packages/sdui-runtime/src/bff/interceptors/auth.ts
@@ -9,12 +9,20 @@
  *   - X-UTM-Source / X-UTM-Medium / X-UTM-Campaign (when present)
  */
 import { buildHeaders, type HeaderContext } from '../header-builders.js';
+import { isLocalhostBffUrl } from '../is-localhost.js';
+import { useDevConfigStore } from '../../state/useDevConfigStore.js';
 
 export interface AuthInterceptorConfig {
   /** Returns the current JWT token (may be null if not authenticated). */
   getAuthToken: () => string | null;
   /** App version string. */
   appVersion: string;
+  /**
+   * BFF base URL — used only to gate the localhost-only X-Dev-Identity
+   * header (mirrors the action engine's bff_call behaviour so document
+   * fetches and action calls present the same identity in local dev).
+   */
+  bffBaseUrl?: string;
   /** Optional UTM parameters for the current session. */
   getUtm?: () => HeaderContext['utm'];
 }
@@ -37,6 +45,13 @@ export function applyAuthHeaders(
   };
 
   const authHeaders = buildHeaders(ctx);
+
+  if (config.bffBaseUrl && isLocalhostBffUrl(config.bffBaseUrl)) {
+    const devIdentity = useDevConfigStore.getState().devIdentity;
+    if (devIdentity) {
+      (authHeaders as Record<string, string>)['X-Dev-Identity'] = devIdentity;
+    }
+  }
   const existingHeaders = init.headers as Record<string, string> | undefined;
 
   return {

--- a/packages/sdui-runtime/src/bff/is-localhost.ts
+++ b/packages/sdui-runtime/src/bff/is-localhost.ts
@@ -1,0 +1,10 @@
+/**
+ * True when the BFF base URL points at a local development server.
+ * Gates dev-only behaviour (X-Dev-Identity header injection) so it can
+ * never activate against staging or production hosts.
+ */
+export function isLocalhostBffUrl(bffBaseUrl: string): boolean {
+  return /^https?:\/\/(localhost|127\.0\.0\.1|10\.0\.2\.2)(:\d+)?(\/|$)/.test(
+    bffBaseUrl,
+  );
+}

--- a/packages/sdui-runtime/src/index.ts
+++ b/packages/sdui-runtime/src/index.ts
@@ -76,10 +76,12 @@ export {
 // need to set them at boot:
 //   - useDevConfigStore: localhost-only X-Dev-Identity header
 //   - useActiveSocialStore: production X-Active-Influencer-Id header
-export { useDevConfigStore, useActiveSocialStore } from "./state/index.js";
+export { useDevConfigStore, useActiveSocialStore, useLocalStore } from "./state/index.js";
 export type {
   DevConfigState,
   DevConfigActions,
   ActiveSocialState,
   ActiveSocialActions,
+  LocalStoreState,
+  LocalStoreActions,
 } from "./state/index.js";

--- a/packages/sdui-runtime/src/ui_components/Button/Button.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Button/Button.renderer.tsx
@@ -1,17 +1,24 @@
 import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { ButtonComponentSchema } from "@one-impression/sdk-native-sdui";
-import { Button as DSButton } from "@one-impression/ui-native";
+import { Button as DSButton, Text as DSText } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
+import { useActionEngine } from "../../action-engine/useActionEngine.js";
 
 export function ButtonRenderer(node: Node): React.ReactElement {
+  const actionEngine = useActionEngine();
+  // on_click is forwarded to DSButton.onPress below rather than relying on
+  // SduiNode's Clickable wrapper: DSButton renders an inner Pressable that
+  // becomes the touch responder, so an outer Pressable never fires. Passing
+  // on_click={undefined} to SduiNode also prevents a disabled button's tap
+  // from bubbling to the wrapper and dispatching anyway.
   return (
     <SduiNode
       data={node.data}
       schema={ButtonComponentSchema.shape.data}
       id={node.id}
-      on_click={node.on_click}
+      on_click={undefined}
       on_load={node.on_load}
       on_view={node.on_view}
       on_dismount={node.on_dismount}
@@ -24,9 +31,18 @@ export function ButtonRenderer(node: Node): React.ReactElement {
           size={v.size}
           loading={v.loading}
           disabled={v.disabled}
+          onPress={
+            node.on_click ? () => actionEngine.dispatch(node.on_click!) : undefined
+          }
         >
           {v.icon_left && <Interpreter node={v.icon_left} />}
-          <Interpreter node={v.label} />
+          {/* label is TextSchema ({ text, color?, font_size? }), not a Node —
+              ButtonComponentSchema types it that way, so render it directly
+              instead of routing through the Interpreter (which requires a
+              wire `type` and crashed on every button). */}
+          <DSText color={v.label.color} size={v.label.font_size}>
+            {v.label.text}
+          </DSText>
           {v.icon_right && <Interpreter node={v.icon_right} />}
         </DSButton>
       )}


### PR DESCRIPTION
Ports the fixes discovered during the creator app's first local end-to-end run from node_modules dist patches into source. Five fixes, one changeset (minor → 2.5.0):

1. **Every SDUI button was dead**: `DSButton` renders an inner `Pressable` that becomes the touch responder, so `SduiNode`'s outer `Clickable` never fired. `ButtonRenderer` now forwards `on_click` to `DSButton.onPress` (and passes `on_click={undefined}` to `SduiNode` so disabled buttons can't dispatch via the wrapper).
2. **Every button render crashed**: `ButtonComponentSchema` types `label` as `TextSchema` (`{ text, color?, font_size? }`) but the renderer passed it to `<Interpreter>`, which requires a wire `type` (`Cannot read property 'startsWith' of undefined`). Renderer and schema now agree.
3. **`useLocalStore` exported from the package root** — amplify-creator-app PR #22 imports it; that PR must not merge before this publishes.
4. **Document fetches now send `X-Dev-Identity`** for localhost BFF URLs, matching the action engine (shared `is-localhost` util; `bffBaseUrl` threaded through `AuthInterceptorConfig`).
5. **`getEndpoint` falls back to the codegen'd `EndpointPaths` catalog** (176 ids) — the hand-maintained registry stub covered 20 ids with divergent naming, so page-document endpoint ids failed with `Unknown endpoint`. Per the registry's own header comment, catalog-backing was the intended end state.

Tests: 145 passing; `node-registry.test` fails identically on unmodified main in a fresh local checkout (react-native flow-syntax transform via tsx) and is green in CI. Build clean.

Verified live (as dist patches) on Android emulator: bootstrap → login renders → button navigates → authenticated home → Explore tab cards from mock BFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)