### PR TITLE
feat(sdui): validate composite against typed SDK schema (sdk-native-sdui@3.1.0)

### DIFF
--- a/.changeset/sdui-typed-composite-sdk-3-1.md
+++ b/.changeset/sdui-typed-composite-sdk-3-1.md
@@ -1,0 +1,14 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+Validate the composite snippet against the typed SDK schema.
+
+Bumps `@one-impression/sdk-native-sdui` to `^3.1.0` (which now ships the
+`composite` / `submit` / `select_trigger` / form-validation / header-slot
+contracts) and switches the composite renderer from the placeholder `z.any()`
+to the real `CompositeSchema.shape.data` discriminated union — so cover/stack/row
+nodes are now type-validated at the boundary. The ephemeral local `submit`
+ActionType patch is no longer needed (the verb is in the published SDK). Also
+aligns the playground's `group_config` `gap` demos to the long-form spacing
+tokens the schema expects.

--- a/apps/sdui-playground/package.json
+++ b/apps/sdui-playground/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@gorhom/bottom-sheet": "^5.2.14",
-    "@one-impression/sdk-native-sdui": "^3.0.0",
+    "@one-impression/sdk-native-sdui": "^3.1.0",
     "@one-impression/sdui-runtime": "*",
     "@one-impression/tokens-creator": "*",
     "@one-impression/ui-native": "*",

--- a/apps/sdui-playground/server/pages/catalog.home.json
+++ b/apps/sdui-playground/server/pages/catalog.home.json
@@ -833,7 +833,7 @@
       "id": "grp-horizontal",
       "data": {
         "stacking": "horizontal",
-        "gap": "sm",
+        "gap": "sdui.spacing.sm",
         "items": [
           { "type": "creator.ui_component.tag", "id": "grp-tag-reach", "data": { "label": { "text": "Reach", "color": "sdui.color.neutral-inverse" }, "gradient": { "angle": 90, "colors": ["#F55DC1", "#495AF4"] } } },
           { "type": "creator.ui_component.tag", "id": "grp-tag-eng", "data": { "label": { "text": "Engagement", "color": "sdui.color.neutral-inverse" }, "gradient": { "angle": 90, "colors": ["#F55DC1", "#495AF4"] } } },
@@ -874,7 +874,7 @@
       "id": "grp-horizontal-cards",
       "data": {
         "stacking": "horizontal",
-        "gap": "md",
+        "gap": "sdui.spacing.md",
         "item_flex": "equal",
         "items": [
           { "type": "creator.snippet.info_row", "id": "grp-card-mon", "data": { "title": { "text": "Mon", "font_weight": "bold", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "12 leads", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" }, "card": {} } },
@@ -897,7 +897,7 @@
       "data": {
         "stacking": "vertical",
         "card": {},
-        "gap": "md",
+        "gap": "sdui.spacing.md",
         "items": [
           { "type": "creator.snippet.info_row", "id": "grp-cv-1", "data": { "title": { "text": "Reach", "font_weight": "medium", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "1.2M accounts", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" } } },
           { "type": "creator.snippet.info_row", "id": "grp-cv-2", "data": { "title": { "text": "Engagement", "font_weight": "medium", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "84K interactions", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" } } },
@@ -919,7 +919,7 @@
       "data": {
         "stacking": "horizontal",
         "card": {},
-        "gap": "md",
+        "gap": "sdui.spacing.md",
         "item_flex": "equal",
         "items": [
           { "type": "creator.snippet.info_row", "id": "grp-ch-1", "data": { "title": { "text": "Reach", "font_weight": "bold", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "1.2M", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" } } },

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@gorhom/bottom-sheet": "^5.2.14",
-        "@one-impression/sdk-native-sdui": "^3.0.0",
+        "@one-impression/sdk-native-sdui": "^3.1.0",
         "@one-impression/sdui-runtime": "*",
         "@one-impression/tokens-creator": "*",
         "@one-impression/ui-native": "*",
@@ -5073,9 +5073,9 @@
       "link": true
     },
     "node_modules/@one-impression/sdk-native-sdui": {
-      "version": "3.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@one-impression/sdk-native-sdui/3.0.0/4cfdfdb4835a7c3aa430daab4919a6380b72c1ec",
-      "integrity": "sha512-TnhFEkJ1kidNmie7GuEy7WMqe+pG2VdH35yJ5QAteUxZpH5iVOfLRHMHhFnr3NF8qlO6m6EQEWxzRoI1u5DTEw==",
+      "version": "3.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@one-impression/sdk-native-sdui/3.1.0/cdacce973d50a2655005260947d83372424b5571",
+      "integrity": "sha512-t8ygsmeTWEFe5EG1+rMqUG1eQ7L/S/StExS1oiRUH+L5Yb1LQN/FQRAKIC6C2DH4agQKvC4KUPVqwwdbknNASg==",
       "dependencies": {
         "zod": "^3.23.0"
       }
@@ -20255,20 +20255,20 @@
     },
     "packages/sdui-runtime": {
       "name": "@one-impression/sdui-runtime",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "zod": "^3.22.0",
         "zustand": "^4.5.0"
       },
       "devDependencies": {
-        "@one-impression/sdk-native-sdui": "^3.0.0",
+        "@one-impression/sdk-native-sdui": "^3.1.0",
         "tsup": "^8.0.0",
         "typescript": "^5.5.0"
       },
       "peerDependencies": {
         "@gorhom/bottom-sheet": "^5.0.0",
-        "@one-impression/sdk-native-sdui": "^3.0.0",
+        "@one-impression/sdk-native-sdui": "^3.1.0",
         "@one-impression/tokens-creator": ">=3.0.0",
         "@one-impression/ui-native": ">=2.0.2",
         "@react-navigation/native": ">=7.0.0",
@@ -20462,7 +20462,7 @@
     },
     "packages/ui-native": {
       "name": "@one-impression/ui-native",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "devDependencies": {
         "@types/react": "^18.2.0",
         "tsup": "^8.0.0",

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "react": ">=18.0.0",
     "react-native": ">=0.72.0",
-    "@one-impression/sdk-native-sdui": "^3.0.0",
+    "@one-impression/sdk-native-sdui": "^3.1.0",
     "@one-impression/ui-native": ">=2.0.2",
     "@one-impression/tokens-creator": ">=3.0.0",
     "@gorhom/bottom-sheet": "^5.0.0",
@@ -82,7 +82,7 @@
     }
   },
   "devDependencies": {
-    "@one-impression/sdk-native-sdui": "^3.0.0",
+    "@one-impression/sdk-native-sdui": "^3.1.0",
     "tsup": "^8.0.0",
     "typescript": "^5.5.0"
   },

--- a/packages/sdui-runtime/src/snippets/Composite/Composite.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/Composite/Composite.renderer.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
-import { z } from "zod";
 import { View, StyleSheet, type LayoutChangeEvent } from "react-native";
 import type { Node } from "@one-impression/sdk-native-sdui";
+import { CompositeSchema } from "@one-impression/sdk-native-sdui";
 import { Box, Card as DSCard } from "@one-impression/ui-native";
 import { sdui } from "@one-impression/tokens-creator/react-native";
 import { SduiNode } from "../../sdui-node/index.js";
@@ -13,17 +13,15 @@ import { Interpreter } from "../../interpreter/index.js";
  * The composite owns ARRANGEMENT (gutter, full-bleed, overlap, gaps) — never
  * CONTENTS. New arrangements are new `layout` values, never new snippet types.
  *
- * Reads `data` raw (permissive `z.any()` schema) until the typed
- * discriminated-union schema lands in `@one-impression/sdk-native-sdui`. The
- * SduiNode wrapper still gives it the clickable / viewable / trigger wiring.
+ * Validated against the typed discriminated-union `CompositeSchema.shape.data`
+ * from `@one-impression/sdk-native-sdui`; SduiNode handles the
+ * clickable / viewable / trigger wiring.
  *
  * Implemented layouts:
  *   - "cover"        media (full-bleed) + overlay chips + float (edge-overlap)
- *                    + body (gutter-inset rows) + banner (full-width footer)
+ *                    + body (gutter-inset rows) + footer (full-width strip)
  *   - "stack"/"row"  generic linear arrangement (supersedes group_config)
  */
-
-const RAW_SCHEMA = z.any();
 
 // Internal rhythm — owned by the composite, sourced from tokens (same discipline
 // as the page gutter). Not declared per-instance on the wire.
@@ -232,7 +230,7 @@ export function CompositeRenderer(node: Node): React.ReactElement | null {
   return (
     <SduiNode
       data={node.data}
-      schema={RAW_SCHEMA}
+      schema={CompositeSchema.shape.data}
       id={node.id}
       type={node.type}
       on_click={node.on_click}
@@ -242,7 +240,10 @@ export function CompositeRenderer(node: Node): React.ReactElement | null {
       view_events={node.view_events}
       load_events={node.load_events}
     >
-      {(v: Record<string, unknown>) => {
+      {(validated) => {
+        // The slot components read fields defensively off a loose record; the
+        // discriminated union is already validated by SduiNode above.
+        const v = validated as Record<string, unknown>;
         switch (layout) {
           case "cover":
             return <CoverLayout v={v} />;


### PR DESCRIPTION
Closes the loop on the SDUI contract work: now that **amplify-schemas #305** shipped the typed contracts and published `@one-impression/sdk-native-sdui@3.1.0`, the runtime validates against them instead of reading raw.

## Changes
- Bump `@one-impression/sdk-native-sdui` `^3.0.0` → `^3.1.0` (sdui-runtime deps+peer, playground app).
- Composite renderer: placeholder `z.any()` → real **`CompositeSchema.shape.data`** discriminated union — cover/stack/row nodes are type-validated at the boundary.
- Drops the ephemeral local `submit` ActionType patch (the verb is in the published SDK now).
- Aligns the playground's `group_config` `gap` demos to long-form spacing tokens (`sdui.spacing.*`), matching the SDK token convention the rest of the demos already use.

## Verification
`sdui-runtime` builds clean against 3.1.0. On-device: the composite campaign card and the home `group_config` demos render with **no `parse_error`** against the typed schema (Android emulator). Changeset included (patch).

Follows #222 (runtime) and amplify-schemas#305 (contracts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)