### PR TITLE
fix(sdui-runtime): register creator.auth.bootstrap endpoint

### DIFF
--- a/.changeset/sdui-runtime-bootstrap-endpoint.md
+++ b/.changeset/sdui-runtime-bootstrap-endpoint.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+Add creator.auth.bootstrap to the endpoint registry — the bootstrap route predates the /v1/creator/* path convention and is absent from the codegen'd catalog, so authenticated app entry could not resolve it

--- a/packages/sdui-runtime/src/bff/endpoint-registry.ts
+++ b/packages/sdui-runtime/src/bff/endpoint-registry.ts
@@ -47,6 +47,10 @@ export function resolvePath(
  */
 export const endpointRegistry: Record<string, EndpointDefinition> = {
   // Auth
+  // bootstrap predates the /v1/creator/* path convention and is absent from
+  // the codegen'd catalog; the registry carries it until the creator-bff
+  // OpenAPI spec covers it.
+  'creator.auth.bootstrap': { method: 'GET', path: '/auth/bootstrap' },
   'auth.otp-init': { method: 'POST', path: '/v1/creator/auth/otp/init' },
   'auth.otp-verify': { method: 'POST', path: '/v1/creator/auth/otp/verify' },
   'auth.refresh': { method: 'POST', path: '/v1/creator/auth/sessions/refresh' },


### PR DESCRIPTION
The bootstrap route (`GET /auth/bootstrap`) predates the `/v1/creator/*` path convention and is absent from the contracts package's codegen'd catalog — so the app's entry flow can't resolve its page document (`Unknown endpoint`). Adds the one registry entry (the registry's remaining purpose post-catalog-fallback: method overrides + catalog gaps), with a pointer to the real fix (cover bootstrap in the creator-bff OpenAPI spec). Patch changeset → 2.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)