### PR TITLE
feat(sdui-runtime): alias sdui.* node-type namespace (registry)

### DIFF
--- a/.changeset/namespace-sdui-registry.md
+++ b/.changeset/namespace-sdui-registry.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+Alias the `sdui.*` node-type namespace in the renderer registries. Every `creator.snippet.*` / `creator.ui_component.*` key now has an `sdui.*` alias resolving to the same renderer, so both prefixes render identically while emitters migrate `creator.* → sdui.*`. The resolver dispatch (on the `.snippet.`/`.ui_component.` segment) is unchanged; `creator.*` keys are retained for backward compatibility. See `NAMESPACE-MIGRATION.md`.

--- a/apps/sdui-playground/server/fixture-server.mjs
+++ b/apps/sdui-playground/server/fixture-server.mjs
@@ -120,16 +120,16 @@ function campaignCard(c) {
     data: {
       layout: "cover",
       surface: { bg_color: "sdui.color.neutral-inverse", border_color: "sdui.color.neutral-subtle" },
-      media: { type: "creator.snippet.banner_image", id: `m-${c.id}`, data: { image: { src: `https://picsum.photos/seed/camp${c.id}/640/320`, aspect_ratio: 2 } } },
-      float: { type: "creator.ui_component.image", id: `a-${c.id}`, data: { src: `https://picsum.photos/seed/brand${c.id}/120`, width: 64, height: 64, border_radius: "sdui.radius.full" } },
+      media: { type: "sdui.snippet.banner_image", id: `m-${c.id}`, data: { image: { src: `https://picsum.photos/seed/camp${c.id}/640/320`, aspect_ratio: 2 } } },
+      float: { type: "sdui.ui_component.image", id: `a-${c.id}`, data: { src: `https://picsum.photos/seed/brand${c.id}/120`, width: 64, height: 64, border_radius: "sdui.radius.full" } },
       float_end: [
-        { type: "creator.ui_component.tag", id: `cash-${c.id}`, data: { label: { text: `₹${c.reward.toLocaleString("en-IN")} Cash` }, bg_color: "sdui.color.positive-weak", text_color: "sdui.color.positive" } },
+        { type: "sdui.ui_component.tag", id: `cash-${c.id}`, data: { label: { text: `₹${c.reward.toLocaleString("en-IN")} Cash` }, bg_color: "sdui.color.positive-weak", text_color: "sdui.color.positive" } },
       ],
       body: [
-        { type: "creator.snippet.info_row", id: `n-${c.id}`, data: { title: { text: c.brand, font_weight: "medium", font_size: "sdui.font-size.lg" } } },
-        { type: "creator.snippet.info_row", id: `meta-${c.id}`, data: { title: { text: `${CATEGORY_LABEL[c.category]} · Micro creators`, font_size: "sdui.font-size.sm", color: "sdui.color.neutral-medium" } } },
+        { type: "sdui.snippet.info_row", id: `n-${c.id}`, data: { title: { text: c.brand, font_weight: "medium", font_size: "sdui.font-size.lg" } } },
+        { type: "sdui.snippet.info_row", id: `meta-${c.id}`, data: { title: { text: `${CATEGORY_LABEL[c.category]} · Micro creators`, font_size: "sdui.font-size.sm", color: "sdui.color.neutral-medium" } } },
       ],
-      footer: { type: "creator.snippet.info_row", id: `f-${c.id}`, data: { title: { text: "Apply now — closes soon", font_size: "sdui.font-size.sm" } } },
+      footer: { type: "sdui.snippet.info_row", id: `f-${c.id}`, data: { title: { text: "Apply now — closes soon", font_size: "sdui.font-size.sm" } } },
     },
   };
 }
@@ -140,7 +140,7 @@ function campaignCard(c) {
 // debounced CONTENT-only reload; the header (and these chips) stay static.
 function filterChip(f) {
   return {
-    type: "creator.snippet.chip",
+    type: "sdui.snippet.chip",
     id: `filter-${f.id}`,
     on_click: {
       type: "compound",
@@ -167,7 +167,7 @@ function filterChip(f) {
 // full-page reload.
 function tabNode(t) {
   return {
-    type: "creator.ui_component.tab",
+    type: "sdui.ui_component.tab",
     id: `tab-${t.id}`,
     on_click: {
       type: "compound",
@@ -203,7 +203,7 @@ function selectCampaigns(tab, filters) {
 // right-side tag/badge/progress, and a chevron. Same snippet drives every row
 // in the Profile screen — only the slots filled differ.
 const infoRow = (id, text, opts = {}) => ({
-  type: "creator.snippet.info_row",
+  type: "sdui.snippet.info_row",
   id,
   data: {
     title: { text, font_size: opts.size ?? "sdui.font-size.md", font_weight: opts.weight ?? "medium" },
@@ -243,7 +243,7 @@ const infoRow = (id, text, opts = {}) => ({
   },
 });
 const sectionHeader = (id, text) => ({
-  type: "creator.snippet.section_header",
+  type: "sdui.snippet.section_header",
   id,
   data: { title: { text, font_weight: "bold", font_size: "sdui.font-size.lg" } },
 });
@@ -252,21 +252,21 @@ const sectionHeader = (id, text) => ({
 // Flat (no elevation) so every card reads consistently with the "Need help"
 // tiles, which render through info_row's `card` and pass no elevation.
 const group = (id, items) => ({
-  type: "creator.snippet.group_config",
+  type: "sdui.snippet.group_config",
   id,
   data: { stacking: "vertical", card: { bg_color: "sdui.color.neutral-inverse" }, items },
 });
 // Horizontal equal-width cards (e.g. the 3 "Need help" tiles) — each child carries
 // its own card surface; item_flex:"equal" splits the row width evenly.
 const groupRow = (id, items) => ({
-  type: "creator.snippet.group_config",
+  type: "sdui.snippet.group_config",
   id,
   data: { stacking: "horizontal", item_flex: "equal", gap: "sdui.spacing.sm", items },
 });
 
 const settingsHeader = () => [
   {
-    type: "creator.snippet.page_header",
+    type: "sdui.snippet.page_header",
     id: "settings-hdr",
     data: {
       title: { text: "Profile", font_size: "sdui.font-size.xl", font_weight: "bold", color: "sdui.color.neutral-inverse" },
@@ -320,7 +320,7 @@ function headerRegion(tab, filters) {
       : `${selectCampaigns(tab, filters).length} campaigns`;
   return [
     {
-      type: "creator.snippet.page_header",
+      type: "sdui.snippet.page_header",
       id: "feed-hdr",
       data: {
         title: { text: "My Campaigns", font_size: "sdui.font-size.xl", font_weight: "bold", color: "sdui.color.neutral-inverse" },
@@ -330,7 +330,7 @@ function headerRegion(tab, filters) {
       },
     },
     // Chips' selected state is render-bound to local — instant, no reload.
-    { type: "creator.snippet.group_chips", id: "feed-filters", data: { items: FILTERS.map(filterChip) } },
+    { type: "sdui.snippet.group_chips", id: "feed-filters", data: { items: FILTERS.map(filterChip) } },
   ];
 }
 
@@ -342,7 +342,7 @@ const contentItems = (tab, filters) =>
 //   header  → title line + right-icon circle (spaced), subtitle, a chip row
 //   content → cards: media + (logo circle + cash-tag pill) + brand + meta
 const headerSkeleton = {
-  type: "creator.snippet.skeleton",
+  type: "sdui.snippet.skeleton",
   id: "skel-header",
   data: {
     padding: 16,
@@ -355,7 +355,7 @@ const headerSkeleton = {
   },
 };
 const contentSkeleton = {
-  type: "creator.snippet.skeleton",
+  type: "sdui.snippet.skeleton",
   id: "skel-content",
   data: {
     card: true,
@@ -390,7 +390,7 @@ function buildShell() {
     },
     on_refresh: reload(["content"], 0),
     data: {
-      footer: { type: "creator.snippet.tabs_footer", id: "feed-tabs", data: { items: TABS.map(tabNode) } },
+      footer: { type: "sdui.snippet.tabs_footer", id: "feed-tabs", data: { items: TABS.map(tabNode) } },
       header_skeleton: headerSkeleton,
       content_skeleton: contentSkeleton,
     },

--- a/apps/sdui-playground/server/pages/catalog.all_snippets.json
+++ b/apps/sdui-playground/server/pages/catalog.all_snippets.json
@@ -5,18 +5,18 @@
     "layout": "standard",
     "items": [
         {
-            "type": "creator.snippet.section_header",
+            "type": "sdui.snippet.section_header",
             "id": "section-header-18",
             "data": {
                 "title": {
-                    "text": "creator.snippet.card",
+                    "text": "sdui.snippet.card",
                     "font_size": "sdui.font-size.lg",
                     "font_weight": "bold"
                 }
             }
         },
         {
-            "type": "creator.snippet.card",
+            "type": "sdui.snippet.card",
             "id": "campaigns-explore-card-fk-1",
             "on_click": {
                 "type": "navigate",
@@ -30,7 +30,7 @@
             },
             "data": {
                 "header": {
-                    "type": "creator.snippet.overlapping_image",
+                    "type": "sdui.snippet.overlapping_image",
                     "id": "campaigns-explore-card-cover-fk-1",
                     "data": {
                         "cover_image": {
@@ -56,7 +56,7 @@
                             },
                             "right_tags": [
                                 {
-                                    "type": "creator.ui_component.tag",
+                                    "type": "sdui.ui_component.tag",
                                     "id": "tag-21",
                                     "data": {
                                         "label": {
@@ -80,7 +80,7 @@
                 },
                 "items": [
                     {
-                        "type": "creator.snippet.info_row",
+                        "type": "sdui.snippet.info_row",
                         "id": "campaigns-explore-card-fk-1-brand-name",
                         "data": {
                             "title": {
@@ -91,7 +91,7 @@
                         }
                     },
                     {
-                        "type": "creator.snippet.info_row",
+                        "type": "sdui.snippet.info_row",
                         "id": "campaigns-explore-card-fk-1-subtitle",
                         "data": {
                             "title": {
@@ -103,12 +103,12 @@
                         }
                     },
                     {
-                        "type": "creator.snippet.group_chips",
+                        "type": "sdui.snippet.group_chips",
                         "id": "campaigns-explore-card-fk-1-tags",
                         "data": {
                             "items": [
                                 {
-                                    "type": "creator.ui_component.tag",
+                                    "type": "sdui.ui_component.tag",
                                     "id": "campaigns-explore-card-fk-1-tag-0",
                                     "data": {
                                         "label": {
@@ -117,7 +117,7 @@
                                     }
                                 },
                                 {
-                                    "type": "creator.ui_component.tag",
+                                    "type": "sdui.ui_component.tag",
                                     "id": "campaigns-explore-card-fk-1-tag-1",
                                     "data": {
                                         "label": {
@@ -129,7 +129,7 @@
                         }
                     },
                     {
-                        "type": "creator.snippet.separator",
+                        "type": "sdui.snippet.separator",
                         "id": "campaigns-explore-card-fk-1-separator",
                         "data": {
                             "color": "sdui.color.neutral-subtle",
@@ -137,7 +137,7 @@
                         }
                     },
                     {
-                        "type": "creator.snippet.info_row",
+                        "type": "sdui.snippet.info_row",
                         "id": "campaigns-explore-card-fk-1-offer",
                         "data": {
                             "title": {
@@ -154,7 +154,7 @@
                         }
                     },
                     {
-                        "type": "creator.snippet.info_row",
+                        "type": "sdui.snippet.info_row",
                         "id": "campaigns-explore-card-fk-1-reward-condition",
                         "data": {
                             "title": {
@@ -172,7 +172,7 @@
                     }
                 ],
                 "footer": {
-                    "type": "creator.snippet.info_row",
+                    "type": "sdui.snippet.info_row",
                     "id": "info-row-11",
                     "data": {
                         "title": {
@@ -190,18 +190,18 @@
             }
         },
         {
-            "type": "creator.snippet.section_header",
+            "type": "sdui.snippet.section_header",
             "id": "section-header-19",
             "data": {
                 "title": {
-                    "text": "creator.snippet.info_row",
+                    "text": "sdui.snippet.info_row",
                     "font_size": "sdui.font-size.lg",
                     "font_weight": "bold"
                 }
             }
         },
         {
-            "type": "creator.snippet.info_row",
+            "type": "sdui.snippet.info_row",
             "id": "sample-info-row-8",
             "data": {
                 "title": {
@@ -219,18 +219,18 @@
             }
         },
         {
-            "type": "creator.snippet.section_header",
+            "type": "sdui.snippet.section_header",
             "id": "section-header-20",
             "data": {
                 "title": {
-                    "text": "creator.snippet.section_header",
+                    "text": "sdui.snippet.section_header",
                     "font_size": "sdui.font-size.lg",
                     "font_weight": "bold"
                 }
             }
         },
         {
-            "type": "creator.snippet.section_header",
+            "type": "sdui.snippet.section_header",
             "id": "sample-section-header-9",
             "data": {
                 "title": {
@@ -244,23 +244,23 @@
             }
         },
         {
-            "type": "creator.snippet.section_header",
+            "type": "sdui.snippet.section_header",
             "id": "section-header-21",
             "data": {
                 "title": {
-                    "text": "creator.snippet.group_chips",
+                    "text": "sdui.snippet.group_chips",
                     "font_size": "sdui.font-size.lg",
                     "font_weight": "bold"
                 }
             }
         },
         {
-            "type": "creator.snippet.group_chips",
+            "type": "sdui.snippet.group_chips",
             "id": "sample-group-chips-10",
             "data": {
                 "items": [
                     {
-                        "type": "creator.ui_component.tag",
+                        "type": "sdui.ui_component.tag",
                         "id": "sample-tag-11",
                         "data": {
                             "label": {
@@ -269,7 +269,7 @@
                         }
                     },
                     {
-                        "type": "creator.ui_component.tag",
+                        "type": "sdui.ui_component.tag",
                         "id": "sample-tag-12",
                         "data": {
                             "label": {
@@ -278,7 +278,7 @@
                         }
                     },
                     {
-                        "type": "creator.ui_component.tag",
+                        "type": "sdui.ui_component.tag",
                         "id": "sample-tag-13",
                         "data": {
                             "label": {
@@ -290,18 +290,18 @@
             }
         },
         {
-            "type": "creator.snippet.section_header",
+            "type": "sdui.snippet.section_header",
             "id": "section-header-22",
             "data": {
                 "title": {
-                    "text": "creator.snippet.separator",
+                    "text": "sdui.snippet.separator",
                     "font_size": "sdui.font-size.lg",
                     "font_weight": "bold"
                 }
             }
         },
         {
-            "type": "creator.snippet.separator",
+            "type": "sdui.snippet.separator",
             "id": "sample-separator-14",
             "data": {}
         }

--- a/apps/sdui-playground/server/pages/catalog.home.json
+++ b/apps/sdui-playground/server/pages/catalog.home.json
@@ -5,7 +5,7 @@
   "layout": "standard",
   "data": {
     "header": {
-      "type": "creator.snippet.page_header",
+      "type": "sdui.snippet.page_header",
       "id": "home-header",
       "data": {
         "title": {
@@ -29,7 +29,7 @@
   },
   "items": [
     {
-      "type": "creator.snippet.section_header",
+      "type": "sdui.snippet.section_header",
       "id": "section-header-1",
       "data": {
         "title": {
@@ -43,7 +43,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "launcher-2",
       "on_click": {
         "type": "navigate",
@@ -66,7 +66,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "launcher-3",
       "on_click": {
         "type": "navigate",
@@ -90,7 +90,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "launcher-3b",
       "on_click": {
         "type": "navigate",
@@ -114,7 +114,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "launcher-3c",
       "on_click": {
         "type": "navigate",
@@ -138,7 +138,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "launcher-4",
       "on_click": {
         "type": "navigate",
@@ -168,7 +168,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "launcher-5",
       "on_click": {
         "type": "navigate",
@@ -195,7 +195,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "launcher-form",
       "on_click": {
         "type": "navigate",
@@ -222,7 +222,7 @@
       }
     },
     {
-      "type": "creator.snippet.section_header",
+      "type": "sdui.snippet.section_header",
       "id": "section-header-6",
       "data": {
         "title": {
@@ -236,7 +236,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "launcher-7",
       "on_click": {
         "type": "navigate",
@@ -272,7 +272,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "launcher-8",
       "on_click": {
         "type": "navigate",
@@ -313,7 +313,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "launcher-9",
       "on_click": {
         "type": "navigate",
@@ -352,7 +352,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "launcher-10",
       "on_click": {
         "type": "navigate",
@@ -391,7 +391,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "launcher-11",
       "on_click": {
         "type": "navigate",
@@ -435,7 +435,7 @@
       }
     },
     {
-      "type": "creator.snippet.section_header",
+      "type": "sdui.snippet.section_header",
       "id": "section-header-12",
       "data": {
         "title": {
@@ -449,7 +449,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "launcher-13",
       "on_click": {
         "type": "sheet",
@@ -489,7 +489,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "launcher-14",
       "on_click": {
         "type": "sheet",
@@ -522,7 +522,7 @@
       }
     },
     {
-      "type": "creator.snippet.section_header",
+      "type": "sdui.snippet.section_header",
       "id": "section-header-15",
       "data": {
         "title": {
@@ -536,7 +536,7 @@
       }
     },
     {
-      "type": "creator.snippet.card",
+      "type": "sdui.snippet.card",
       "id": "campaigns-explore-card-fk-1",
       "on_click": {
         "type": "navigate",
@@ -550,7 +550,7 @@
       },
       "data": {
         "header": {
-          "type": "creator.snippet.overlapping_image",
+          "type": "sdui.snippet.overlapping_image",
           "id": "campaigns-explore-card-cover-fk-1",
           "data": {
             "cover_image": {
@@ -576,7 +576,7 @@
               },
               "right_tags": [
                 {
-                  "type": "creator.ui_component.tag",
+                  "type": "sdui.ui_component.tag",
                   "id": "tag-21",
                   "data": {
                     "label": {
@@ -600,7 +600,7 @@
         },
         "items": [
           {
-            "type": "creator.snippet.info_row",
+            "type": "sdui.snippet.info_row",
             "id": "campaigns-explore-card-fk-1-brand-name",
             "data": {
               "title": {
@@ -611,7 +611,7 @@
             }
           },
           {
-            "type": "creator.snippet.info_row",
+            "type": "sdui.snippet.info_row",
             "id": "campaigns-explore-card-fk-1-subtitle",
             "data": {
               "title": {
@@ -623,12 +623,12 @@
             }
           },
           {
-            "type": "creator.snippet.group_chips",
+            "type": "sdui.snippet.group_chips",
             "id": "campaigns-explore-card-fk-1-tags",
             "data": {
               "items": [
                 {
-                  "type": "creator.ui_component.tag",
+                  "type": "sdui.ui_component.tag",
                   "id": "campaigns-explore-card-fk-1-tag-0",
                   "data": {
                     "label": {
@@ -637,7 +637,7 @@
                   }
                 },
                 {
-                  "type": "creator.ui_component.tag",
+                  "type": "sdui.ui_component.tag",
                   "id": "campaigns-explore-card-fk-1-tag-1",
                   "data": {
                     "label": {
@@ -649,7 +649,7 @@
             }
           },
           {
-            "type": "creator.snippet.separator",
+            "type": "sdui.snippet.separator",
             "id": "campaigns-explore-card-fk-1-separator",
             "data": {
               "color": "sdui.color.neutral-subtle",
@@ -657,7 +657,7 @@
             }
           },
           {
-            "type": "creator.snippet.info_row",
+            "type": "sdui.snippet.info_row",
             "id": "campaigns-explore-card-fk-1-offer",
             "data": {
               "title": {
@@ -674,7 +674,7 @@
             }
           },
           {
-            "type": "creator.snippet.info_row",
+            "type": "sdui.snippet.info_row",
             "id": "campaigns-explore-card-fk-1-reward-condition",
             "data": {
               "title": {
@@ -692,7 +692,7 @@
           }
         ],
         "footer": {
-          "type": "creator.snippet.info_row",
+          "type": "sdui.snippet.info_row",
           "id": "info-row-11",
           "data": {
             "title": {
@@ -710,7 +710,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "sample-info-row-1",
       "data": {
         "title": {
@@ -731,7 +731,7 @@
       }
     },
     {
-      "type": "creator.snippet.section_header",
+      "type": "sdui.snippet.section_header",
       "id": "sample-section-header-2",
       "data": {
         "title": {
@@ -744,12 +744,12 @@
       }
     },
     {
-      "type": "creator.snippet.group_chips",
+      "type": "sdui.snippet.group_chips",
       "id": "sample-group-chips-3",
       "data": {
         "items": [
           {
-            "type": "creator.ui_component.tag",
+            "type": "sdui.ui_component.tag",
             "id": "sample-tag-4",
             "data": {
               "label": {
@@ -758,7 +758,7 @@
             }
           },
           {
-            "type": "creator.ui_component.tag",
+            "type": "sdui.ui_component.tag",
             "id": "sample-tag-5",
             "data": {
               "label": {
@@ -767,7 +767,7 @@
             }
           },
           {
-            "type": "creator.ui_component.tag",
+            "type": "sdui.ui_component.tag",
             "id": "sample-tag-6",
             "data": {
               "label": {
@@ -779,12 +779,12 @@
       }
     },
     {
-      "type": "creator.snippet.separator",
+      "type": "sdui.snippet.separator",
       "id": "sample-separator-7",
       "data": {}
     },
     {
-      "type": "creator.snippet.section_header",
+      "type": "sdui.snippet.section_header",
       "id": "section-header-16",
       "data": {
         "title": {
@@ -794,7 +794,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "launcher-17",
       "on_click": {
         "type": "navigate",
@@ -821,7 +821,7 @@
       }
     },
     {
-      "type": "creator.snippet.section_header",
+      "type": "sdui.snippet.section_header",
       "id": "grp-hdr-h",
       "data": {
         "title": { "text": "Group stacking · horizontal", "font_size": "sdui.font-size.lg", "font_weight": "bold" },
@@ -829,20 +829,20 @@
       }
     },
     {
-      "type": "creator.snippet.group_config",
+      "type": "sdui.snippet.group_config",
       "id": "grp-horizontal",
       "data": {
         "stacking": "horizontal",
         "gap": "sdui.spacing.sm",
         "items": [
-          { "type": "creator.ui_component.tag", "id": "grp-tag-reach", "data": { "label": { "text": "Reach", "color": "sdui.color.neutral-inverse" }, "gradient": { "angle": 90, "colors": ["#F55DC1", "#495AF4"] } } },
-          { "type": "creator.ui_component.tag", "id": "grp-tag-eng", "data": { "label": { "text": "Engagement", "color": "sdui.color.neutral-inverse" }, "gradient": { "angle": 90, "colors": ["#F55DC1", "#495AF4"] } } },
-          { "type": "creator.ui_component.tag", "id": "grp-tag-conv", "data": { "label": { "text": "Conversions", "color": "sdui.color.neutral-inverse" }, "gradient": { "angle": 90, "colors": ["#F55DC1", "#495AF4"] } } }
+          { "type": "sdui.ui_component.tag", "id": "grp-tag-reach", "data": { "label": { "text": "Reach", "color": "sdui.color.neutral-inverse" }, "gradient": { "angle": 90, "colors": ["#F55DC1", "#495AF4"] } } },
+          { "type": "sdui.ui_component.tag", "id": "grp-tag-eng", "data": { "label": { "text": "Engagement", "color": "sdui.color.neutral-inverse" }, "gradient": { "angle": 90, "colors": ["#F55DC1", "#495AF4"] } } },
+          { "type": "sdui.ui_component.tag", "id": "grp-tag-conv", "data": { "label": { "text": "Conversions", "color": "sdui.color.neutral-inverse" }, "gradient": { "angle": 90, "colors": ["#F55DC1", "#495AF4"] } } }
         ]
       }
     },
     {
-      "type": "creator.snippet.section_header",
+      "type": "sdui.snippet.section_header",
       "id": "grp-hdr-v",
       "data": {
         "title": { "text": "Group stacking · vertical", "font_size": "sdui.font-size.lg", "font_weight": "bold" },
@@ -850,19 +850,19 @@
       }
     },
     {
-      "type": "creator.snippet.group_config",
+      "type": "sdui.snippet.group_config",
       "id": "grp-vertical",
       "data": {
         "stacking": "vertical",
         "items": [
-          { "type": "creator.snippet.info_row", "id": "grp-row-1", "data": { "title": { "text": "Vertical item 1", "font_weight": "medium", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "stacked top to bottom", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" }, "card": {} } },
-          { "type": "creator.snippet.info_row", "id": "grp-row-2", "data": { "title": { "text": "Vertical item 2", "font_weight": "medium", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "stacked top to bottom", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" }, "card": {} } },
-          { "type": "creator.snippet.info_row", "id": "grp-row-3", "data": { "title": { "text": "Vertical item 3", "font_weight": "medium", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "stacked top to bottom", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" }, "card": {} } }
+          { "type": "sdui.snippet.info_row", "id": "grp-row-1", "data": { "title": { "text": "Vertical item 1", "font_weight": "medium", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "stacked top to bottom", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" }, "card": {} } },
+          { "type": "sdui.snippet.info_row", "id": "grp-row-2", "data": { "title": { "text": "Vertical item 2", "font_weight": "medium", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "stacked top to bottom", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" }, "card": {} } },
+          { "type": "sdui.snippet.info_row", "id": "grp-row-3", "data": { "title": { "text": "Vertical item 3", "font_weight": "medium", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "stacked top to bottom", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" }, "card": {} } }
         ]
       }
     },
     {
-      "type": "creator.snippet.section_header",
+      "type": "sdui.snippet.section_header",
       "id": "grp-hdr-hcards",
       "data": {
         "title": { "text": "Group stacking · horizontal cards", "font_size": "sdui.font-size.lg", "font_weight": "bold" },
@@ -870,21 +870,21 @@
       }
     },
     {
-      "type": "creator.snippet.group_config",
+      "type": "sdui.snippet.group_config",
       "id": "grp-horizontal-cards",
       "data": {
         "stacking": "horizontal",
         "gap": "sdui.spacing.md",
         "item_flex": "equal",
         "items": [
-          { "type": "creator.snippet.info_row", "id": "grp-card-mon", "data": { "title": { "text": "Mon", "font_weight": "bold", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "12 leads", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" }, "card": {} } },
-          { "type": "creator.snippet.info_row", "id": "grp-card-tue", "data": { "title": { "text": "Tue", "font_weight": "bold", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "18 leads", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" }, "card": {} } },
-          { "type": "creator.snippet.info_row", "id": "grp-card-wed", "data": { "title": { "text": "Wed", "font_weight": "bold", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "9 leads", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" }, "card": {} } }
+          { "type": "sdui.snippet.info_row", "id": "grp-card-mon", "data": { "title": { "text": "Mon", "font_weight": "bold", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "12 leads", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" }, "card": {} } },
+          { "type": "sdui.snippet.info_row", "id": "grp-card-tue", "data": { "title": { "text": "Tue", "font_weight": "bold", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "18 leads", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" }, "card": {} } },
+          { "type": "sdui.snippet.info_row", "id": "grp-card-wed", "data": { "title": { "text": "Wed", "font_weight": "bold", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "9 leads", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" }, "card": {} } }
         ]
       }
     },
     {
-      "type": "creator.snippet.section_header",
+      "type": "sdui.snippet.section_header",
       "id": "grp-hdr-cardv",
       "data": {
         "title": { "text": "Group · one card, plain children (vertical)", "font_size": "sdui.font-size.lg", "font_weight": "bold" },
@@ -892,21 +892,21 @@
       }
     },
     {
-      "type": "creator.snippet.group_config",
+      "type": "sdui.snippet.group_config",
       "id": "grp-cardv",
       "data": {
         "stacking": "vertical",
         "card": {},
         "gap": "sdui.spacing.md",
         "items": [
-          { "type": "creator.snippet.info_row", "id": "grp-cv-1", "data": { "title": { "text": "Reach", "font_weight": "medium", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "1.2M accounts", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" } } },
-          { "type": "creator.snippet.info_row", "id": "grp-cv-2", "data": { "title": { "text": "Engagement", "font_weight": "medium", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "84K interactions", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" } } },
-          { "type": "creator.snippet.info_row", "id": "grp-cv-3", "data": { "title": { "text": "Conversions", "font_weight": "medium", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "2,310 orders", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" } } }
+          { "type": "sdui.snippet.info_row", "id": "grp-cv-1", "data": { "title": { "text": "Reach", "font_weight": "medium", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "1.2M accounts", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" } } },
+          { "type": "sdui.snippet.info_row", "id": "grp-cv-2", "data": { "title": { "text": "Engagement", "font_weight": "medium", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "84K interactions", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" } } },
+          { "type": "sdui.snippet.info_row", "id": "grp-cv-3", "data": { "title": { "text": "Conversions", "font_weight": "medium", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "2,310 orders", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" } } }
         ]
       }
     },
     {
-      "type": "creator.snippet.section_header",
+      "type": "sdui.snippet.section_header",
       "id": "grp-hdr-cardh",
       "data": {
         "title": { "text": "Group · one card, plain children (horizontal)", "font_size": "sdui.font-size.lg", "font_weight": "bold" },
@@ -914,7 +914,7 @@
       }
     },
     {
-      "type": "creator.snippet.group_config",
+      "type": "sdui.snippet.group_config",
       "id": "grp-cardh",
       "data": {
         "stacking": "horizontal",
@@ -922,9 +922,9 @@
         "gap": "sdui.spacing.md",
         "item_flex": "equal",
         "items": [
-          { "type": "creator.snippet.info_row", "id": "grp-ch-1", "data": { "title": { "text": "Reach", "font_weight": "bold", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "1.2M", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" } } },
-          { "type": "creator.snippet.info_row", "id": "grp-ch-2", "data": { "title": { "text": "Eng.", "font_weight": "bold", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "84K", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" } } },
-          { "type": "creator.snippet.info_row", "id": "grp-ch-3", "data": { "title": { "text": "Conv.", "font_weight": "bold", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "2.3K", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" } } }
+          { "type": "sdui.snippet.info_row", "id": "grp-ch-1", "data": { "title": { "text": "Reach", "font_weight": "bold", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "1.2M", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" } } },
+          { "type": "sdui.snippet.info_row", "id": "grp-ch-2", "data": { "title": { "text": "Eng.", "font_weight": "bold", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "84K", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" } } },
+          { "type": "sdui.snippet.info_row", "id": "grp-ch-3", "data": { "title": { "text": "Conv.", "font_weight": "bold", "font_size": "sdui.font-size.md" }, "subtitle": { "text": "2.3K", "color": "sdui.color.text-muted", "font_size": "sdui.font-size.sm" } } }
         ]
       }
     }
@@ -936,7 +936,7 @@
       "size": "medium",
       "items": [
         {
-          "type": "creator.snippet.section_header",
+          "type": "sdui.snippet.section_header",
           "id": "sheet-hd-Info bottom sheet",
           "data": {
             "title": {
@@ -947,7 +947,7 @@
           }
         },
         {
-          "type": "creator.snippet.info_row",
+          "type": "sdui.snippet.info_row",
           "id": "sheet-row-Info bottom sheet",
           "data": {
             "title": {
@@ -958,12 +958,12 @@
         }
       ],
       "footer": {
-        "type": "creator.snippet.page_footer",
+        "type": "sdui.snippet.page_footer",
         "id": "sheet-ftr-Info bottom sheet",
         "data": {
           "background": "transparent",
           "primary_button": {
-            "type": "creator.ui_component.button",
+            "type": "sdui.ui_component.button",
             "id": "sheet-btn-GotIt",
             "on_click": {
               "type": "dismiss",
@@ -985,7 +985,7 @@
       "size": "small",
       "items": [
         {
-          "type": "creator.snippet.section_header",
+          "type": "sdui.snippet.section_header",
           "id": "sheet-hd-Are you sure?",
           "data": {
             "title": {
@@ -996,7 +996,7 @@
           }
         },
         {
-          "type": "creator.snippet.info_row",
+          "type": "sdui.snippet.info_row",
           "id": "sheet-row-Are you sure?",
           "data": {
             "title": {

--- a/apps/sdui-playground/server/pages/creator.campaigns.detail.json
+++ b/apps/sdui-playground/server/pages/creator.campaigns.detail.json
@@ -15,21 +15,21 @@
                 "layout": "cover",
                 "surface": { "bg_color": "sdui.color.neutral-inverse", "border_color": "sdui.color.neutral-subtle" },
                 "header_bg": "sdui.color.notice-weak",
-                "header": { "type": "creator.snippet.info_row", "id": "c-hdr", "data": { "title": { "text": "New Brand Name is eagerly waiting for your creative magic", "font_size": "sdui.font-size.sm", "color": "sdui.color.notice" } } },
-                "media": { "type": "creator.snippet.banner_image", "id": "c-media", "data": { "image": { "src": "https://picsum.photos/seed/lumina/640/320", "aspect_ratio": 2 } } },
+                "header": { "type": "sdui.snippet.info_row", "id": "c-hdr", "data": { "title": { "text": "New Brand Name is eagerly waiting for your creative magic", "font_size": "sdui.font-size.sm", "color": "sdui.color.notice" } } },
+                "media": { "type": "sdui.snippet.banner_image", "id": "c-media", "data": { "image": { "src": "https://picsum.photos/seed/lumina/640/320", "aspect_ratio": 2 } } },
                 "overlay": [
-                    { "type": "creator.ui_component.tag", "id": "c-rec", "data": { "label": { "text": "Recommended" }, "gradient": { "angle": 90, "colors": ["#F55DC1", "#495AF4"] } } }
+                    { "type": "sdui.ui_component.tag", "id": "c-rec", "data": { "label": { "text": "Recommended" }, "gradient": { "angle": 90, "colors": ["#F55DC1", "#495AF4"] } } }
                 ],
-                "float": { "type": "creator.ui_component.image", "id": "c-avatar", "data": { "src": "https://picsum.photos/seed/nb/120", "width": 72, "height": 72, "border_radius": "sdui.radius.full" } },
+                "float": { "type": "sdui.ui_component.image", "id": "c-avatar", "data": { "src": "https://picsum.photos/seed/nb/120", "width": 72, "height": 72, "border_radius": "sdui.radius.full" } },
                 "float_end": [
-                    { "type": "creator.ui_component.tag", "id": "c-prod", "data": { "label": { "text": "worth ₹1500" }, "gradient": { "angle": 90, "colors": ["#FFF7DC", "#FDE68A"] }, "text_color": "sdui.color.state-action-required-text", "icon": { "name": "product-benefits" } } },
-                    { "type": "creator.ui_component.tag", "id": "c-cash", "data": { "label": { "text": "₹2400 Cash" }, "bg_color": "sdui.color.positive-weak", "text_color": "sdui.color.positive" } }
+                    { "type": "sdui.ui_component.tag", "id": "c-prod", "data": { "label": { "text": "worth ₹1500" }, "gradient": { "angle": 90, "colors": ["#FFF7DC", "#FDE68A"] }, "text_color": "sdui.color.state-action-required-text", "icon": { "name": "product-benefits" } } },
+                    { "type": "sdui.ui_component.tag", "id": "c-cash", "data": { "label": { "text": "₹2400 Cash" }, "bg_color": "sdui.color.positive-weak", "text_color": "sdui.color.positive" } }
                 ],
                 "body": [
-                    { "type": "creator.snippet.info_row", "id": "c-name", "data": { "title": { "text": "New Brand Name", "font_weight": "medium", "font_size": "sdui.font-size.lg" } } },
-                    { "type": "creator.snippet.info_row", "id": "c-meta", "data": { "title": { "text": "Beauty · Jnsn (26 February - Micro creators)", "font_size": "sdui.font-size.sm", "color": "sdui.color.neutral-medium" } } }
+                    { "type": "sdui.snippet.info_row", "id": "c-name", "data": { "title": { "text": "New Brand Name", "font_weight": "medium", "font_size": "sdui.font-size.lg" } } },
+                    { "type": "sdui.snippet.info_row", "id": "c-meta", "data": { "title": { "text": "Beauty · Jnsn (26 February - Micro creators)", "font_size": "sdui.font-size.sm", "color": "sdui.color.neutral-medium" } } }
                 ],
-                "footer": { "type": "creator.snippet.info_row", "id": "c-ftr", "data": { "title": { "text": "Earn 10% EXTRA — Submit content in 19 hours", "font_size": "sdui.font-size.sm" } } }
+                "footer": { "type": "sdui.snippet.info_row", "id": "c-ftr", "data": { "title": { "text": "Earn 10% EXTRA — Submit content in 19 hours", "font_size": "sdui.font-size.sm" } } }
             }
         }
     ],

--- a/apps/sdui-playground/server/pages/demo.feed.json
+++ b/apps/sdui-playground/server/pages/demo.feed.json
@@ -5,7 +5,7 @@
     "layout": "feed",
     "items": [
         {
-            "type": "creator.snippet.page_header",
+            "type": "sdui.snippet.page_header",
             "id": "hdr-Explore feed",
             "data": {
                 "title": {
@@ -23,12 +23,12 @@
             }
         },
         {
-            "type": "creator.ui_component.section",
+            "type": "sdui.ui_component.section",
             "id": "home-items-section",
             "data": {
                 "items": [
                     {
-                        "type": "creator.snippet.card",
+                        "type": "sdui.snippet.card",
                         "id": "campaigns-explore-card-fk-1",
                         "on_click": {
                             "type": "navigate",
@@ -42,7 +42,7 @@
                         },
                         "data": {
                             "header": {
-                                "type": "creator.snippet.overlapping_image",
+                                "type": "sdui.snippet.overlapping_image",
                                 "id": "campaigns-explore-card-cover-fk-1",
                                 "data": {
                                     "cover_image": {
@@ -68,7 +68,7 @@
                                         },
                                         "right_tags": [
                                             {
-                                                "type": "creator.ui_component.tag",
+                                                "type": "sdui.ui_component.tag",
                                                 "id": "tag-21",
                                                 "data": {
                                                     "label": {
@@ -92,7 +92,7 @@
                             },
                             "items": [
                                 {
-                                    "type": "creator.snippet.info_row",
+                                    "type": "sdui.snippet.info_row",
                                     "id": "campaigns-explore-card-fk-1-brand-name",
                                     "data": {
                                         "title": {
@@ -103,7 +103,7 @@
                                     }
                                 },
                                 {
-                                    "type": "creator.snippet.info_row",
+                                    "type": "sdui.snippet.info_row",
                                     "id": "campaigns-explore-card-fk-1-subtitle",
                                     "data": {
                                         "title": {
@@ -115,12 +115,12 @@
                                     }
                                 },
                                 {
-                                    "type": "creator.snippet.group_chips",
+                                    "type": "sdui.snippet.group_chips",
                                     "id": "campaigns-explore-card-fk-1-tags",
                                     "data": {
                                         "items": [
                                             {
-                                                "type": "creator.ui_component.tag",
+                                                "type": "sdui.ui_component.tag",
                                                 "id": "campaigns-explore-card-fk-1-tag-0",
                                                 "data": {
                                                     "label": {
@@ -129,7 +129,7 @@
                                                 }
                                             },
                                             {
-                                                "type": "creator.ui_component.tag",
+                                                "type": "sdui.ui_component.tag",
                                                 "id": "campaigns-explore-card-fk-1-tag-1",
                                                 "data": {
                                                     "label": {
@@ -141,7 +141,7 @@
                                     }
                                 },
                                 {
-                                    "type": "creator.snippet.separator",
+                                    "type": "sdui.snippet.separator",
                                     "id": "campaigns-explore-card-fk-1-separator",
                                     "data": {
                                         "color": "sdui.color.neutral-subtle",
@@ -149,7 +149,7 @@
                                     }
                                 },
                                 {
-                                    "type": "creator.snippet.info_row",
+                                    "type": "sdui.snippet.info_row",
                                     "id": "campaigns-explore-card-fk-1-offer",
                                     "data": {
                                         "title": {
@@ -166,7 +166,7 @@
                                     }
                                 },
                                 {
-                                    "type": "creator.snippet.info_row",
+                                    "type": "sdui.snippet.info_row",
                                     "id": "campaigns-explore-card-fk-1-reward-condition",
                                     "data": {
                                         "title": {
@@ -184,7 +184,7 @@
                                 }
                             ],
                             "footer": {
-                                "type": "creator.snippet.info_row",
+                                "type": "sdui.snippet.info_row",
                                 "id": "info-row-11",
                                 "data": {
                                     "title": {
@@ -202,7 +202,7 @@
                         }
                     },
                     {
-                        "type": "creator.snippet.card",
+                        "type": "sdui.snippet.card",
                         "id": "campaigns-explore-card-fk-2",
                         "on_click": {
                             "type": "navigate",
@@ -216,7 +216,7 @@
                         },
                         "data": {
                             "header": {
-                                "type": "creator.snippet.overlapping_image",
+                                "type": "sdui.snippet.overlapping_image",
                                 "id": "campaigns-explore-card-cover-fk-2",
                                 "data": {
                                     "cover_image": {
@@ -227,7 +227,7 @@
                                     "footer": {
                                         "right_tags": [
                                             {
-                                                "type": "creator.ui_component.tag",
+                                                "type": "sdui.ui_component.tag",
                                                 "id": "tag-22",
                                                 "data": {
                                                     "label": {
@@ -251,7 +251,7 @@
                             },
                             "items": [
                                 {
-                                    "type": "creator.snippet.info_row",
+                                    "type": "sdui.snippet.info_row",
                                     "id": "campaigns-explore-card-fk-2-brand-name",
                                     "data": {
                                         "title": {
@@ -262,7 +262,7 @@
                                     }
                                 },
                                 {
-                                    "type": "creator.snippet.info_row",
+                                    "type": "sdui.snippet.info_row",
                                     "id": "campaigns-explore-card-fk-2-subtitle",
                                     "data": {
                                         "title": {
@@ -274,12 +274,12 @@
                                     }
                                 },
                                 {
-                                    "type": "creator.snippet.group_chips",
+                                    "type": "sdui.snippet.group_chips",
                                     "id": "campaigns-explore-card-fk-2-tags",
                                     "data": {
                                         "items": [
                                             {
-                                                "type": "creator.ui_component.tag",
+                                                "type": "sdui.ui_component.tag",
                                                 "id": "campaigns-explore-card-fk-2-tag-0",
                                                 "data": {
                                                     "label": {
@@ -291,7 +291,7 @@
                                     }
                                 },
                                 {
-                                    "type": "creator.snippet.separator",
+                                    "type": "sdui.snippet.separator",
                                     "id": "campaigns-explore-card-fk-2-separator",
                                     "data": {
                                         "color": "sdui.color.neutral-subtle",
@@ -299,7 +299,7 @@
                                     }
                                 },
                                 {
-                                    "type": "creator.snippet.info_row",
+                                    "type": "sdui.snippet.info_row",
                                     "id": "campaigns-explore-card-fk-2-offer",
                                     "data": {
                                         "title": {
@@ -316,7 +316,7 @@
                                     }
                                 },
                                 {
-                                    "type": "creator.snippet.info_row",
+                                    "type": "sdui.snippet.info_row",
                                     "id": "campaigns-explore-card-fk-2-reward-condition",
                                     "data": {
                                         "title": {
@@ -341,7 +341,7 @@
                         }
                     },
                     {
-                        "type": "creator.snippet.card",
+                        "type": "sdui.snippet.card",
                         "id": "campaigns-explore-card-fk-3",
                         "on_click": {
                             "type": "navigate",
@@ -355,7 +355,7 @@
                         },
                         "data": {
                             "header": {
-                                "type": "creator.snippet.overlapping_image",
+                                "type": "sdui.snippet.overlapping_image",
                                 "id": "campaigns-explore-card-cover-fk-3",
                                 "data": {
                                     "cover_image": {
@@ -368,7 +368,7 @@
                             },
                             "items": [
                                 {
-                                    "type": "creator.snippet.info_row",
+                                    "type": "sdui.snippet.info_row",
                                     "id": "campaigns-explore-card-fk-3-brand-name",
                                     "data": {
                                         "title": {
@@ -379,7 +379,7 @@
                                     }
                                 },
                                 {
-                                    "type": "creator.snippet.info_row",
+                                    "type": "sdui.snippet.info_row",
                                     "id": "campaigns-explore-card-fk-3-subtitle",
                                     "data": {
                                         "title": {
@@ -391,12 +391,12 @@
                                     }
                                 },
                                 {
-                                    "type": "creator.snippet.group_chips",
+                                    "type": "sdui.snippet.group_chips",
                                     "id": "campaigns-explore-card-fk-3-tags",
                                     "data": {
                                         "items": [
                                             {
-                                                "type": "creator.ui_component.tag",
+                                                "type": "sdui.ui_component.tag",
                                                 "id": "campaigns-explore-card-fk-3-tag-0",
                                                 "data": {
                                                     "label": {
@@ -408,7 +408,7 @@
                                     }
                                 },
                                 {
-                                    "type": "creator.snippet.separator",
+                                    "type": "sdui.snippet.separator",
                                     "id": "campaigns-explore-card-fk-3-separator",
                                     "data": {
                                         "color": "sdui.color.neutral-subtle",
@@ -416,7 +416,7 @@
                                     }
                                 },
                                 {
-                                    "type": "creator.snippet.info_row",
+                                    "type": "sdui.snippet.info_row",
                                     "id": "campaigns-explore-card-fk-3-offer",
                                     "data": {
                                         "title": {
@@ -433,7 +433,7 @@
                                     }
                                 },
                                 {
-                                    "type": "creator.snippet.info_row",
+                                    "type": "sdui.snippet.info_row",
                                     "id": "campaigns-explore-card-fk-3-reward-condition",
                                     "data": {
                                         "title": {

--- a/apps/sdui-playground/server/pages/demo.form.json
+++ b/apps/sdui-playground/server/pages/demo.form.json
@@ -5,7 +5,7 @@
   "layout": "sticky_footer",
   "data": {
     "header": {
-      "type": "creator.snippet.page_header",
+      "type": "sdui.snippet.page_header",
       "id": "form-header",
       "data": {
         "title": {
@@ -32,11 +32,11 @@
       }
     },
     "footer": {
-      "type": "creator.snippet.page_footer",
+      "type": "sdui.snippet.page_footer",
       "id": "form-footer",
       "data": {
         "primary_button": {
-          "type": "creator.ui_component.button",
+          "type": "sdui.ui_component.button",
           "id": "form-submit",
           "on_click": {
             "type": "submit",
@@ -68,7 +68,7 @@
   },
   "items": [
     {
-      "type": "creator.snippet.section_header",
+      "type": "sdui.snippet.section_header",
       "id": "form-hdr",
       "data": {
         "title": {
@@ -84,13 +84,13 @@
       }
     },
     {
-      "type": "creator.snippet.form",
+      "type": "sdui.snippet.form",
       "id": "campaign-form",
       "data": {
         "form_id": "campaign",
         "fields": [
           {
-            "type": "creator.snippet.input",
+            "type": "sdui.snippet.input",
             "id": "f-name",
             "data": {
               "field_name": "campaign_name",
@@ -110,7 +110,7 @@
             }
           },
           {
-            "type": "creator.snippet.input",
+            "type": "sdui.snippet.input",
             "id": "f-email",
             "data": {
               "field_name": "email",
@@ -130,7 +130,7 @@
             }
           },
           {
-            "type": "creator.snippet.input",
+            "type": "sdui.snippet.input",
             "id": "f-budget",
             "data": {
               "field_name": "budget",
@@ -152,7 +152,7 @@
             }
           },
           {
-            "type": "creator.snippet.input",
+            "type": "sdui.snippet.input",
             "id": "f-phone",
             "data": {
               "field_name": "phone",
@@ -162,7 +162,7 @@
                 "font_weight": "semiBold"
               },
               "leading": {
-                "type": "creator.ui_component.select_trigger",
+                "type": "sdui.ui_component.select_trigger",
                 "id": "phone-cc-trigger",
                 "data": {
                   "form_id": "campaign",
@@ -188,7 +188,7 @@
             }
           },
           {
-            "type": "creator.snippet.single_select_input",
+            "type": "sdui.snippet.single_select_input",
             "id": "f-objective",
             "data": {
               "field_name": "objective",
@@ -200,7 +200,7 @@
               "required": true,
               "options": [
                 {
-                  "type": "creator.ui_component.selectable_item",
+                  "type": "sdui.ui_component.selectable_item",
                   "id": "obj-awareness",
                   "data": {
                     "label": {
@@ -214,7 +214,7 @@
                   }
                 },
                 {
-                  "type": "creator.ui_component.selectable_item",
+                  "type": "sdui.ui_component.selectable_item",
                   "id": "obj-conversions",
                   "data": {
                     "label": {
@@ -228,7 +228,7 @@
                   }
                 },
                 {
-                  "type": "creator.ui_component.selectable_item",
+                  "type": "sdui.ui_component.selectable_item",
                   "id": "obj-engagement",
                   "data": {
                     "label": {
@@ -242,7 +242,7 @@
             }
           },
           {
-            "type": "creator.snippet.multi_select_input",
+            "type": "sdui.snippet.multi_select_input",
             "id": "f-platforms",
             "data": {
               "field_name": "platforms",
@@ -255,7 +255,7 @@
               "selected_values": ["instagram"],
               "options": [
                 {
-                  "type": "creator.ui_component.selectable_item",
+                  "type": "sdui.ui_component.selectable_item",
                   "id": "pf-ig",
                   "data": {
                     "label": {
@@ -266,7 +266,7 @@
                   }
                 },
                 {
-                  "type": "creator.ui_component.selectable_item",
+                  "type": "sdui.ui_component.selectable_item",
                   "id": "pf-yt",
                   "data": {
                     "label": {
@@ -277,7 +277,7 @@
                   }
                 },
                 {
-                  "type": "creator.ui_component.selectable_item",
+                  "type": "sdui.ui_component.selectable_item",
                   "id": "pf-x",
                   "data": {
                     "label": {
@@ -291,7 +291,7 @@
             }
           },
           {
-            "type": "creator.snippet.toggle_input",
+            "type": "sdui.snippet.toggle_input",
             "id": "f-renew",
             "data": {
               "field_name": "auto_renew",
@@ -303,7 +303,7 @@
             }
           },
           {
-            "type": "creator.snippet.upload_file",
+            "type": "sdui.snippet.upload_file",
             "id": "f-brief",
             "data": {
               "field_name": "brief",
@@ -327,7 +327,7 @@
       "size": "large",
       "items": [
         {
-          "type": "creator.snippet.single_select_input",
+          "type": "sdui.snippet.single_select_input",
           "id": "country-select",
           "data": {
             "form_id": "campaign",
@@ -335,17 +335,17 @@
             "selected_value": "+91",
             "on_change": { "type": "dismiss", "payload": {} },
             "options": [
-              { "type": "creator.ui_component.selectable_item", "id": "cc-IN", "data": { "label": { "text": "🇮🇳  India" }, "subtitle": { "text": "+91" }, "value": "+91" } },
-              { "type": "creator.ui_component.selectable_item", "id": "cc-US", "data": { "label": { "text": "🇺🇸  United States" }, "subtitle": { "text": "+1" }, "value": "+1" } },
-              { "type": "creator.ui_component.selectable_item", "id": "cc-GB", "data": { "label": { "text": "🇬🇧  United Kingdom" }, "subtitle": { "text": "+44" }, "value": "+44" } },
-              { "type": "creator.ui_component.selectable_item", "id": "cc-AE", "data": { "label": { "text": "🇦🇪  United Arab Emirates" }, "subtitle": { "text": "+971" }, "value": "+971" } },
-              { "type": "creator.ui_component.selectable_item", "id": "cc-SG", "data": { "label": { "text": "🇸🇬  Singapore" }, "subtitle": { "text": "+65" }, "value": "+65" } },
-              { "type": "creator.ui_component.selectable_item", "id": "cc-AU", "data": { "label": { "text": "🇦🇺  Australia" }, "subtitle": { "text": "+61" }, "value": "+61" } },
-              { "type": "creator.ui_component.selectable_item", "id": "cc-DE", "data": { "label": { "text": "🇩🇪  Germany" }, "subtitle": { "text": "+49" }, "value": "+49" } },
-              { "type": "creator.ui_component.selectable_item", "id": "cc-FR", "data": { "label": { "text": "🇫🇷  France" }, "subtitle": { "text": "+33" }, "value": "+33" } },
-              { "type": "creator.ui_component.selectable_item", "id": "cc-JP", "data": { "label": { "text": "🇯🇵  Japan" }, "subtitle": { "text": "+81" }, "value": "+81" } },
-              { "type": "creator.ui_component.selectable_item", "id": "cc-BR", "data": { "label": { "text": "🇧🇷  Brazil" }, "subtitle": { "text": "+55" }, "value": "+55" } },
-              { "type": "creator.ui_component.selectable_item", "id": "cc-ID", "data": { "label": { "text": "🇮🇩  Indonesia" }, "subtitle": { "text": "+62" }, "value": "+62" } }
+              { "type": "sdui.ui_component.selectable_item", "id": "cc-IN", "data": { "label": { "text": "🇮🇳  India" }, "subtitle": { "text": "+91" }, "value": "+91" } },
+              { "type": "sdui.ui_component.selectable_item", "id": "cc-US", "data": { "label": { "text": "🇺🇸  United States" }, "subtitle": { "text": "+1" }, "value": "+1" } },
+              { "type": "sdui.ui_component.selectable_item", "id": "cc-GB", "data": { "label": { "text": "🇬🇧  United Kingdom" }, "subtitle": { "text": "+44" }, "value": "+44" } },
+              { "type": "sdui.ui_component.selectable_item", "id": "cc-AE", "data": { "label": { "text": "🇦🇪  United Arab Emirates" }, "subtitle": { "text": "+971" }, "value": "+971" } },
+              { "type": "sdui.ui_component.selectable_item", "id": "cc-SG", "data": { "label": { "text": "🇸🇬  Singapore" }, "subtitle": { "text": "+65" }, "value": "+65" } },
+              { "type": "sdui.ui_component.selectable_item", "id": "cc-AU", "data": { "label": { "text": "🇦🇺  Australia" }, "subtitle": { "text": "+61" }, "value": "+61" } },
+              { "type": "sdui.ui_component.selectable_item", "id": "cc-DE", "data": { "label": { "text": "🇩🇪  Germany" }, "subtitle": { "text": "+49" }, "value": "+49" } },
+              { "type": "sdui.ui_component.selectable_item", "id": "cc-FR", "data": { "label": { "text": "🇫🇷  France" }, "subtitle": { "text": "+33" }, "value": "+33" } },
+              { "type": "sdui.ui_component.selectable_item", "id": "cc-JP", "data": { "label": { "text": "🇯🇵  Japan" }, "subtitle": { "text": "+81" }, "value": "+81" } },
+              { "type": "sdui.ui_component.selectable_item", "id": "cc-BR", "data": { "label": { "text": "🇧🇷  Brazil" }, "subtitle": { "text": "+55" }, "value": "+55" } },
+              { "type": "sdui.ui_component.selectable_item", "id": "cc-ID", "data": { "label": { "text": "🇮🇩  Indonesia" }, "subtitle": { "text": "+62" }, "value": "+62" } }
             ]
           }
         }

--- a/apps/sdui-playground/server/pages/demo.standard.json
+++ b/apps/sdui-playground/server/pages/demo.standard.json
@@ -5,7 +5,7 @@
   "layout": "standard",
   "items": [
     {
-      "type": "creator.snippet.page_header",
+      "type": "sdui.snippet.page_header",
       "id": "hdr-Standard page",
       "data": {
         "title": {
@@ -23,7 +23,7 @@
       }
     },
     {
-      "type": "creator.snippet.section_header",
+      "type": "sdui.snippet.section_header",
       "id": "sample-section-header-15",
       "data": {
         "title": {
@@ -37,7 +37,7 @@
       }
     },
     {
-      "type": "creator.snippet.card",
+      "type": "sdui.snippet.card",
       "id": "campaigns-explore-card-fk-1",
       "on_click": {
         "type": "navigate",
@@ -51,7 +51,7 @@
       },
       "data": {
         "header": {
-          "type": "creator.snippet.overlapping_image",
+          "type": "sdui.snippet.overlapping_image",
           "id": "campaigns-explore-card-cover-fk-1",
           "data": {
             "cover_image": {
@@ -77,7 +77,7 @@
               },
               "right_tags": [
                 {
-                  "type": "creator.ui_component.tag",
+                  "type": "sdui.ui_component.tag",
                   "id": "tag-21",
                   "data": {
                     "label": {
@@ -101,7 +101,7 @@
         },
         "items": [
           {
-            "type": "creator.snippet.info_row",
+            "type": "sdui.snippet.info_row",
             "id": "campaigns-explore-card-fk-1-brand-name",
             "data": {
               "title": {
@@ -112,7 +112,7 @@
             }
           },
           {
-            "type": "creator.snippet.info_row",
+            "type": "sdui.snippet.info_row",
             "id": "campaigns-explore-card-fk-1-subtitle",
             "data": {
               "title": {
@@ -124,12 +124,12 @@
             }
           },
           {
-            "type": "creator.snippet.group_chips",
+            "type": "sdui.snippet.group_chips",
             "id": "campaigns-explore-card-fk-1-tags",
             "data": {
               "items": [
                 {
-                  "type": "creator.ui_component.tag",
+                  "type": "sdui.ui_component.tag",
                   "id": "campaigns-explore-card-fk-1-tag-0",
                   "data": {
                     "label": {
@@ -138,7 +138,7 @@
                   }
                 },
                 {
-                  "type": "creator.ui_component.tag",
+                  "type": "sdui.ui_component.tag",
                   "id": "campaigns-explore-card-fk-1-tag-1",
                   "data": {
                     "label": {
@@ -150,7 +150,7 @@
             }
           },
           {
-            "type": "creator.snippet.separator",
+            "type": "sdui.snippet.separator",
             "id": "campaigns-explore-card-fk-1-separator",
             "data": {
               "color": "sdui.color.neutral-subtle",
@@ -158,7 +158,7 @@
             }
           },
           {
-            "type": "creator.snippet.info_row",
+            "type": "sdui.snippet.info_row",
             "id": "campaigns-explore-card-fk-1-offer",
             "data": {
               "title": {
@@ -175,7 +175,7 @@
             }
           },
           {
-            "type": "creator.snippet.info_row",
+            "type": "sdui.snippet.info_row",
             "id": "campaigns-explore-card-fk-1-reward-condition",
             "data": {
               "title": {
@@ -193,7 +193,7 @@
           }
         ],
         "footer": {
-          "type": "creator.snippet.info_row",
+          "type": "sdui.snippet.info_row",
           "id": "info-row-11",
           "data": {
             "title": {
@@ -211,7 +211,7 @@
       }
     },
     {
-      "type": "creator.snippet.info_row",
+      "type": "sdui.snippet.info_row",
       "id": "sample-info-row-16",
       "data": {
         "title": {
@@ -229,17 +229,17 @@
       }
     },
     {
-      "type": "creator.snippet.separator",
+      "type": "sdui.snippet.separator",
       "id": "sample-separator-17",
       "data": {}
     },
     {
-      "type": "creator.snippet.group_chips",
+      "type": "sdui.snippet.group_chips",
       "id": "sample-group-chips-18",
       "data": {
         "items": [
           {
-            "type": "creator.ui_component.tag",
+            "type": "sdui.ui_component.tag",
             "id": "sample-tag-19",
             "data": {
               "label": {
@@ -248,7 +248,7 @@
             }
           },
           {
-            "type": "creator.ui_component.tag",
+            "type": "sdui.ui_component.tag",
             "id": "sample-tag-20",
             "data": {
               "label": {
@@ -257,7 +257,7 @@
             }
           },
           {
-            "type": "creator.ui_component.tag",
+            "type": "sdui.ui_component.tag",
             "id": "sample-tag-21",
             "data": {
               "label": {

--- a/apps/sdui-playground/server/pages/demo.sticky_footer.json
+++ b/apps/sdui-playground/server/pages/demo.sticky_footer.json
@@ -5,12 +5,12 @@
     "layout": "sticky_footer",
     "data": {
         "footer": {
-            "type": "creator.snippet.page_footer",
+            "type": "sdui.snippet.page_footer",
             "id": "ftr-Continue",
             "data": {
                 "background": "transparent",
                 "secondary_button": {
-                    "type": "creator.ui_component.button",
+                    "type": "sdui.ui_component.button",
                     "id": "btn-SaveForLater",
                     "data": {
                         "label": {
@@ -20,7 +20,7 @@
                     }
                 },
                 "primary_button": {
-                    "type": "creator.ui_component.button",
+                    "type": "sdui.ui_component.button",
                     "id": "btn-Continue",
                     "data": {
                         "label": {
@@ -34,7 +34,7 @@
     },
     "items": [
         {
-            "type": "creator.snippet.page_header",
+            "type": "sdui.snippet.page_header",
             "id": "hdr-Sticky footer",
             "data": {
                 "title": {
@@ -52,7 +52,7 @@
             }
         },
         {
-            "type": "creator.snippet.section_header",
+            "type": "sdui.snippet.section_header",
             "id": "sample-section-header-22",
             "data": {
                 "title": {
@@ -66,7 +66,7 @@
             }
         },
         {
-            "type": "creator.snippet.info_row",
+            "type": "sdui.snippet.info_row",
             "id": "sample-info-row-23",
             "data": {
                 "left_media": {
@@ -93,12 +93,12 @@
             }
         },
         {
-            "type": "creator.snippet.separator",
+            "type": "sdui.snippet.separator",
             "id": "sample-separator-24",
             "data": {}
         },
         {
-            "type": "creator.snippet.info_row",
+            "type": "sdui.snippet.info_row",
             "id": "sample-info-row-25",
             "data": {
                 "title": {

--- a/apps/sdui-playground/server/pages/demo.sticky_footer.white_1.json
+++ b/apps/sdui-playground/server/pages/demo.sticky_footer.white_1.json
@@ -5,11 +5,11 @@
     "layout": "sticky_footer",
     "data": {
         "footer": {
-            "type": "creator.snippet.page_footer",
+            "type": "sdui.snippet.page_footer",
             "id": "ftr-Continue",
             "data": {
                 "primary_button": {
-                    "type": "creator.ui_component.button",
+                    "type": "sdui.ui_component.button",
                     "id": "btn-Continue",
                     "data": {
                         "label": {
@@ -23,7 +23,7 @@
     },
     "items": [
         {
-            "type": "creator.snippet.page_header",
+            "type": "sdui.snippet.page_header",
             "id": "hdr-Sticky footer",
             "data": {
                 "title": {
@@ -41,7 +41,7 @@
             }
         },
         {
-            "type": "creator.snippet.section_header",
+            "type": "sdui.snippet.section_header",
             "id": "sample-section-header-22",
             "data": {
                 "title": {
@@ -55,7 +55,7 @@
             }
         },
         {
-            "type": "creator.snippet.info_row",
+            "type": "sdui.snippet.info_row",
             "id": "sample-info-row-23",
             "data": {
                 "title": {
@@ -73,12 +73,12 @@
             }
         },
         {
-            "type": "creator.snippet.separator",
+            "type": "sdui.snippet.separator",
             "id": "sample-separator-24",
             "data": {}
         },
         {
-            "type": "creator.snippet.info_row",
+            "type": "sdui.snippet.info_row",
             "id": "sample-info-row-25",
             "data": {
                 "title": {

--- a/apps/sdui-playground/server/pages/demo.sticky_footer.white_2.json
+++ b/apps/sdui-playground/server/pages/demo.sticky_footer.white_2.json
@@ -5,11 +5,11 @@
     "layout": "sticky_footer",
     "data": {
         "footer": {
-            "type": "creator.snippet.page_footer",
+            "type": "sdui.snippet.page_footer",
             "id": "ftr-Continue",
             "data": {
                 "secondary_button": {
-                    "type": "creator.ui_component.button",
+                    "type": "sdui.ui_component.button",
                     "id": "btn-SaveForLater",
                     "data": {
                         "label": {
@@ -19,7 +19,7 @@
                     }
                 },
                 "primary_button": {
-                    "type": "creator.ui_component.button",
+                    "type": "sdui.ui_component.button",
                     "id": "btn-Continue",
                     "data": {
                         "label": {
@@ -33,7 +33,7 @@
     },
     "items": [
         {
-            "type": "creator.snippet.page_header",
+            "type": "sdui.snippet.page_header",
             "id": "hdr-Sticky footer",
             "data": {
                 "title": {
@@ -51,7 +51,7 @@
             }
         },
         {
-            "type": "creator.snippet.section_header",
+            "type": "sdui.snippet.section_header",
             "id": "sample-section-header-22",
             "data": {
                 "title": {
@@ -65,7 +65,7 @@
             }
         },
         {
-            "type": "creator.snippet.info_row",
+            "type": "sdui.snippet.info_row",
             "id": "sample-info-row-23",
             "data": {
                 "title": {
@@ -83,12 +83,12 @@
             }
         },
         {
-            "type": "creator.snippet.separator",
+            "type": "sdui.snippet.separator",
             "id": "sample-separator-24",
             "data": {}
         },
         {
-            "type": "creator.snippet.info_row",
+            "type": "sdui.snippet.info_row",
             "id": "sample-info-row-25",
             "data": {
                 "title": {

--- a/packages/sdui-runtime/NAMESPACE-MIGRATION.md
+++ b/packages/sdui-runtime/NAMESPACE-MIGRATION.md
@@ -34,33 +34,32 @@ The running app and deployed BFFs emit `creator.*` today, so a hard rename would
 break them. The migration accepts **both** prefixes during the transition and
 only drops `creator.*` once nothing emits it.
 
-A small helper centralizes the dual-accept so the final flip is one-line:
+No schema-level union/helper is needed — `NodeSchema.type` is a generic
+`z.string()`, so node validation accepts **any** prefix. Backward-compatibility
+comes from three places, not a union:
 
-```ts
-// schemas/nodeType.ts
-export const snippetType = (name: string) =>
-  z.union([z.literal(`creator.snippet.${name}`), z.literal(`sdui.snippet.${name}`)]);
-export const uiComponentType = (name: string) =>
-  z.union([z.literal(`creator.ui_component.${name}`), z.literal(`sdui.ui_component.${name}`)]);
-```
+1. **SDK** — rename schema discriminants + builders `creator.* → sdui.*` (plain
+   single literals; keeps `MediaSchema`/`cond` discriminated-unions intact).
+2. **Runtime registry** — keep the `creator.*` keys AND add `sdui.*` aliases, so
+   old payloads still resolve a renderer. (The resolver already dispatches on the
+   `.snippet.`/`.ui_component.` segment, so only the map keys change.)
+3. **Generic `NodeSchema`** — accepts both at the validation boundary.
 
-Builders keep an explicit `sdui.*` string literal (preserves literal-type
-inference on the node's `type`).
+A union discriminator was the original idea but is both unnecessary (the type
+field isn't enforced per-node) and unsafe (it would break the discriminated
+unions that key on a *different* `type` field).
 
 ## Steps
 
-**Step 0 — helper (SDK).** Add `schemas/nodeType.ts` with `snippetType` /
-`uiComponentType` dual-accept helpers.
+**Step 1 — runtime registry alias (one PR, patch). Ships FIRST.** Add `sdui.*`
+keys alongside `creator.*` in the registry maps (alias to the same renderers).
+Dispatch is unchanged. This must publish + be adopted **before** any producer
+emits `sdui.*`, so the runtime can render the new prefix the moment it appears.
 
-**Step 1 — SDK dual-accept + emit-new (one PR, minor, non-breaking).**
-Replace each schema's `z.literal("creator.X")` with `snippetType("X")` /
-`uiComponentType("X")`; switch each builder to emit `sdui.X`. Tests assert both
-prefixes parse and builders emit `sdui.*`. Publish. Old `creator.*` payloads
-still validate.
-
-**Step 2 — runtime registry alias (one PR, patch).** Add `sdui.*` keys alongside
-`creator.*` in the registry maps (alias to the same renderers). Dispatch is
-unchanged. Publish.
+**Step 2 — SDK rename + emit-new (one PR, minor). Ships SECOND.** Rename each
+schema discriminant and builder `creator.* → sdui.*` (plain literals). Tests
+assert builders emit `sdui.*`. Publish. Old `creator.*` payloads still validate
+(generic `NodeSchema`).
 
 **Step 3 — flip emitters (per surface, mechanical).** Switch fixtures / BFFs
 `creator.* → sdui.*`. Both prefixes are accepted, so there is no coordination
@@ -72,8 +71,9 @@ line each) and the alias registry keys.
 
 ### Order
 
-SDK (0+1) → runtime (2) → emitters (3) → cleanup (4). Steps 0–3 are
+**Runtime alias (1) → SDK rename (2) → emitters (3) → cleanup (4).** Runtime
+goes first so it can render `sdui.*` before any producer emits it. Steps 1–3 are
 non-breaking and can ship immediately; Step 4 waits for zero `creator.*` traffic.
 
-The bulk (Steps 1–2) is mechanical — best applied with a codemod over the schema
-/ builder / registry files plus the helper, not by hand.
+The bulk (Steps 1–2) is mechanical — applied with a codemod over the schema /
+builder / registry files (no helper needed).

--- a/packages/sdui-runtime/src/registries/snippets.ts
+++ b/packages/sdui-runtime/src/registries/snippets.ts
@@ -126,9 +126,12 @@ const baseSnippetRegistry: Record<string, (node: Node) => React.ReactElement> = 
 
 // Namespace migration: alias every `creator.*` entry to its `sdui.*` key so both
 // prefixes resolve to the same renderer while emitters move creator.* -> sdui.*.
+// Derived aliases are spread FIRST and the explicit base map LAST, so an
+// intentional explicit key (e.g. `sdui.snippet.composite`) always wins over a
+// derived alias and can never be silently overwritten.
 export const snippetRegistry: Record<string, (node: Node) => React.ReactElement> = {
-  ...baseSnippetRegistry,
   ...Object.fromEntries(
     Object.entries(baseSnippetRegistry).map(([k, v]) => [k.replace(/^creator\./, "sdui."), v]),
   ),
+  ...baseSnippetRegistry,
 };

--- a/packages/sdui-runtime/src/registries/snippets.ts
+++ b/packages/sdui-runtime/src/registries/snippets.ts
@@ -63,7 +63,7 @@ import { ChipRenderer } from "../snippets/Chip/index.js";
  * 43 snippets covering layout, headers, footers, cards, images,
  * info rows, inputs, and chips.
  */
-export const snippetRegistry: Record<string, (node: Node) => React.ReactElement> = {
+const baseSnippetRegistry: Record<string, (node: Node) => React.ReactElement> = {
   // Layout / Utility
   // First citizen of the domain-neutral `sdui.*` namespace (see migration plan).
   "sdui.snippet.composite": CompositeRenderer,
@@ -122,4 +122,13 @@ export const snippetRegistry: Record<string, (node: Node) => React.ReactElement>
 
   // Chip (1)
   "creator.snippet.chip": ChipRenderer,
+};
+
+// Namespace migration: alias every `creator.*` entry to its `sdui.*` key so both
+// prefixes resolve to the same renderer while emitters move creator.* -> sdui.*.
+export const snippetRegistry: Record<string, (node: Node) => React.ReactElement> = {
+  ...baseSnippetRegistry,
+  ...Object.fromEntries(
+    Object.entries(baseSnippetRegistry).map(([k, v]) => [k.replace(/^creator\./, "sdui."), v]),
+  ),
 };

--- a/packages/sdui-runtime/src/registries/snippets.ts
+++ b/packages/sdui-runtime/src/registries/snippets.ts
@@ -124,14 +124,15 @@ const baseSnippetRegistry: Record<string, (node: Node) => React.ReactElement> = 
   "creator.snippet.chip": ChipRenderer,
 };
 
-// Namespace migration: alias every `creator.*` entry to its `sdui.*` key so both
-// prefixes resolve to the same renderer while emitters move creator.* -> sdui.*.
-// Derived aliases are spread FIRST and the explicit base map LAST, so an
-// intentional explicit key (e.g. `sdui.snippet.composite`) always wins over a
-// derived alias and can never be silently overwritten.
+// Namespace migration: for each `creator.*` entry, add an `sdui.*` alias to the
+// same renderer (entries already in the `sdui.*` namespace are left untouched —
+// the loop only transforms `creator.*` keys). The base map is spread last, so
+// any explicitly declared key remains authoritative.
 export const snippetRegistry: Record<string, (node: Node) => React.ReactElement> = {
   ...Object.fromEntries(
-    Object.entries(baseSnippetRegistry).map(([k, v]) => [k.replace(/^creator\./, "sdui."), v]),
+    Object.entries(baseSnippetRegistry)
+      .filter(([k]) => k.startsWith("creator."))
+      .map(([k, v]) => [k.replace(/^creator\./, "sdui."), v]),
   ),
   ...baseSnippetRegistry,
 };

--- a/packages/sdui-runtime/src/registries/ui-components.ts
+++ b/packages/sdui-runtime/src/registries/ui-components.ts
@@ -44,9 +44,11 @@ const baseUiComponentRegistry: Record<string, (node: Node) => React.ReactElement
 
 // Namespace migration: alias every `creator.*` entry to its `sdui.*` key so both
 // prefixes resolve to the same renderer while emitters move creator.* -> sdui.*.
+// Derived aliases are spread FIRST and the explicit base map LAST, so an
+// intentional explicit key always wins over a derived alias.
 export const uiComponentRegistry: Record<string, (node: Node) => React.ReactElement> = {
-  ...baseUiComponentRegistry,
   ...Object.fromEntries(
     Object.entries(baseUiComponentRegistry).map(([k, v]) => [k.replace(/^creator\./, "sdui."), v]),
   ),
+  ...baseUiComponentRegistry,
 };

--- a/packages/sdui-runtime/src/registries/ui-components.ts
+++ b/packages/sdui-runtime/src/registries/ui-components.ts
@@ -42,13 +42,15 @@ const baseUiComponentRegistry: Record<string, (node: Node) => React.ReactElement
   "creator.ui_component.scroll_view": ScrollViewRenderer,
 };
 
-// Namespace migration: alias every `creator.*` entry to its `sdui.*` key so both
-// prefixes resolve to the same renderer while emitters move creator.* -> sdui.*.
-// Derived aliases are spread FIRST and the explicit base map LAST, so an
-// intentional explicit key always wins over a derived alias.
+// Namespace migration: for each `creator.*` entry, add an `sdui.*` alias to the
+// same renderer (the loop only transforms `creator.*` keys; `sdui.*` entries are
+// left untouched). The base map is spread last, so any explicitly declared key
+// remains authoritative.
 export const uiComponentRegistry: Record<string, (node: Node) => React.ReactElement> = {
   ...Object.fromEntries(
-    Object.entries(baseUiComponentRegistry).map(([k, v]) => [k.replace(/^creator\./, "sdui."), v]),
+    Object.entries(baseUiComponentRegistry)
+      .filter(([k]) => k.startsWith("creator."))
+      .map(([k, v]) => [k.replace(/^creator\./, "sdui."), v]),
   ),
   ...baseUiComponentRegistry,
 };

--- a/packages/sdui-runtime/src/registries/ui-components.ts
+++ b/packages/sdui-runtime/src/registries/ui-components.ts
@@ -20,7 +20,7 @@ import { SelectableItemRenderer } from "../ui_components/SelectableItem/index.js
 import { SelectTriggerRenderer } from "../ui_components/SelectTrigger/index.js";
 import { ScrollViewRenderer } from "../ui_components/ScrollView/index.js";
 
-export const uiComponentRegistry: Record<string, (node: Node) => React.ReactElement> = {
+const baseUiComponentRegistry: Record<string, (node: Node) => React.ReactElement> = {
   "creator.ui_component.button": ButtonRenderer,
   "creator.ui_component.text": TextRenderer,
   "creator.ui_component.card": CardRenderer,
@@ -40,4 +40,13 @@ export const uiComponentRegistry: Record<string, (node: Node) => React.ReactElem
   "creator.ui_component.selectable_item": SelectableItemRenderer,
   "creator.ui_component.select_trigger": SelectTriggerRenderer,
   "creator.ui_component.scroll_view": ScrollViewRenderer,
+};
+
+// Namespace migration: alias every `creator.*` entry to its `sdui.*` key so both
+// prefixes resolve to the same renderer while emitters move creator.* -> sdui.*.
+export const uiComponentRegistry: Record<string, (node: Node) => React.ReactElement> = {
+  ...baseUiComponentRegistry,
+  ...Object.fromEntries(
+    Object.entries(baseUiComponentRegistry).map(([k, v]) => [k.replace(/^creator\./, "sdui."), v]),
+  ),
 };


### PR DESCRIPTION
Step 1 of the `creator.* → sdui.*` migration (see `NAMESPACE-MIGRATION.md`). Adds `sdui.*` aliases for every `creator.*` registry key (same renderer); `creator.*` keys retained for back-compat. Resolver dispatch unchanged. Flips the playground fixtures to `sdui.*`.

**Ships first** — the runtime must render `sdui.*` before any producer emits it (the SDK rename PR follows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)