### PR TITLE
docs(zenith): update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,11 +51,19 @@ packages/
   tokens-brand/       — Brand Platform tokens (purple primary, light/dark themes)
   tokens-atmosphere/  — Atmosphere tokens (gold accent, dark-first themes)
   tokens-creator/     — Creator App tokens (SDUI mappings, mobile-optimized)
+  tokens-oportunities/ — Oportunities tokens (apricot palette, light/dark)
   ui/                 — Shared React components (Button, Badge, Card, EmptyState, Skeleton)
   storybook/          — Component documentation and visual testing
   eslint-config/      — Design system lint rules (no-hardcoded-colors, no-raw-spacing, prefer-token-import)
   feature-flags/      — Feature flag utilities
+  sdui-runtime/       — SDUI runtime for Creator App (interpreter, action engine, bottom-sheet manager, loaders, providers)
 ```
+
+### sdui-runtime endpoint registry notes
+
+- The endpoint registry is **partially codegen'd** from the `/v1/creator/*` path convention. Routes that predate this convention are **absent from the generated catalog** and must be added manually.
+- `creator.auth.bootstrap` is one such manually-registered route — it predates `/v1/creator/*` and is required for authenticated app entry. See `packages/sdui-runtime/CHANGELOG.md` v2.5.1.
+- When adding a new route that does not follow `/v1/creator/*`, register it explicitly in the endpoint registry rather than relying on codegen.
 
 ## Token File Format
 


### PR DESCRIPTION
## Summary
- **Trigger:** commit `12679e6`
- **File updated:** `CLAUDE.md`
- **Confidence:** 🟡 0.67
- **Reason:** A missing endpoint (creator.auth.bootstrap) was added to the sdui-runtime endpoint registry — engineers working in this repo need to know this route exists outside the codegen'd catalog and predates the /v1/creator/* path convention.

This is an automated documentation update by Zenith. Needs human review.

---
Generated by [Zenith AI CTO](https://github.com/one-impression/zenith-coding-agent)