### PR TITLE
feat(sdui): viewport-visibility lifecycle + backend-driven infinite-scroll feeds

### DIFF
--- a/.changeset/sdui-viewport-lifecycle-feed.md
+++ b/.changeset/sdui-viewport-lifecycle-feed.md
@@ -1,0 +1,9 @@
+---
+"@one-impression/sdui-runtime": minor
+---
+
+Viewport-visibility lifecycle + backend-driven infinite-scroll feeds.
+
+- **Viewport coordinator** — `PageFeed` now detects real item visibility via FlatList `onViewableItemsChanged` (50% / 250ms), replacing the `onLayout` proxy for list items. It fires each node's `on_view` / `on_exit` triggers honoring per-trigger `policy` (`once` | `every`), with `once`-dedup keyed by `(node_id, trigger_id)`. `SduiNode` defers its view lifecycle to the surface when one manages it (`ViewportManagedProvider`).
+- **Backend-driven infinite scroll** — a feed renders `sdui.snippet.composite` cards as top-level `page.items`; the BFF puts an `on_view` (policy `once`) load-more on the Nth-last card, returns an `append_items` action, and omits `on_view` on the last batch to terminate. The cursor lives entirely server-side; the client takes no pagination decisions. `usePageStore.appendItems` now supports top-level (feed) append, and `append_items` appends the raw nodes (validated at render) so node-level fields like `viewability` aren't stripped.
+- Playground: the campaigns feed (`demo.feed`) + a paginated fixture endpoint demonstrate it end-to-end (15 cards over 2 backend-driven loads, no cascade, clean termination).

--- a/apps/sdui-playground/package.json
+++ b/apps/sdui-playground/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@gorhom/bottom-sheet": "^5.2.14",
-    "@one-impression/sdk-native-sdui": "^3.1.0",
+    "@one-impression/sdk-native-sdui": "^3.2.0",
     "@one-impression/sdui-runtime": "*",
     "@one-impression/tokens-creator": "*",
     "@one-impression/ui-native": "*",

--- a/apps/sdui-playground/server/fixture-server.mjs
+++ b/apps/sdui-playground/server/fixture-server.mjs
@@ -55,6 +55,84 @@ const readJsonBody = (req) =>
     });
   });
 
+// ─── Campaigns feed (composite cards + backend-driven infinite scroll) ───────
+// The feed renders `sdui.snippet.composite` cards as top-level page.items. The
+// 2nd-last card of each batch carries a `viewability.on_view` (policy: once)
+// that bff_calls this server for the next batch; the server returns an
+// `append_items` action. The LAST batch omits `on_view`, so it self-terminates
+// — the cursor lives entirely here, never on the client.
+const FEED_PAGE_SIZE = 5;
+const FEED_TOTAL = 15;
+const FEED_BRANDS = [
+  "Lumina Beauty", "Verde Skincare", "Aura Cosmetics", "Nova Wellness",
+  "Bloom Organics", "Ceré Paris", "Indigo Hair", "Solstice Fragrance",
+];
+
+function campaignCard(i) {
+  const brand = FEED_BRANDS[(i - 1) % FEED_BRANDS.length];
+  return {
+    type: "sdui.snippet.composite",
+    id: `campaign-${i}`,
+    on_click: { type: "navigate", payload: { target: "creator.campaigns.detail", op: "push", params: { id: String(i) } } },
+    data: {
+      layout: "cover",
+      surface: { bg_color: "sdui.color.neutral-inverse", border_color: "sdui.color.neutral-subtle" },
+      media: { type: "creator.snippet.banner_image", id: `m-${i}`, data: { image: { src: `https://picsum.photos/seed/camp${i}/640/320`, aspect_ratio: 2 } } },
+      float: { type: "creator.ui_component.image", id: `a-${i}`, data: { src: `https://picsum.photos/seed/brand${i}/120`, width: 64, height: 64, border_radius: "sdui.radius.full" } },
+      float_end: [
+        { type: "creator.ui_component.tag", id: `cash-${i}`, data: { label: { text: `₹${(1000 + i * 200).toLocaleString("en-IN")} Cash` }, bg_color: "sdui.color.positive-weak", text_color: "sdui.color.positive" } },
+      ],
+      body: [
+        { type: "creator.snippet.info_row", id: `n-${i}`, data: { title: { text: `${brand} · #${i}`, font_weight: "medium", font_size: "sdui.font-size.lg" } } },
+        { type: "creator.snippet.info_row", id: `meta-${i}`, data: { title: { text: "Beauty · Micro creators", font_size: "sdui.font-size.sm", color: "sdui.color.neutral-medium" } } },
+      ],
+      footer: { type: "creator.snippet.info_row", id: `f-${i}`, data: { title: { text: "Apply now — closes soon", font_size: "sdui.font-size.sm" } } },
+    },
+  };
+}
+
+// `nextCursor` null ⇒ last page (no on_view ⇒ stops). Otherwise the 2nd-last
+// card carries the load-more trigger pointing at the next cursor.
+function campaignBatch(startId, count, nextCursor) {
+  const cards = [];
+  for (let k = 0; k < count; k++) {
+    const card = campaignCard(startId + k);
+    if (nextCursor !== null && k === count - 2) {
+      card.viewability = {
+        on_view: [{
+          id: "load-more",
+          policy: "once",
+          action: { type: "bff_call", payload: { endpoint: "creator.campaigns.list", method: "GET", query_params: { cursor: String(nextCursor) } } },
+        }],
+      };
+    }
+    cards.push(card);
+  }
+  return cards;
+}
+
+function buildFeedPage() {
+  const nextCursor = FEED_TOTAL > FEED_PAGE_SIZE ? FEED_PAGE_SIZE : null;
+  return {
+    id: "demo.feed",
+    title: "Campaigns",
+    protocol_version: "1.0.0",
+    layout: "feed",
+    data: {
+      header: {
+        type: "creator.snippet.page_header",
+        id: "feed-hdr",
+        data: {
+          title: { text: "Campaigns", font_size: "sdui.font-size.xl", font_weight: "bold", color: "sdui.color.neutral-inverse" },
+          subtitle: { text: "infinite scroll · composite cards", color: "sdui.color.neutral-inverse" },
+          background: { gradient: { colors: ["#7C3AED", "#F2F2F2"], angle: 180 } },
+        },
+      },
+    },
+    items: campaignBatch(1, FEED_PAGE_SIZE, nextCursor),
+  };
+}
+
 const server = createServer(async (req, res) => {
   const url = req.url ?? "/";
   // eslint-disable-next-line no-console
@@ -93,8 +171,32 @@ const server = createServer(async (req, res) => {
     return;
   }
 
+  // Campaigns pagination — the load-more bff_call (creator.campaigns.list →
+  // /v1/creator/campaigns) lands here. Returns an `append_items` action that the
+  // bff_call handler dispatches. The cursor is tracked server-side via the query
+  // param baked into each batch's load-more trigger; the final page omits it.
+  if (url.startsWith("/v1/creator/campaigns")) {
+    const cursor = Number(new URL(url, "http://x").searchParams.get("cursor") || "0");
+    const count = Math.min(FEED_PAGE_SIZE, FEED_TOTAL - cursor);
+    if (count <= 0) {
+      json(res, 200, { action: { type: "append_items", payload: { target: "demo.feed", items: [], has_more: false } } });
+      return;
+    }
+    const nextCursor = cursor + count < FEED_TOTAL ? cursor + count : null;
+    const items = campaignBatch(cursor + 1, count, nextCursor);
+    console.log(`[fixture-server] campaigns cursor=${cursor} → cards ${cursor + 1}..${cursor + count} (next=${nextCursor})`);
+    json(res, 200, { action: { type: "append_items", payload: { target: "demo.feed", items, has_more: nextCursor !== null } } });
+    return;
+  }
+
   if (url.startsWith(PAGE_PREFIX)) {
     const target = decodeURIComponent(url.slice(PAGE_PREFIX.length));
+    // Generated campaigns feed (composite cards + infinite scroll) — overrides
+    // any on-disk fixture of the same name.
+    if (target === "demo.feed") {
+      json(res, 200, buildFeedPage());
+      return;
+    }
     // Guard against path traversal — target is a flat page id, never a path.
     if (target.includes("/") || target.includes("..")) {
       json(res, 400, { error: `invalid target "${target}"` });

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@gorhom/bottom-sheet": "^5.2.14",
-        "@one-impression/sdk-native-sdui": "^3.1.0",
+        "@one-impression/sdk-native-sdui": "^3.2.0",
         "@one-impression/sdui-runtime": "*",
         "@one-impression/tokens-creator": "*",
         "@one-impression/ui-native": "*",
@@ -5073,9 +5073,9 @@
       "link": true
     },
     "node_modules/@one-impression/sdk-native-sdui": {
-      "version": "3.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@one-impression/sdk-native-sdui/3.1.0/cdacce973d50a2655005260947d83372424b5571",
-      "integrity": "sha512-t8ygsmeTWEFe5EG1+rMqUG1eQ7L/S/StExS1oiRUH+L5Yb1LQN/FQRAKIC6C2DH4agQKvC4KUPVqwwdbknNASg==",
+      "version": "3.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@one-impression/sdk-native-sdui/3.2.0/6f425844c474f518ec8b8acb982a88c4c5556715",
+      "integrity": "sha512-uMhDeeGdtctGPW2s3rjm/3WeVVCGg+HylumMFPWDi7tvZxvJYPR6GDGH2pJBlKD+NEJ+VN449N99r4+qGULPTg==",
       "dependencies": {
         "zod": "^3.23.0"
       }
@@ -20262,13 +20262,13 @@
         "zustand": "^4.5.0"
       },
       "devDependencies": {
-        "@one-impression/sdk-native-sdui": "^3.1.0",
+        "@one-impression/sdk-native-sdui": "^3.2.0",
         "tsup": "^8.0.0",
         "typescript": "^5.5.0"
       },
       "peerDependencies": {
         "@gorhom/bottom-sheet": "^5.0.0",
-        "@one-impression/sdk-native-sdui": "^3.1.0",
+        "@one-impression/sdk-native-sdui": "^3.2.0",
         "@one-impression/tokens-creator": ">=3.0.0",
         "@one-impression/ui-native": ">=2.0.2",
         "@react-navigation/native": ">=7.0.0",

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "react": ">=18.0.0",
     "react-native": ">=0.72.0",
-    "@one-impression/sdk-native-sdui": "^3.1.0",
+    "@one-impression/sdk-native-sdui": "^3.2.0",
     "@one-impression/ui-native": ">=2.0.2",
     "@one-impression/tokens-creator": ">=3.0.0",
     "@gorhom/bottom-sheet": "^5.0.0",
@@ -82,7 +82,7 @@
     }
   },
   "devDependencies": {
-    "@one-impression/sdk-native-sdui": "^3.1.0",
+    "@one-impression/sdk-native-sdui": "^3.2.0",
     "tsup": "^8.0.0",
     "typescript": "^5.5.0"
   },

--- a/packages/sdui-runtime/src/action-engine/handlers/append-items.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/append-items.ts
@@ -1,10 +1,17 @@
 import { AppendItemsPayloadSchema } from "@one-impression/sdk-native-sdui";
-import type { Action } from "@one-impression/sdk-native-sdui";
+import type { Action, Node } from "@one-impression/sdk-native-sdui";
 import type { ActionEngineConfig, ActionEngine } from "../types.js";
 
 /**
  * append_items — appends items to a target list node in the page store.
  * Supports cursor and has_more for infinite scroll pagination.
+ *
+ * We validate the envelope (target / cursor / has_more) but append the RAW
+ * item nodes rather than the strict-parsed ones: appended nodes are validated
+ * at render time by SduiNode, and a strict node parse here would silently strip
+ * node-level fields the installed SDK doesn't yet model (e.g. `viewability`),
+ * which would break the very triggers driving pagination. Keeping the raw nodes
+ * is also forward-compatible with any future node field.
  */
 export async function handleAppendItems(
   action: Action,
@@ -12,9 +19,11 @@ export async function handleAppendItems(
   _engine: ActionEngine,
 ): Promise<void> {
   const payload = AppendItemsPayloadSchema.parse(action.payload);
+  const rawItems =
+    ((action.payload as { items?: Node[] } | undefined)?.items) ?? payload.items;
 
   const { usePageStore } = await import("../../state/usePageStore.js");
-  usePageStore.getState().appendItems(payload.target, payload.items, {
+  usePageStore.getState().appendItems(payload.target, rawItems, {
     cursor: payload.cursor,
     hasMore: payload.has_more,
   });

--- a/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
@@ -13,11 +13,13 @@ import type { Page, Node, Action } from "@one-impression/sdk-native-sdui";
 import { Interpreter } from "../../interpreter/index.js";
 import { GutterItem } from "../../layout/page-gutter.js";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";
+import { useTelemetry } from "../../telemetry/useTelemetry.js";
 import { useBottomSheetStore } from "../../bottom-sheet/useBottomSheetStore.js";
 import { usePageRefresh } from "../../hooks/usePageRefresh.js";
 import { useAppStateSession } from "../../hooks/useAppStateSession.js";
 import { usePageStore } from "../../state/usePageStore.js";
 import { Gradient, type GradientItem } from "../../gradient/index.js";
+import { ViewportManagedProvider, fireViewability } from "../../viewport/index.js";
 import { extractFeedPageData, type FeedPageData } from "./extractFeedPageData.js";
 
 interface PageProps {
@@ -98,6 +100,7 @@ export type { FeedPageData };
  */
 export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
   const actionEngine = useActionEngine();
+  const telemetry = useTelemetry();
   const register = useBottomSheetStore((s) => s.register);
   const unregister = useBottomSheetStore((s) => s.unregister);
   const { refreshing, onRefresh } = usePageRefresh(page.on_refresh);
@@ -105,6 +108,31 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
   const [loadingMore, setLoadingMore] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const loadingMoreRef = useRef(false);
+
+  // Viewport lifecycle for list items — real visibility via FlatList's
+  // onViewableItemsChanged (NOT onLayout). Fires each item's on_view/on_exit
+  // triggers per policy; one-shot triggers dedup against `viewFiredRef`. This is
+  // how backend-driven infinite scroll works: the BFF puts an `on_view`
+  // load-more on the Nth-last card; it fires only when that card is truly seen.
+  const viewFiredRef = useRef<Set<string>>(new Set());
+  // viewabilityConfig MUST be a stable reference — FlatList throws if it changes.
+  const viewabilityConfigRef = useRef({
+    itemVisiblePercentThreshold: 50,
+    minimumViewTime: 250,
+  });
+  const handleViewableItemsChanged = useRef(
+    ({ changed }: { changed: { item: Node; isViewable: boolean }[] }) => {
+      const deps = {
+        fired: viewFiredRef.current,
+        dispatch: (a: Action) => actionEngine.dispatch(a),
+        emit: (name: string, params?: Record<string, unknown>) =>
+          telemetry.emit(name, params),
+      };
+      for (const { item, isViewable } of changed) {
+        fireViewability(item, isViewable ? "view" : "exit", deps);
+      }
+    },
+  ).current;
 
   const pageData = extractFeedPageData(page.data);
   const { header, filters, on_load_more: onLoadMore, loader, empty_state: emptyState, config, footer } =
@@ -281,29 +309,35 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
           <Interpreter node={header} />
         </View>
       ) : null}
-      <View style={styles.body}>
-        <FlatList
-          data={items}
-          renderItem={renderItem}
-          keyExtractor={keyExtractor}
-          ListHeaderComponent={renderHeader}
-          ListFooterComponent={renderListFooter}
-          ListEmptyComponent={renderEmpty}
-          onEndReached={handleEndReached}
-          onEndReachedThreshold={0.5}
-          onScroll={handleScroll}
-          scrollEventThrottle={16}
-          contentContainerStyle={[
-            items?.length ? null : styles.container,
-            { paddingBottom: insets.bottom + sdui.spacing.lg },
-          ]}
-          refreshControl={
-            page.on_refresh ? (
-              <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
-            ) : undefined
-          }
-        />
-      </View>
+      {/* The list owns viewport detection for its items, so SduiNode defers its
+          on_view/on_exit to onViewableItemsChanged (real visibility) below. */}
+      <ViewportManagedProvider>
+        <View style={styles.body}>
+          <FlatList
+            data={items}
+            renderItem={renderItem}
+            keyExtractor={keyExtractor}
+            ListHeaderComponent={renderHeader}
+            ListFooterComponent={renderListFooter}
+            ListEmptyComponent={renderEmpty}
+            onEndReached={handleEndReached}
+            onEndReachedThreshold={0.5}
+            onViewableItemsChanged={handleViewableItemsChanged}
+            viewabilityConfig={viewabilityConfigRef.current}
+            onScroll={handleScroll}
+            scrollEventThrottle={16}
+            contentContainerStyle={[
+              items?.length ? null : styles.container,
+              { paddingBottom: insets.bottom + sdui.spacing.lg },
+            ]}
+            refreshControl={
+              page.on_refresh ? (
+                <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+              ) : undefined
+            }
+          />
+        </View>
+      </ViewportManagedProvider>
       {footer ? (
         <View style={styles.footer}>
           <Interpreter node={footer} />

--- a/packages/sdui-runtime/src/sdui-node/SduiNode.tsx
+++ b/packages/sdui-runtime/src/sdui-node/SduiNode.tsx
@@ -6,6 +6,7 @@ import { SduiErrorBoundary } from "./SduiErrorBoundary.js";
 import { SduiFallback } from "./SduiFallback.js";
 import { Clickable } from "../clickable/Clickable.js";
 import { Viewable } from "../viewable/Viewable.js";
+import { useViewportManaged } from "../viewport/index.js";
 import { useActionEngine } from "../action-engine/useActionEngine.js";
 import { useTelemetry } from "../telemetry/useTelemetry.js";
 import { parseNodeData } from "./parseNodeData.js";
@@ -35,6 +36,10 @@ export function SduiNode<TSchema extends z.ZodTypeAny>(
 ): React.ReactElement {
   const actionEngine = useActionEngine();
   const telemetry = useTelemetry();
+  // When an ancestor surface (e.g. a feed FlatList) manages viewport detection,
+  // it fires the view lifecycle centrally via real visibility — so we must NOT
+  // also fire on_view here through the onLayout proxy (which fires on render).
+  const viewportManaged = useViewportManaged();
 
   // Parse defensively. A naked `schema.parse(...)` call would throw on
   // malformed or stale wire payloads and crash the entire page. During
@@ -112,7 +117,9 @@ export function SduiNode<TSchema extends z.ZodTypeAny>(
       nodeId={props.id}
       fallback={<SduiFallback nodeId={props.id} nodeType={props.type} />}
     >
-      <Viewable onView={handleViewed}>
+      {viewportManaged ? (
+        // Managed surface owns the view lifecycle (real visibility) — render the
+        // clickable content directly, no onLayout-based Viewable.
         <Clickable
           onPress={
             props.on_click
@@ -122,7 +129,19 @@ export function SduiNode<TSchema extends z.ZodTypeAny>(
         >
           {props.children(parsed.value)}
         </Clickable>
-      </Viewable>
+      ) : (
+        <Viewable onView={handleViewed}>
+          <Clickable
+            onPress={
+              props.on_click
+                ? () => actionEngine.dispatch(props.on_click!)
+                : undefined
+            }
+          >
+            {props.children(parsed.value)}
+          </Clickable>
+        </Viewable>
+      )}
     </SduiErrorBoundary>
   );
 }

--- a/packages/sdui-runtime/src/state/usePageStore.ts
+++ b/packages/sdui-runtime/src/state/usePageStore.ts
@@ -283,6 +283,13 @@ export const usePageStore = create<PageStoreState & PageStoreActions>((set) => (
         );
         return {};
       }
+      // Top-level append: a feed renders `page.items` directly (each item is a
+      // card), so paginating it targets the page id and appends to that array.
+      // (Nested list/section nodes still append into their own `data.items`
+      // via appendItemsInTree below.)
+      if (targetId === state.page.id) {
+        return { page: { ...state.page, items: [...state.page.items, ...items] } };
+      }
       const [nextItems, matched, mutated] = appendItemsInTree(
         state.page.items,
         targetId,

--- a/packages/sdui-runtime/src/viewport/ViewportManagedContext.tsx
+++ b/packages/sdui-runtime/src/viewport/ViewportManagedContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext } from "react";
+
+/**
+ * Signals that an ancestor surface (e.g. a feed's FlatList) owns viewport
+ * detection for this subtree via a real visibility API (onViewableItemsChanged)
+ * and drives each node's view lifecycle centrally.
+ *
+ * When true, `SduiNode` does NOT fire its own `on_view` / `view_events` via the
+ * `onLayout` proxy — that would fire on render, not on visibility. The managing
+ * surface fires the full lifecycle (see {@link fireViewability}) instead.
+ *
+ * Default false: outside a managed surface (standard ScrollView pages) SduiNode
+ * keeps its existing self-managed behavior.
+ */
+const ViewportManagedContext = createContext<boolean>(false);
+
+export function ViewportManagedProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <ViewportManagedContext.Provider value={true}>
+      {children}
+    </ViewportManagedContext.Provider>
+  );
+}
+
+/** True when an ancestor surface manages this node's viewport lifecycle. */
+export function useViewportManaged(): boolean {
+  return useContext(ViewportManagedContext);
+}

--- a/packages/sdui-runtime/src/viewport/fireViewability.ts
+++ b/packages/sdui-runtime/src/viewport/fireViewability.ts
@@ -1,0 +1,74 @@
+import type { Action, Node } from "@one-impression/sdk-native-sdui";
+
+interface ViewTrigger {
+  action: Action;
+  policy?: "once" | "every";
+  id?: string;
+}
+
+interface ViewabilityBlock {
+  on_view?: ViewTrigger[];
+  on_exit?: ViewTrigger[];
+}
+
+interface TrackEvent {
+  name: string;
+  params?: Record<string, unknown>;
+}
+
+export interface FireViewabilityDeps {
+  /** Fire-once memory across re-entries, keyed `${nodeId}::${phase}::${triggerKey}`. */
+  fired: Set<string>;
+  dispatch: (action: Action) => void;
+  emit: (name: string, params?: Record<string, unknown>) => void;
+}
+
+/**
+ * Fire a node's viewport triggers for a phase, honoring per-trigger policy.
+ *
+ * Phase `view` runs: the scalar `on_view` sugar (once) + every `viewability.on_view`
+ * trigger (per its policy) + `view_events` telemetry (once). Phase `exit` runs the
+ * `viewability.on_exit` triggers (per policy). `once` triggers dedup against
+ * `fired` (so they don't re-run when the node re-enters); `every` always fires.
+ *
+ * Called by a surface that owns real viewport detection (see PageFeed) — NOT by
+ * SduiNode's onLayout proxy, which fires on render rather than on visibility.
+ */
+export function fireViewability(
+  node: Node,
+  phase: "view" | "exit",
+  deps: FireViewabilityDeps,
+): void {
+  const nodeId = node.id ?? "";
+  const v = (node as { viewability?: ViewabilityBlock }).viewability;
+
+  const triggers: ViewTrigger[] = [];
+  if (phase === "view") {
+    // Scalar `on_view` is sugar for a single once-trigger.
+    if (node.on_view) triggers.push({ action: node.on_view, policy: "once", id: "__scalar" });
+    if (v?.on_view) triggers.push(...v.on_view);
+  } else if (v?.on_exit) {
+    triggers.push(...v.on_exit);
+  }
+
+  triggers.forEach((t, i) => {
+    if ((t.policy ?? "once") === "once") {
+      const key = `${nodeId}::${phase}::${t.id ?? i}`;
+      if (deps.fired.has(key)) return;
+      deps.fired.add(key);
+    }
+    deps.dispatch(t.action);
+  });
+
+  // Impression telemetry — one-shot per node, on first view.
+  if (phase === "view") {
+    const events = (node as { view_events?: TrackEvent[] }).view_events;
+    if (events && events.length) {
+      const key = `${nodeId}::__view_events`;
+      if (!deps.fired.has(key)) {
+        deps.fired.add(key);
+        for (const e of events) deps.emit(e.name, e.params);
+      }
+    }
+  }
+}

--- a/packages/sdui-runtime/src/viewport/index.ts
+++ b/packages/sdui-runtime/src/viewport/index.ts
@@ -1,0 +1,6 @@
+export {
+  ViewportManagedProvider,
+  useViewportManaged,
+} from "./ViewportManagedContext.js";
+export { fireViewability } from "./fireViewability.js";
+export type { FireViewabilityDeps } from "./fireViewability.js";


### PR DESCRIPTION
Makes `on_view` mean *entered the viewport* (it was an `onLayout` proxy that fired on render) and uses it for fully backend-driven infinite scroll. Verified end-to-end on device.

## Runtime
- **Viewport coordinator** — `PageFeed` detects real visibility via FlatList `onViewableItemsChanged` (50% / 250ms). It fires each node's `on_view` / `on_exit` triggers honoring per-trigger **`policy` (`once` | `every`)**, with `once`-dedup keyed `(node_id, trigger_id)`. `SduiNode` defers its view lifecycle to a managing surface (`ViewportManagedProvider`) so it no longer fires on render inside a feed.
- **Backend-driven infinite scroll** — a feed renders `composite` cards as top-level `page.items`; the BFF puts an `on_view` (policy `once`) load-more on the Nth-last card, returns an `append_items`, and omits `on_view` on the final batch to terminate. **The cursor lives entirely server-side — the client takes no pagination decisions.**
- `usePageStore.appendItems` supports top-level (feed) append; `append_items` now appends **raw** nodes (validated at render) so node-level fields like `viewability` aren't stripped.

## Verified on device
15 campaigns over **2** backend-driven loads: `cursor=5` once → `cursor=10` once → stop. **No cascade on mount** (0 calls until scroll), once-dedup holds (no double-fire), cursor advances server-side, clean termination.

## Contract
Runs on the installed SDK **3.1.0** (coordinator reads `viewability` raw; the append fix preserves it). The typed `viewability` contract is merged in amplify-schemas (#312) and ships in **3.2.0** (Version PR pending). Follow-up: bump the SDK dep `3.1.0 → 3.2.0` once published — typed-contract only, no behavior change.

Pairs with amplify-schemas#312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)