### PR TITLE
docs(sdui-runtime): integration guide + BFF contract

### DIFF
--- a/packages/sdui-runtime/BFF-CONTRACT.md
+++ b/packages/sdui-runtime/BFF-CONTRACT.md
@@ -1,0 +1,140 @@
+# SDUI BFF contract
+
+How a backend emits SDUI pages the runtime can render. The wire types + typed
+builders live in `@one-impression/sdk-native-sdui` — **prefer the builders** over
+hand-written JSON; they validate shape at construction. The *why* behind the region
+model is in [`REGION-PAGE-MODEL.md`](./REGION-PAGE-MODEL.md); this is the reference.
+
+## 1. Page envelope
+
+```jsonc
+{
+  "id": "demo.feed",              // screen id (the navigate target)
+  "title": "My Campaigns",        // native-header title (used only if no header region)
+  "protocol_version": "1.0.0",
+  "layout": "feed",               // selects the layout renderer (standard | feed | sticky_footer | web_view | …)
+  "data": { /* chrome regions + skeletons — see §2 */ },
+  "items": [ /* the content region — see §2 */ ],
+  "on_load":    { /* Action — fires once when the screen mounts */ },
+  "on_refresh": { /* Action — pull-to-refresh */ },
+  "on_dismount":{ /* Action */ },
+  "on_back_press": { /* Action — Android hardware back */ },
+  "bottom_sheets": [ /* inline sheets, registered (not opened) */ ]
+}
+```
+
+Only `id` / `title` / `protocol_version` / `layout` / `items` are always meaningful; the
+rest are optional. A page that just renders content needs only `layout` + `items`.
+
+## 2. Regions
+
+A page is composed of **regions**. The convention:
+- `data.<region>` — a chrome region (a `Node` or `Node[]`), e.g. `data.header`, `data.footer`.
+- `items` — the **content** region (top-level).
+- `data.<region>_skeleton` — the region's loading placeholder.
+
+Which region renders in which on-screen **zone** (pinned top / scroll body / pinned bottom)
+is owned by the layout renderer, not the wire. For the `feed` layout: `header` → pinned top,
+`content` (= `items`) → scroll body, `footer` → pinned bottom.
+
+## 3. Shell-first + reload scopes
+
+A page can render a **shell** first (chrome + skeletons), then stream regions in via
+`reload` from `on_load`. The `reload` response is a **partial page**:
+
+- `response.data` is **shallow-merged** into the live page's `data` (unrefreshed regions + skeletons survive).
+- `response.items` **replaces** `items`.
+- The action's `regions` names which regions are refreshing → the runtime shows each one's skeleton while in flight; unnamed regions (e.g. a footer shell) stay mounted.
+
+| Trigger | `reload` regions | Response |
+|---------|------------------|----------|
+| first load / tab switch | `["header","content"]` | `{ data: { header: [...] }, items: [...] }` |
+| filter / pull-refresh | `["content"]` | `{ items: [...] }` |
+
+The runtime sends `regions` + the bound context as query params; return exactly the named regions. Full model + worked example: [`REGION-PAGE-MODEL.md`](./REGION-PAGE-MODEL.md).
+
+## 4. Action vocabulary
+
+Every interactive field (`on_click`, `on_load`, `on_refresh`, a chip's `on_click`, …) is an `Action`:
+
+| Verb | Payload (key fields) | Effect |
+|------|----------------------|--------|
+| `navigate` | `{ target, op, params }` | Push/replace a screen (via the app's `onNavigate`). |
+| `bff_call` | `{ endpoint, method?, query_params?, request_body?, on_success?, on_error? }` | Fetch; may dispatch a follow-up action from the response body. |
+| `reload` | `{ endpoint, regions[], method?, query_params?, request_body? }` | Region-scoped partial-page refresh (§3). |
+| `set_local` | `{ key, op, value? }` | Mutate local store. `op`: `set` / `merge` / `toggle` / `increment` / `remove` / **`array_toggle`** (add/remove a value from an array — multi-select). |
+| `compound` | `{ actions: Action[], mode? }` | Run actions in sequence (default) or parallel. |
+| `append_items` | `{ target, items, has_more? }` | Append raw nodes to a container (infinite scroll). |
+| `reload_section` / `replace_section` | `{ target, endpoint?/data }` | Swap a single node by id. |
+| `toast` / `dismiss` / `deeplink` / `emit_telemetry` / `branch` / `submit` | — | As named. |
+
+Any action may carry **`debounce_ms`** (backend-controlled): the engine coalesces a burst of
+the same action (keyed by verb + target + endpoint) onto the trailing run — e.g. a filter chip
+that re-fetches sets ~400ms; a tab switch omits it.
+
+## 5. Render-bindings (reactive local state)
+
+A `data` field may be a **binding** resolved (reactively) from the local store before
+render — so chips/tabs reflect selection instantly with no reload:
+
+```jsonc
+"selected": { "ref": "$.local.selected_filters", "contains": "beauty" }  // array membership → bool
+"active":   { "ref": "$.local.selected_tab",     "equals": "for_you"  }  // scalar equality → bool
+"x":        { "ref": "$.local.<key>" }                                    // raw value
+```
+
+`$.local.<key>` is a **flat** key lookup (mirrors `set_local` / `get` — `$.local.form.submitted`
+reads the literal key `"form.submitted"`, not nested). Bindings also work in request fields
+(`query_params` / `request_body`) of `bff_call` / `reload`, so a reload binds to the current
+context; arrays become CSV in query params.
+
+## 6. Skeletons
+
+`creator.snippet.skeleton` is a BFF-composed shimmer — the runtime supplies the pulse, you
+compose the shape:
+
+```jsonc
+{ "type": "creator.snippet.skeleton", "id": "skel-header", "data": {
+  "padding": 16,
+  "rows": [
+    { "row": [ { "shape": "line", "height": 24, "width": "55%" }, { "shape": "circle", "width": 24 } ], "justify": "between" },
+    { "shape": "line", "height": 14, "width": "35%" },
+    { "row": [ { "shape": "rect", "height": 32, "width": 76, "radius": 16 } ] }   // chip row
+  ]
+} }
+```
+
+- `rows` — stacked bars; a row is a single bar (`shape`: `rect` / `line` / `circle`, `height` / `width` / `radius`) or a **horizontal group** (`{ row: [...], justify }`).
+- `repeat` — render the rows N times (e.g. 4 card placeholders).
+- `card` — wrap each group in a card surface.
+- `padding` — horizontal inset (match the content's gutter).
+
+Compose a skeleton that *resembles* the region it replaces (header = title + icon + chip row; card = media + logo + tag + lines), and declare it as `data.<region>_skeleton`.
+
+## 7. Use the SDK builders
+
+`@one-impression/sdk-native-sdui` exports typed builders for nodes + actions — construct
+pages type-safely instead of raw JSON: `composite`, `chip`, `groupChips`, `tabsFooter`,
+`pageHeader`, `reload`, `setLocal`, `compound`, `bffCall`, `navigate`, … Each returns a
+validated node/action.
+
+```ts
+import { reload } from "@one-impression/sdk-native-sdui";
+reload({ endpoint: "creator.campaigns.list", regions: ["content"], debounceMs: 400,
+         queryParams: { tab: { ref: "$.local.selected_tab" }, filter: { ref: "$.local.selected_filters" } } });
+```
+
+## 8. Endpoints
+
+`bff_call` / `reload` take an **endpoint id** (e.g. `creator.campaigns.list`), not a path. The
+SDK's `EndpointPaths` maps id → request path (`/v1/creator/campaigns`) — the single source of
+truth shared with the gateway. Path params (`{id}`) are filled from `path_params`. Add new
+endpoints to the SDK's endpoint registry.
+
+## 9. Worked example
+
+The campaigns feed (`apps/sdui-playground/server/fixture-server.mjs`) is the canonical
+example: a shell (footer + header/content skeletons + `on_load → reload(["header","content"])`),
+a tab tap (`compound[set_local tab, set_local filters=[], reload(["header","content"])]`), and
+a filter tap (`compound[set_local array_toggle, reload(["content"], debounce 400)]`), with the
+endpoint returning the matching partial page per requested `regions`.

--- a/packages/sdui-runtime/INTEGRATION.md
+++ b/packages/sdui-runtime/INTEGRATION.md
@@ -1,0 +1,139 @@
+# Integrating SDUI into an app
+
+`@one-impression/sdui-runtime` renders **server-driven screens**: your BFF emits a
+page as JSON (the wire contract from `@one-impression/sdk-native-sdui`), and the
+runtime renders it, dispatches its actions, and owns navigation. You wire *how* to
+load a page and *how* actions reach your app's nav/auth — nothing else.
+
+- **`@one-impression/sdui-runtime`** — renderers, action engine, navigation host, the page scaffold.
+- **`@one-impression/sdk-native-sdui`** — the wire schemas + typed builders (Node-safe; used by your BFF too). See [`BFF-CONTRACT.md`](./BFF-CONTRACT.md).
+
+A complete working reference is `apps/sdui-playground` in this repo.
+
+## 1. Install
+
+```sh
+npm i @one-impression/sdui-runtime @one-impression/sdk-native-sdui
+```
+
+Peer dependencies the app must already have (see this package's `peerDependencies`):
+`react`, `react-native`, `@react-navigation/native` + `@react-navigation/native-stack`,
+`react-native-screens`, `react-native-safe-area-context`, `react-native-gesture-handler`,
+`@gorhom/bottom-sheet`, `@tanstack/react-query`. (`react-native-webview` if you use web-view pages.)
+
+## 2. Metro config — one `react` / `react-native`
+
+The #1 cause of red-screens: more than one copy of `react`/`react-native` in the tree
+(invalid-hook / invalid-element errors). In `metro.config.js`, force resolution to the
+**app's** copy and watch the workspace:
+
+```js
+config.resolver.resolveRequest = (ctx, moduleName, platform) => {
+  if (moduleName === "react" || moduleName === "react-native" || moduleName.startsWith("react-native/")) {
+    return ctx.resolveRequest({ ...ctx, originModulePath: APP_NODE_MODULES }, moduleName, platform);
+  }
+  return ctx.resolveRequest(ctx, moduleName, platform);
+};
+```
+
+See `apps/sdui-playground/metro.config.js` for the full monorepo setup (`watchFolders`, `nodeModulesPaths`, `unstable_enablePackageExports`).
+
+## 3. Provider stack
+
+Wrap the app once. The runtime exposes `SduiRuntimeProvider` (configures the action
+engine) and `IconStoreProvider` (fetches + caches the icon manifest):
+
+```tsx
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { SduiRuntimeProvider, IconStoreProvider, applyNavigate } from "@one-impression/sdui-runtime";
+
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+export function Providers({ children }) {
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider>
+        <BottomSheetModalProvider>
+          <QueryClientProvider client={queryClient}>
+            <SduiRuntimeProvider
+              bffConfig={{ baseUrl: "https://api.your-app.com" }}
+              authConfig={{ getToken: () => authStore.accessToken ?? null }}
+              telemetryConfig={{ emitter: { emit: (e, p) => analytics.track(e, p) } }}
+              onNavigate={(op, target, params) => applyNavigate(op, target, params)}
+              onToast={(level, message) => showToast(level, message)}
+              onDeeplink={(url) => Linking.openURL(url)}
+            >
+              <IconStoreProvider bffBaseUrl="https://api.your-app.com" authToken={authStore.accessToken}>
+                {children}
+              </IconStoreProvider>
+            </SduiRuntimeProvider>
+          </QueryClientProvider>
+        </BottomSheetModalProvider>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
+  );
+}
+```
+
+## 4. What the app supplies (`SduiRuntimeProvider`)
+
+| Prop | What it's for |
+|------|---------------|
+| `bffConfig.baseUrl` | Base URL the runtime's `bff_call` / `reload` resolve endpoint paths against. |
+| `authConfig.getToken()` | Returns the current bearer token (or `null`); the runtime adds `Authorization` on every BFF call. |
+| `telemetryConfig.emitter.emit(event, params)` | Where `sdui.node.rendered`, `view_events`, etc. go — wire to your analytics. |
+| `onNavigate(op, target, params)` | A `navigate` action lands here. Forward to `applyNavigate` (runtime's native stack) or your own router. |
+| `onToast(level, message)` | A `toast` action. |
+| `onDeeplink(url)` | A `deeplink` action. |
+
+The runtime also sends `X-Active-Influencer-Id` (when set via `useActiveSocialStore`) and,
+for localhost BFFs only, `X-Dev-Identity` — both handled internally.
+
+## 5. Mount the navigation host
+
+`SduiNavigationHost` owns the page stack + native transitions. Give it `resolvePage`
+(how to fetch a page by its `navigate` target) and the first screen:
+
+```tsx
+import { SduiNavigationHost } from "@one-impression/sdui-runtime";
+import type { Page } from "@one-impression/sdk-native-sdui";
+
+async function resolvePage(screenId: string): Promise<Page> {
+  const res = await fetch(`https://api.your-app.com/sdui/page/${encodeURIComponent(screenId)}`);
+  if (!res.ok) throw new Error(`page ${screenId} → ${res.status}`);
+  return (await res.json()) as Page;
+}
+
+export default function App() {
+  return (
+    <Providers>
+      <SduiNavigationHost resolvePage={resolvePage} initialScreenId="home" />
+    </Providers>
+  );
+}
+```
+
+`resolvePage` is the only wired seam — every `navigate` target round-trips through it, so
+navigation stays fully data-driven. The host hides its native header automatically when a
+page declares a header region (`data.header` or `data.header_skeleton`).
+
+## 6. Registering app-specific snippets
+
+> **Pending the `creator.* → sdui.*` namespace standardization.** Today the core snippet
+> registry is keyed under `creator.*`. Once neutralized, the core library is `sdui.*` and an
+> app registers its own snippets/ui-components by extending the runtime's registries
+> (`snippets` / `ui-components`), with `resolveRenderer` dispatching on the `.snippet.` /
+> `.ui_component.` layer segment so app types and core types coexist. This section will be
+> finalized when that lands.
+
+## Gotchas
+- **Single react/RN** — see §2. The most common red-screen.
+- **Icon manifest** — `IconStoreProvider` fetches the glyph manifest from your BFF (`/v1/.../assets/icons-manifest`) into MMKV; bundled essentials cover first paint. Point its `bffBaseUrl` at your BFF.
+- **`reload`/`bff_call` use endpoint *ids*, not paths** — the id (e.g. `creator.campaigns.list`) resolves to a path via the SDK's `EndpointPaths`. See [`BFF-CONTRACT.md`](./BFF-CONTRACT.md) §Endpoints.
+
+## Reference
+`apps/sdui-playground` is the canonical, runnable integration — `App.tsx`, `src/providers.tsx`,
+`src/fixtures/loadPage.ts`, `metro.config.js`, and a mock BFF (`server/fixture-server.mjs`).

--- a/packages/sdui-runtime/INTEGRATION.md
+++ b/packages/sdui-runtime/INTEGRATION.md
@@ -52,6 +52,11 @@ import { SduiRuntimeProvider, IconStoreProvider, applyNavigate } from "@one-impr
 
 const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
+// One source of truth — both the action engine (bff_call / reload) and the icon
+// store hit your BFF, so derive both from a single constant (and reuse it in
+// resolvePage, §5) rather than repeating the literal.
+const BFF_BASE_URL = "https://api.your-app.com";
+
 export function Providers({ children }) {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
@@ -59,14 +64,14 @@ export function Providers({ children }) {
         <BottomSheetModalProvider>
           <QueryClientProvider client={queryClient}>
             <SduiRuntimeProvider
-              bffConfig={{ baseUrl: "https://api.your-app.com" }}
+              bffConfig={{ baseUrl: BFF_BASE_URL }}
               authConfig={{ getToken: () => authStore.accessToken ?? null }}
               telemetryConfig={{ emitter: { emit: (e, p) => analytics.track(e, p) } }}
               onNavigate={(op, target, params) => applyNavigate(op, target, params)}
               onToast={(level, message) => showToast(level, message)}
               onDeeplink={(url) => Linking.openURL(url)}
             >
-              <IconStoreProvider bffBaseUrl="https://api.your-app.com" authToken={authStore.accessToken}>
+              <IconStoreProvider bffBaseUrl={BFF_BASE_URL} authToken={authStore.accessToken}>
                 {children}
               </IconStoreProvider>
             </SduiRuntimeProvider>
@@ -101,8 +106,9 @@ for localhost BFFs only, `X-Dev-Identity` — both handled internally.
 import { SduiNavigationHost } from "@one-impression/sdui-runtime";
 import type { Page } from "@one-impression/sdk-native-sdui";
 
+// BFF_BASE_URL is the same shared constant from §3.
 async function resolvePage(screenId: string): Promise<Page> {
-  const res = await fetch(`https://api.your-app.com/sdui/page/${encodeURIComponent(screenId)}`);
+  const res = await fetch(`${BFF_BASE_URL}/sdui/page/${encodeURIComponent(screenId)}`);
   if (!res.ok) throw new Error(`page ${screenId} → ${res.status}`);
   return (await res.json()) as Page;
 }


### PR DESCRIPTION
Phase 5 docs for the SDUI region page model (the runtime + SDK published as `sdui-runtime@2.7.0` / `sdk-native-sdui@3.4.0`).

- **`INTEGRATION.md`** (app/frontend) — install + peer deps, the single-`react` metro gotcha, the provider stack (`SduiRuntimeProvider` + `IconStoreProvider`), the 6 things the app supplies (`bffConfig`/`authConfig`/`telemetryConfig`/`onNavigate`/`onToast`/`onDeeplink`), mounting `SduiNavigationHost` + `resolvePage`, and a stub for app-specific snippet registration (marked **pending** the `creator.*`→`sdui.*` namespace work).
- **`BFF-CONTRACT.md`** (backend) — the page envelope, the region model, shell-first reload scopes + partial-page merge, the full action vocabulary (incl. `reload` regions, `set_local` `array_toggle`, `debounce_ms`), render-bindings (`$.local` + `contains`/`equals`), skeleton composition, the SDK builders, endpoint ids, and the campaigns worked example.

Grounded in the real published API (verified against `SduiRuntimeProvider`/`SduiNavigationHost`/`ActionEngineConfig` source + SDK builder exports). Companion to `REGION-PAGE-MODEL.md`. Docs only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)