### PR TITLE
feat: circular progress ring, tag colors, icon-svg fix, reload latest-wins

### DIFF
--- a/.changeset/circular-progress-ring.md
+++ b/.changeset/circular-progress-ring.md
@@ -1,0 +1,11 @@
+---
+"@one-impression/ui-native": minor
+"@one-impression/sdui-runtime": minor
+---
+
+Add circular progress support.
+
+- **ui-native:** new `CircularProgress` primitive (SVG ring with optional centered content); declares `react-native-svg` as a peer dependency.
+- **sdui-runtime:** `info_row` progress with `shape: "ring"` now renders the ring (with its `%` label centered) via `right_media`; `shape: "bar"` (default) keeps the linear indicator. Progress `value` is now normalized against `max` (a `value: 41, max: 100` previously rendered as a full bar). `info_row` tags now pass `bg_color`/`label.color` through to the pill instead of dropping them.
+
+Requires `@one-impression/sdk-native-sdui` with the `ProgressSchema.shape` field.

--- a/.changeset/icon-svg-comment-stripping.md
+++ b/.changeset/icon-svg-comment-stripping.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+Strip JSX (`{/* ... */}`) and HTML (`<!-- ... -->`) comments from icon SVG markup before handing it to `SvgXml`. Several manifest glyphs were authored as JSX and leaked comments into the markup string, which `SvgXml` rendered as raw text nodes — throwing "Text strings must be rendered within a `<Text>` component" wherever those icons appeared. Comments carry no rendering meaning, so removing them is always safe.

--- a/.changeset/reload-latest-wins.md
+++ b/.changeset/reload-latest-wins.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+`reload` is now latest-wins per region. A new reload of a region takes ownership from any in-flight reload of that region, so rapid/chained tab switches render only the latest response instead of flickering through each one in arrival order (and the last to *arrive* no longer wins over the last clicked). Reloads targeting disjoint regions still run in parallel; an in-flight reload is aborted only when *all* its regions are superseded — partial overlap (e.g. a `["content"]` filter over an in-flight `["header","content"]` tab switch) lets the older reload still apply the regions it owns. Skeletons are held across the hand-off. Automatic — no wire/BFF change.

--- a/apps/sdui-playground/server/fixture-server.mjs
+++ b/apps/sdui-playground/server/fixture-server.mjs
@@ -195,7 +195,124 @@ function selectCampaigns(tab, filters) {
 // stacks in the header zone. Per-tab (refreshed on tab switch). content region =
 // the items array. footer region = the tabs shell (loaded once).
 
+// ── Settings page (3rd tab) ──────────────────────────────────────────────────
+// Demonstrates that a totally different page is JUST a different BFF response:
+// the `saved` tab returns a simple header + info-row + group snippets instead of
+// the campaign feed. Same region reload, same runtime — no frontend change.
+// info_row is a full list row: left media (avatar/icon), title + subtitle, a
+// right-side tag/badge/progress, and a chevron. Same snippet drives every row
+// in the Profile screen — only the slots filled differ.
+const infoRow = (id, text, opts = {}) => ({
+  type: "creator.snippet.info_row",
+  id,
+  data: {
+    title: { text, font_size: opts.size ?? "sdui.font-size.md", font_weight: opts.weight ?? "medium" },
+    ...(opts.subtitle
+      ? { subtitle: { text: opts.subtitle, color: "sdui.color.neutral-medium", font_size: "sdui.font-size.sm" } }
+      : {}),
+    ...(opts.avatar
+      ? { left_media: { type: "image", image: { src: opts.avatar, width: 48, height: 48, container_shape: "circle" } } }
+      : opts.icon
+        ? { left_media: { type: "icon", icon: { name: opts.icon, color: "sdui.color.primary" } } }
+        : {}),
+    ...(opts.tag
+      ? { tag: { label: { text: opts.tag, color: opts.tagColor ?? "sdui.color.notice" }, bg_color: opts.tagBg ?? "sdui.color.notice-weak" } }
+      : {}),
+    ...(opts.progress != null
+      ? { progress: { value: opts.progress, max: 100, label: { text: `${opts.progress}%` } } }
+      : {}),
+    ...(opts.ring != null
+      ? {
+          right_media: {
+            type: "progress",
+            progress: {
+              value: opts.ring,
+              max: 100,
+              shape: "ring",
+              label: { text: `${opts.ring}%` },
+              color: "sdui.color.primary",
+              track_color: "sdui.color.neutral-subtle",
+            },
+          },
+        }
+      : {}),
+    ...(opts.chevron === false || opts.ring != null
+      ? {}
+      : { right_icon: { name: "chevron-right", color: "sdui.color.neutral-medium" } }),
+    ...(opts.card ? { card: opts.card === true ? {} : opts.card } : {}),
+  },
+});
+const sectionHeader = (id, text) => ({
+  type: "creator.snippet.section_header",
+  id,
+  data: { title: { text, font_weight: "bold", font_size: "sdui.font-size.lg" } },
+});
+// Carded vertical group — one white rounded card surface wrapping the rows
+// (same `group_config` + `card` pattern the home page uses for its sections).
+// Flat (no elevation) so every card reads consistently with the "Need help"
+// tiles, which render through info_row's `card` and pass no elevation.
+const group = (id, items) => ({
+  type: "creator.snippet.group_config",
+  id,
+  data: { stacking: "vertical", card: { bg_color: "sdui.color.neutral-inverse" }, items },
+});
+// Horizontal equal-width cards (e.g. the 3 "Need help" tiles) — each child carries
+// its own card surface; item_flex:"equal" splits the row width evenly.
+const groupRow = (id, items) => ({
+  type: "creator.snippet.group_config",
+  id,
+  data: { stacking: "horizontal", item_flex: "equal", gap: "sdui.spacing.sm", items },
+});
+
+const settingsHeader = () => [
+  {
+    type: "creator.snippet.page_header",
+    id: "settings-hdr",
+    data: {
+      title: { text: "Profile", font_size: "sdui.font-size.xl", font_weight: "bold", color: "sdui.color.neutral-inverse" },
+      background: { gradient: { colors: ["#7C3AED", "#F2F2F2"], angle: 180 } },
+    },
+  },
+];
+const settingsContent = () => [
+  // Profile card — avatar (left media) + name + phone + chevron.
+  infoRow("set-name", "Sonali Kalra", {
+    weight: "bold", size: "sdui.font-size.lg", subtitle: "+91 99584 78802",
+    avatar: "https://picsum.photos/seed/sonali/120",
+  }),
+  group("set-earnings", [infoRow("set-earn", "My earnings", { icon: "earnings" })]),
+  // "Get discovered quickly" — header row carries the progress circle (no chevron),
+  // sub-rows carry a left icon + a count tag + chevron.
+  group("set-discover", [
+    infoRow("set-disc-h", "Get discovered quickly", {
+      weight: "bold", subtitle: "Complete your profile to attract brands", ring: 41,
+    }),
+    infoRow("set-personal", "Personal details", { icon: "profile-icon", tag: "8/9" }),
+    infoRow("set-about-me", "About me", { icon: "key-message", tag: "2/6" }),
+    infoRow("set-social", "Connect social accounts", { icon: "connect-social-accounts", subtitle: "To get Verified tag", tag: "0" }),
+  ]),
+  group("set-paid", [
+    infoRow("set-paid-h", "Get paid quickly", {
+      weight: "bold", subtitle: "Set up payment details to receive payments", ring: 0,
+    }),
+    infoRow("set-kyc", "KYC details", { icon: "kyc-details", tag: "Not Verified", tagColor: "sdui.color.negative", tagBg: "sdui.color.negative-weak" }),
+    infoRow("set-pay", "Payment methods", { icon: "payment-details", tag: "0" }),
+    infoRow("set-ship", "Shipping address", { icon: "document", tag: "0" }),
+  ]),
+  group("set-actions", [
+    infoRow("set-prof-actions", "Profile actions", { icon: "nav-profile" }),
+    infoRow("set-about-app", "About", { icon: "document" }),
+  ]),
+  sectionHeader("set-help-h", "Need help"),
+  groupRow("set-help", [
+    infoRow("set-call", "Call", { icon: "call-us", chevron: false, card: true }),
+    infoRow("set-email", "Email", { icon: "email-us", chevron: false, card: true }),
+    infoRow("set-chat", "Chat", { icon: "chat-with-us", chevron: false, card: true }),
+  ]),
+];
+
 function headerRegion(tab, filters) {
+  if (tab === "saved") return settingsHeader();
   const tabLabel = TABS.find((t) => t.id === tab).label;
   const subtitle =
     filters.length > 0
@@ -217,7 +334,8 @@ function headerRegion(tab, filters) {
   ];
 }
 
-const contentItems = (tab, filters) => selectCampaigns(tab, filters).map(campaignCard);
+const contentItems = (tab, filters) =>
+  tab === "saved" ? settingsContent() : selectCampaigns(tab, filters).map(campaignCard);
 
 // Per-region skeletons (BFF-composed, cached in the shell so they show
 // instantly). Composed to MATCH the content they stand in for:

--- a/packages/sdui-runtime/BFF-CONTRACT.md
+++ b/packages/sdui-runtime/BFF-CONTRACT.md
@@ -53,6 +53,8 @@ A page can render a **shell** first (chrome + skeletons), then stream regions in
 
 The runtime sends `regions` + the bound context as query params; return exactly the named regions. Full model + worked example: [`REGION-PAGE-MODEL.md`](./REGION-PAGE-MODEL.md).
 
+**Latest-wins per region.** Reloads are coordinated by the regions they target: a new `reload` of a region takes ownership from any in-flight `reload` of that region, so only the most recent response is applied — chained tab switches render just the latest tab, never a flicker through every response in arrival order. Reloads targeting *disjoint* regions run in parallel untouched. An in-flight reload is aborted only when *all* its regions have been superseded; if only some were (e.g. a `["content"]` filter landing over an in-flight `["header","content"]` tab switch), it still applies the regions it owns. This is automatic — the BFF declares no concurrency flag.
+
 ## 4. Action vocabulary
 
 Every interactive field (`on_click`, `on_load`, `on_refresh`, a chip's `on_click`, …) is an `Action`:

--- a/packages/sdui-runtime/src/action-engine/handlers/__tests__/reload.test.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/__tests__/reload.test.ts
@@ -1,8 +1,8 @@
 import { test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { handleReload } from "../reload.ts";
+import { handleReload, __resetReloadConcurrency } from "../reload.ts";
 import type { ActionEngine, ActionEngineConfig } from "../../types.ts";
-import type { Action, Page } from "@one-impression/sdk-native-sdui";
+import type { Action, Node, Page } from "@one-impression/sdk-native-sdui";
 import { useLocalStore } from "../../../state/useLocalStore.ts";
 import { usePageStore } from "../../../state/usePageStore.ts";
 
@@ -43,14 +43,59 @@ const BASE_PAGE = {
   items: [],
 } as unknown as Page;
 
+// A deferred fetch: each call records its signal + a `resolve` handle so a test
+// can land responses in a chosen order and observe abort behavior mid-flight.
+interface Pending {
+  url: string;
+  signal?: AbortSignal;
+  resolve: (body: unknown, status?: number) => void;
+}
+function installDeferredFetch(): Pending[] {
+  const pendings: Pending[] = [];
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = ((input: unknown, init?: { signal?: AbortSignal }) => {
+    const signal = init?.signal;
+    const abortErr = () => Object.assign(new Error("aborted"), { name: "AbortError" });
+    return new Promise<Response>((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(abortErr());
+        return;
+      }
+      pendings.push({
+        url: String(input),
+        signal,
+        resolve: (body, status = 200) =>
+          resolve(
+            new Response(JSON.stringify(body), {
+              status,
+              headers: { "Content-Type": "application/json" },
+            }),
+          ),
+      });
+      signal?.addEventListener("abort", () => reject(abortErr()));
+    });
+  }) as unknown as typeof globalThis.fetch;
+  return pendings;
+}
+
+/** Flush the microtask/timer queue so an in-flight handler reaches its fetch. */
+const flush = () => new Promise<void>((r) => setImmediate(r));
+
+const composite = (id: string) =>
+  ({ type: "sdui.snippet.composite", id, data: {} }) as unknown as Node;
+const header = (id: string) =>
+  [{ type: "creator.snippet.page_header", id, data: {} }] as unknown as Node[];
+
 beforeEach(() => {
   originalFetch = globalThis.fetch;
   lastUrl = undefined;
+  __resetReloadConcurrency();
   useLocalStore.setState({ data: {} });
   usePageStore.setState({ page: BASE_PAGE, pageId: BASE_PAGE.id, loadingRegions: {} });
 });
 
 afterEach(() => {
+  __resetReloadConcurrency();
   if (originalFetch) globalThis.fetch = originalFetch;
 });
 
@@ -114,4 +159,75 @@ test("reload — clears loading even on a non-OK response (and throws)", async (
     /reload: BFF GET .* returned 500/,
   );
   assert.equal(usePageStore.getState().loadingRegions.content, false);
+});
+
+test("reload — chained same-region reloads: latest wins, earlier aborted, skeleton held", async () => {
+  const pendings = installDeferredFetch();
+  const a = reloadAction({ endpoint: "creator.campaigns.list", regions: ["content"] });
+  const b = reloadAction({ endpoint: "creator.campaigns.list", regions: ["content"] });
+
+  const pA = handleReload(a, config, noopEngine);
+  await flush(); // A reaches its fetch (pending)
+  assert.equal(pendings.length, 1);
+  assert.equal(usePageStore.getState().loadingRegions.content, true);
+
+  const pB = handleReload(b, config, noopEngine);
+  await flush(); // B claims content → aborts A; B reaches its fetch
+  assert.equal(pendings[0].signal!.aborted, true, "A's fetch aborted by B");
+  assert.equal(pendings.length, 2);
+  assert.equal(pendings[1].signal!.aborted, false);
+  assert.equal(usePageStore.getState().loadingRegions.content, true, "skeleton held across hand-off");
+
+  await pA; // A was aborted → resolves without applying or clearing loading
+  assert.equal(usePageStore.getState().page!.items.length, 0, "A applied nothing");
+  assert.equal(usePageStore.getState().loadingRegions.content, true, "A did not clear loading");
+
+  pendings[1].resolve({ items: [composite("b")] });
+  await pB;
+  assert.equal(usePageStore.getState().page!.items[0].id, "b", "only the latest response rendered");
+  assert.equal(usePageStore.getState().loadingRegions.content, false);
+});
+
+test("reload — disjoint regions run in parallel, neither aborted", async () => {
+  const pendings = installDeferredFetch();
+  const pH = handleReload(reloadAction({ endpoint: "creator.campaigns.list", regions: ["header"] }), config, noopEngine);
+  await flush();
+  const pC = handleReload(reloadAction({ endpoint: "creator.campaigns.list", regions: ["content"] }), config, noopEngine);
+  await flush();
+
+  assert.equal(pendings.length, 2);
+  assert.equal(pendings[0].signal!.aborted, false, "header reload not aborted by content reload");
+  assert.equal(pendings[1].signal!.aborted, false);
+
+  pendings[0].resolve({ data: { header: header("h1") } });
+  pendings[1].resolve({ items: [composite("c1")] });
+  await Promise.all([pH, pC]);
+
+  const page = usePageStore.getState().page!;
+  assert.equal((page.data as Record<string, Node[]>).header[0].id, "h1");
+  assert.equal(page.items[0].id, "c1");
+});
+
+test("reload — partial overlap: newer wins the shared region, older still applies its own", async () => {
+  const pendings = installDeferredFetch();
+  // Tab switch: header + content. Filter: content only, lands mid-flight.
+  const pTab = handleReload(reloadAction({ endpoint: "creator.campaigns.list", regions: ["header", "content"] }), config, noopEngine);
+  await flush();
+  const pFilter = handleReload(reloadAction({ endpoint: "creator.campaigns.list", regions: ["content"] }), config, noopEngine);
+  await flush();
+
+  // Filter took `content`; tab still owns `header`, so its fetch is NOT aborted.
+  assert.equal(pendings[0].signal!.aborted, false, "tab fetch survives (still owns header)");
+
+  // Tab response carries header + content; only its header should apply.
+  pendings[0].resolve({ data: { header: header("hTab") }, items: [composite("tabContent")] });
+  await pTab;
+  pendings[1].resolve({ items: [composite("filtered")] });
+  await pFilter;
+
+  const page = usePageStore.getState().page!;
+  assert.equal((page.data as Record<string, Node[]>).header[0].id, "hTab", "header from the tab reload applied");
+  assert.equal(page.items[0].id, "filtered", "content from the filter reload won; tab's content dropped");
+  assert.equal(usePageStore.getState().loadingRegions.content, false);
+  assert.equal(usePageStore.getState().loadingRegions.header, false);
 });

--- a/packages/sdui-runtime/src/action-engine/handlers/reload.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/reload.ts
@@ -6,14 +6,54 @@ import { bindRequestPayload } from "../cond/resolve-request-refs.js";
 import { resolveEndpointUrl, buildBffHeaders } from "./_shared/bff-request.js";
 
 /**
+ * Per-region in-flight registry — latest-wins concurrency for `reload`.
+ *
+ * A reload replaces/merges the regions it targets, so for any region only the
+ * MOST RECENT reload should win. Rapid tab switches each fire a reload of the
+ * same regions; without coordination they all run and apply in arrival order,
+ * so the page flickers through every response and the last to *arrive* wins
+ * (not the last clicked). We key in-flight fetches by region: a new reload of
+ * region `r` takes ownership of `r` from whoever held it. Region overlap is
+ * exactly "multiple parallel fetches targeting the same view"; reloads with
+ * DISJOINT regions never contend and run in parallel.
+ *
+ * Abort vs. partial supersession: a reload's regions share one fetch (one
+ * `AbortController`), so we abort it ONLY when ALL its regions have been taken
+ * by newer reloads. If only some were taken (e.g. a `["content"]` filter lands
+ * over an in-flight `["header","content"]` tab switch), the older fetch is left
+ * to finish and applies just the regions it STILL owns — so its header isn't
+ * lost while the newer reload wins the shared `content`.
+ */
+interface ReloadRequest {
+  regions: Set<string>;
+  controller: AbortController;
+}
+const requests = new Map<number, ReloadRequest>();
+const regionOwners = new Map<string, number>();
+let reloadCounter = 0;
+
+/** The content region maps to `items`; every other region maps to `data.<region>`. */
+const CONTENT_REGION = "content";
+
+/** Test-only: abort + clear the in-flight registry between cases. */
+export function __resetReloadConcurrency(): void {
+  for (const { controller } of requests.values()) controller.abort();
+  requests.clear();
+  regionOwners.clear();
+  reloadCounter = 0;
+}
+
+/**
  * reload — region-scoped page refresh. Marks the named `regions` loading (so the
  * renderer shows each one's skeleton), fetches `endpoint` with the bound request
  * context, then applies the response as a PARTIAL page: `response.data`
  * shallow-merges into the live page's `data`, `response.items` replaces `items`.
  * Regions not named (e.g. a footer shell) stay mounted and untouched.
  *
- * One verb, every scope: `["content"]` for a filter, `["header","content"]` for
- * a tab switch / first content load. Response is set RAW (no schema parse) so
+ * Latest-wins per region (see the registry note above): chained tab switches
+ * render only the latest, with each skeleton held across the hand-off. One verb,
+ * every scope: `["content"]` for a filter, `["header","content"]` for a tab
+ * switch / first content load. Response is set RAW (no schema parse) so
  * node-level fields like `viewability` survive.
  */
 export async function handleReload(
@@ -33,6 +73,30 @@ export async function handleReload(
   });
   const headers = buildBffHeaders(config);
 
+  // Claim every targeted region for this call, taking ownership from prior
+  // reloads. A prior reload that loses ALL its regions is aborted; one that
+  // still owns some is left to finish (and will apply only those).
+  const token = ++reloadCounter;
+  const controller = new AbortController();
+  requests.set(token, { regions: new Set(payload.regions), controller });
+  const superseded = new Set<number>();
+  for (const region of payload.regions) {
+    const prev = regionOwners.get(region);
+    if (prev !== undefined && prev !== token) {
+      requests.get(prev)?.regions.delete(region);
+      superseded.add(prev);
+    }
+    regionOwners.set(region, token);
+  }
+  for (const t of superseded) {
+    const req = requests.get(t);
+    if (req && req.regions.size === 0) req.controller.abort();
+  }
+
+  /** Regions this call still owns (not yet taken by a newer reload). */
+  const ownedRegions = () =>
+    payload.regions.filter((r) => regionOwners.get(r) === token);
+
   const { usePageStore } = await import("../../state/usePageStore.js");
   usePageStore.getState().setRegionsLoading(payload.regions, true);
 
@@ -41,6 +105,7 @@ export async function handleReload(
       method: payload.method,
       headers,
       body: payload.request_body ? JSON.stringify(payload.request_body) : undefined,
+      signal: controller.signal,
     });
 
     if (!res.ok) {
@@ -54,8 +119,34 @@ export async function handleReload(
       data?: Record<string, unknown>;
       items?: Node[];
     };
-    usePageStore.getState().mergeRegions({ data: body.data, items: body.items });
+
+    // Apply ONLY the regions we still own — a newer reload may have taken some
+    // (or all) of them while this fetch was in flight.
+    const owned = ownedRegions();
+    if (owned.length > 0) {
+      const dataKeys = owned.filter((r) => r !== CONTENT_REGION);
+      const data =
+        dataKeys.length > 0 && body.data
+          ? Object.fromEntries(
+              dataKeys.filter((k) => k in body.data!).map((k) => [k, body.data![k]]),
+            )
+          : undefined;
+      const items = owned.includes(CONTENT_REGION) ? body.items : undefined;
+      usePageStore.getState().mergeRegions({ data, items });
+    }
+  } catch (err) {
+    // Fully superseded — our controller was aborted. Drop silently; the newer
+    // reloads own these regions and keep their skeletons up.
+    if (controller.signal.aborted) return;
+    throw err;
   } finally {
-    usePageStore.getState().setRegionsLoading(payload.regions, false);
+    // Release + clear loading only for regions we still hold. Regions taken by
+    // a newer reload stay loading until that reload settles.
+    const stillOwned = ownedRegions();
+    if (stillOwned.length > 0) {
+      usePageStore.getState().setRegionsLoading(stillOwned, false);
+      for (const r of stillOwned) regionOwners.delete(r);
+    }
+    requests.delete(token);
   }
 }

--- a/packages/sdui-runtime/src/icon-store/parseSvg.ts
+++ b/packages/sdui-runtime/src/icon-store/parseSvg.ts
@@ -10,6 +10,21 @@ import { SvgXml } from 'react-native-svg';
 /** Cache of already-parsed SVG components keyed by icon name. */
 const svgCache = new Map<string, React.FC<SvgIconProps>>();
 
+/**
+ * Strip comment syntax that is invalid inside an SVG/XML document. Some glyphs
+ * in the icon manifest were authored as JSX and leaked `{/* ... *\/}` comments
+ * (and occasionally HTML `<!-- ... -->` comments) into the markup string. The
+ * `SvgXml` parser treats these as raw text nodes and renders them as bare
+ * strings inside an SVG element, which throws "Text strings must be rendered
+ * within a <Text> component". Removing them is always safe — comments carry no
+ * rendering meaning.
+ */
+function sanitizeSvg(svg: string): string {
+  return svg
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "") // JSX comments: {/* ... */}
+    .replace(/<!--[\s\S]*?-->/g, ""); // HTML/XML comments: <!-- ... -->
+}
+
 export interface SvgIconProps {
   width?: number;
   height?: number;
@@ -31,8 +46,10 @@ export function parseSvg(name: string, svg: string): React.FC<SvgIconProps> {
   const cached = svgCache.get(name);
   if (cached) return cached;
 
+  const cleanSvg = sanitizeSvg(svg);
+
   const Component: React.FC<SvgIconProps> = ({ width = 24, height = 24, color }) => {
-    const resolvedSvg = color ? svg.replace(/currentColor/g, color) : svg;
+    const resolvedSvg = color ? cleanSvg.replace(/currentColor/g, color) : cleanSvg;
 
     return React.createElement(SvgXml, {
       xml: resolvedSvg,

--- a/packages/sdui-runtime/src/snippets/InfoRow/InfoRow.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/InfoRow/InfoRow.renderer.tsx
@@ -50,7 +50,11 @@ export function InfoRowRenderer(node: Node): React.ReactElement {
                 )}
                 {v.progress && (
                   <DSProgressIndicator
-                    value={v.progress.value}
+                    value={
+                      v.progress.max != null && v.progress.max > 0
+                        ? v.progress.value / v.progress.max
+                        : v.progress.value
+                    }
                     trackColor={v.progress.track_color}
                     fillColor={v.progress.fill_color}
                     height={v.progress.height}
@@ -59,7 +63,13 @@ export function InfoRowRenderer(node: Node): React.ReactElement {
               </Stack>
             </Box>
             <Stack direction="row" align="center" gap={8}>
-              {v.tag && <DSTag label={v.tag.label.text} />}
+              {v.tag && (
+                <DSTag
+                  label={v.tag.label.text}
+                  bgColor={v.tag.bg_color}
+                  textColor={v.tag.label.color}
+                />
+              )}
               {v.badge &&
                 (v.badge.dot ? (
                   // count/dot indicator (BadgeSchema = { count, dot, color }) —

--- a/packages/sdui-runtime/src/snippets/_shared/describe-media.ts
+++ b/packages/sdui-runtime/src/snippets/_shared/describe-media.ts
@@ -32,9 +32,14 @@ export type MediaDescriptor =
   | {
       kind: "progress";
       props: {
+        /** Normalized fraction, 0..1. */
         value: number;
         trackColor?: string;
         fillColor?: string;
+        /** "bar" (default, linear) or "ring" (circular). */
+        shape?: "bar" | "ring";
+        /** Optional label text (rendered centered inside a ring). */
+        label?: string;
       };
     };
 
@@ -97,12 +102,20 @@ export function describeMedia(media: Media): MediaDescriptor | null {
     }
     case "progress": {
       const { progress } = media;
+      // `max` present → value is on a 0..max scale; absent → already a 0..1
+      // fraction (back-compat with callers that pre-normalize).
+      const value =
+        progress.max != null && progress.max > 0
+          ? progress.value / progress.max
+          : progress.value;
       return {
         kind: "progress",
         props: {
-          value: progress.value,
+          value,
           trackColor: progress.track_color,
           fillColor: progress.color,
+          shape: progress.shape,
+          label: progress.label?.text,
         },
       };
     }

--- a/packages/sdui-runtime/src/snippets/_shared/render-media.tsx
+++ b/packages/sdui-runtime/src/snippets/_shared/render-media.tsx
@@ -4,6 +4,8 @@ import {
   Image as DSImage,
   ImageStack as DSImageStack,
   ProgressIndicator as DSProgressIndicator,
+  CircularProgress as DSCircularProgress,
+  Text as DSText,
 } from "@one-impression/ui-native";
 import { IconGlyph } from "../../icon-store/IconGlyph.js";
 import { describeMedia } from "./describe-media.js";
@@ -25,8 +27,23 @@ export function renderMedia(media: Media): React.ReactElement | null {
       return <IconGlyph {...desc.props} />;
     case "image_stack":
       return <DSImageStack {...desc.props} />;
-    case "progress":
-      return <DSProgressIndicator {...desc.props} />;
+    case "progress": {
+      const { shape, label, value, trackColor, fillColor } = desc.props;
+      if (shape === "ring") {
+        return (
+          <DSCircularProgress value={value} trackColor={trackColor} fillColor={fillColor}>
+            {label ? (
+              <DSText size={12} weight="bold">
+                {label}
+              </DSText>
+            ) : null}
+          </DSCircularProgress>
+        );
+      }
+      return (
+        <DSProgressIndicator value={value} trackColor={trackColor} fillColor={fillColor} />
+      );
+    }
     default: {
       const _exhaustive: never = desc;
       void _exhaustive;

--- a/packages/ui-native/package.json
+++ b/packages/ui-native/package.json
@@ -22,9 +22,10 @@
     "test": "jest"
   },
   "peerDependencies": {
+    "@one-impression/tokens-creator": ">=3.0.0",
     "react": ">=18.0.0",
     "react-native": ">=0.72.0",
-    "@one-impression/tokens-creator": ">=3.0.0"
+    "react-native-svg": ">=13.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/packages/ui-native/src/index.ts
+++ b/packages/ui-native/src/index.ts
@@ -85,6 +85,10 @@ export type { TabProps } from './primitives/Tab';
 export { ProgressIndicator } from './primitives/ProgressIndicator';
 export type { ProgressIndicatorProps } from './primitives/ProgressIndicator';
 
+// CircularProgress
+export { CircularProgress } from './primitives/CircularProgress';
+export type { CircularProgressProps } from './primitives/CircularProgress';
+
 // SearchBar
 export { SearchBar } from './primitives/SearchBar';
 export type { SearchBarProps } from './primitives/SearchBar';

--- a/packages/ui-native/src/primitives/CircularProgress/CircularProgress.styles.ts
+++ b/packages/ui-native/src/primitives/CircularProgress/CircularProgress.styles.ts
@@ -1,0 +1,11 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  svg: {
+    position: 'absolute',
+  },
+});

--- a/packages/ui-native/src/primitives/CircularProgress/CircularProgress.test.tsx
+++ b/packages/ui-native/src/primitives/CircularProgress/CircularProgress.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, screen } from '@testing-library/react-native';
+import { CircularProgress } from './CircularProgress';
+
+describe('CircularProgress', () => {
+  it('renders with progressbar role', () => {
+    render(<CircularProgress testID="ring" value={0.5} />);
+    const el = screen.getByTestId('ring');
+    expect(el.props.accessibilityRole).toBe('progressbar');
+  });
+
+  it('clamps value to 0-1 range', () => {
+    render(<CircularProgress testID="ring" value={1.5} />);
+    const el = screen.getByTestId('ring');
+    expect(el.props.accessibilityValue.now).toBe(100);
+  });
+
+  it('reports percentage in accessibility value', () => {
+    render(<CircularProgress testID="ring" value={0.41} />);
+    const el = screen.getByTestId('ring');
+    expect(el.props.accessibilityValue.now).toBe(41);
+  });
+
+  it('renders centered children (e.g. a label)', () => {
+    render(
+      <CircularProgress value={0.41}>
+        <Text>41%</Text>
+      </CircularProgress>,
+    );
+    expect(screen.getByText('41%')).toBeTruthy();
+  });
+});

--- a/packages/ui-native/src/primitives/CircularProgress/CircularProgress.tsx
+++ b/packages/ui-native/src/primitives/CircularProgress/CircularProgress.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { View } from 'react-native';
+import Svg, { Circle } from 'react-native-svg';
+import type { CircularProgressProps } from './CircularProgress.types';
+import { styles } from './CircularProgress.styles';
+import { resolveColor } from '../../theme/resolvers';
+
+/**
+ * CircularProgress — a circular ring showing completion progress, with optional
+ * centered content (typically a percentage label). The SVG arc is drawn via a
+ * dashed `Circle` whose dash offset encodes the fraction; rotated -90° so it
+ * starts at 12 o'clock and fills clockwise.
+ */
+export const CircularProgress = React.forwardRef<View, CircularProgressProps>(
+  (
+    {
+      value,
+      size = 44,
+      strokeWidth = 4,
+      trackColor = 'neutralSubtle',
+      fillColor = 'primary',
+      children,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const clamped = Math.max(0, Math.min(1, value));
+    const center = size / 2;
+    const radius = (size - strokeWidth) / 2;
+    const circumference = 2 * Math.PI * radius;
+    const dashOffset = circumference * (1 - clamped);
+
+    return (
+      <View
+        ref={ref}
+        accessibilityRole="progressbar"
+        accessibilityValue={{ min: 0, max: 100, now: Math.round(clamped * 100) }}
+        style={[styles.container, { width: size, height: size }, style]}
+        {...props}
+      >
+        <Svg width={size} height={size} style={styles.svg}>
+          <Circle
+            cx={center}
+            cy={center}
+            r={radius}
+            stroke={resolveColor(trackColor)}
+            strokeWidth={strokeWidth}
+            fill="none"
+          />
+          <Circle
+            cx={center}
+            cy={center}
+            r={radius}
+            stroke={resolveColor(fillColor)}
+            strokeWidth={strokeWidth}
+            fill="none"
+            strokeDasharray={circumference}
+            strokeDashoffset={dashOffset}
+            strokeLinecap="round"
+            transform={`rotate(-90 ${center} ${center})`}
+          />
+        </Svg>
+        {children}
+      </View>
+    );
+  },
+);
+
+CircularProgress.displayName = 'CircularProgress';

--- a/packages/ui-native/src/primitives/CircularProgress/CircularProgress.types.ts
+++ b/packages/ui-native/src/primitives/CircularProgress/CircularProgress.types.ts
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+import type { ViewProps } from 'react-native';
+import type { ColorToken } from '../../tokens';
+
+export interface CircularProgressProps extends Omit<ViewProps, 'style'> {
+  /** Progress value between 0 and 1. */
+  value: number;
+  /** Outer diameter in pixels. Defaults to 44. */
+  size?: number;
+  /** Ring thickness in pixels. Defaults to 4. */
+  strokeWidth?: number;
+  /** Track (unfilled) color. Defaults to 'neutralSubtle'. */
+  trackColor?: ColorToken | string;
+  /** Fill (progress) color. Defaults to 'primary'. */
+  fillColor?: ColorToken | string;
+  /** Content rendered centered inside the ring (e.g. a percentage label). */
+  children?: ReactNode;
+  /** Additional style overrides. */
+  style?: ViewProps['style'];
+}

--- a/packages/ui-native/src/primitives/CircularProgress/index.ts
+++ b/packages/ui-native/src/primitives/CircularProgress/index.ts
@@ -1,0 +1,2 @@
+export { CircularProgress } from './CircularProgress';
+export type { CircularProgressProps } from './CircularProgress.types';


### PR DESCRIPTION
Stacked work from the SDUI settings-page polish (docs PR #232 already merged). Four changes:

- **fix(icon-store):** strip JSX/HTML comments from icon SVG before `SvgXml` parse — 6 manifest glyphs leaked `{/* */}` comments and crashed with "Text strings must be rendered within a <Text>".
- **feat(ui-native):** `CircularProgress` SVG primitive (ring + centered label); `react-native-svg` peer dep.
- **feat(sdui-runtime):** render `info_row` progress as a ring when `shape:"ring"`; normalize progress `value` against `max`; pass tag `bg_color`/`label.color` through to the pill.
- **fix(sdui-runtime):** latest-wins concurrency for chained region reloads (abort/supersede per region; disjoint reloads stay parallel; partial overlap still applies owned regions). +3 tests.

**Depends on** amplify-schemas#324 (the `ProgressSchema.shape` field) — merge + publish that first, then this bumps the SDK dep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)