### PR TITLE
docs(zenith): update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ Build script (`scripts/build-tokens.js`) generates CSS variables, SCSS, JSON, JS
 3. **All token changes** go through direct PR (Pixel will detect drift and auto-cascade)
 4. **ESLint rules** exist in `packages/eslint-config/rules/` but are NOT enforced in product repos yet
 5. **Breaking changes** to CSS variable names or values require a migration note in the PR description
+6. **SDUI node-type namespace is `sdui.*` only** — the `creator.*` prefix (`creator.snippet.*`, `creator.ui_component.*`) has been fully removed from all renderer registries, type literals, and fixtures. Do not use `creator.*` prefixes anywhere. All node types must use `sdui.snippet.*` / `sdui.ui_component.*`.
 
 ## Oportunities theme (newest product line)
 


### PR DESCRIPTION
## Summary
- **Trigger:** commit `7c45fc2`
- **File updated:** `CLAUDE.md`
- **Confidence:** 🟢 0.80
- **Reason:** The `creator.*` node-type namespace has been fully removed from sdui-runtime — all renderer registries, type literals, and fixtures now use `sdui.*` only — which engineers working in this repo must know to avoid using deprecated node-type prefixes.

This is an automated documentation update by Zenith. Auto-merge eligible.

---
Generated by [Zenith AI CTO](https://github.com/one-impression/zenith-coding-agent)