### PR TITLE
chore(sdui-runtime): require sdk-native-sdui ^3.5.0

### DIFF
--- a/.changeset/runtime-sdk-peer-3-5-0.md
+++ b/.changeset/runtime-sdk-peer-3-5-0.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+Bump the `@one-impression/sdk-native-sdui` peer (and dev) dependency to `^3.5.0`. The ring rendering added in 2.8.0 reads `ProgressSchema.shape`, which only exists from SDK 3.5.0 — the range now states that requirement explicitly. The peer remains optional, so the runtime still degrades gracefully (renders the linear bar) against older SDKs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5073,9 +5073,9 @@
       "link": true
     },
     "node_modules/@one-impression/sdk-native-sdui": {
-      "version": "3.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@one-impression/sdk-native-sdui/3.4.0/c99e3366510b5df749f4662df39f1f6b8f5fda59",
-      "integrity": "sha512-3zuG4IaPoojG4zu+u+Xdr6EehUehUoEHhsvgZDXiP6fGR+VhAZ6wr/mqo4tqazIQcngi9ZCxIAugZue7PV15Fw==",
+      "version": "3.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@one-impression/sdk-native-sdui/3.5.0/1d7acccf6391563581b0d2d01da379b45cebd2dc",
+      "integrity": "sha512-VZBxydHzy15AhZhDktovPOL0gtZuqUpNN7evmn1r/JggAITHnIP5zSlKzucm5/bG5Gua3I6ViKeFe0f6xe2f6A==",
       "dependencies": {
         "zod": "^3.23.0"
       }
@@ -20255,20 +20255,20 @@
     },
     "packages/sdui-runtime": {
       "name": "@one-impression/sdui-runtime",
-      "version": "2.6.0",
+      "version": "2.8.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "zod": "^3.22.0",
         "zustand": "^4.5.0"
       },
       "devDependencies": {
-        "@one-impression/sdk-native-sdui": "^3.4.0",
+        "@one-impression/sdk-native-sdui": "^3.5.0",
         "tsup": "^8.0.0",
         "typescript": "^5.5.0"
       },
       "peerDependencies": {
         "@gorhom/bottom-sheet": "^5.0.0",
-        "@one-impression/sdk-native-sdui": "^3.4.0",
+        "@one-impression/sdk-native-sdui": "^3.5.0",
         "@one-impression/tokens-creator": ">=3.0.0",
         "@one-impression/ui-native": ">=2.0.2",
         "@react-navigation/native": ">=7.0.0",
@@ -20384,7 +20384,7 @@
     },
     "packages/tokens-creator": {
       "name": "@one-impression/tokens-creator",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "dependencies": {
         "@one-impression/tokens-foundation": "^3.0.0"
       },
@@ -20462,7 +20462,7 @@
     },
     "packages/ui-native": {
       "name": "@one-impression/ui-native",
-      "version": "2.1.0",
+      "version": "2.3.0",
       "devDependencies": {
         "@types/react": "^18.2.0",
         "tsup": "^8.0.0",
@@ -20471,7 +20471,8 @@
       "peerDependencies": {
         "@one-impression/tokens-creator": ">=3.0.0",
         "react": ">=18.0.0",
-        "react-native": ">=0.72.0"
+        "react-native": ">=0.72.0",
+        "react-native-svg": ">=13.0.0"
       }
     },
     "packages/ui-native/node_modules/@types/react": {

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "react": ">=18.0.0",
     "react-native": ">=0.72.0",
-    "@one-impression/sdk-native-sdui": "^3.4.0",
+    "@one-impression/sdk-native-sdui": "^3.5.0",
     "@one-impression/ui-native": ">=2.0.2",
     "@one-impression/tokens-creator": ">=3.0.0",
     "@gorhom/bottom-sheet": "^5.0.0",
@@ -82,7 +82,7 @@
     }
   },
   "devDependencies": {
-    "@one-impression/sdk-native-sdui": "^3.4.0",
+    "@one-impression/sdk-native-sdui": "^3.5.0",
     "tsup": "^8.0.0",
     "typescript": "^5.5.0"
   },


### PR DESCRIPTION
Tightens the runtime's optional `@one-impression/sdk-native-sdui` peer (and dev) dep from `^3.4.0` to `^3.5.0` — the ring rendering shipped in sdui-runtime 2.8.0 reads `ProgressSchema.shape`, which only exists from SDK 3.5.0. Peer stays optional, so the runtime still degrades to the linear bar on older SDKs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)