### PR TITLE
docs(zenith): update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ packages/
   storybook/          — Component documentation and visual testing
   eslint-config/      — Design system lint rules (no-hardcoded-colors, no-raw-spacing, prefer-token-import)
   feature-flags/      — Feature flag utilities
+  sdui-runtime/       — SDUI runtime interpreter, action engine, bottom-sheet manager, loaders, providers (v2.9.0+: renderer registries are keyed `sdui.*` only — `creator.*` namespace removed)
 ```
 
 ## Token File Format


### PR DESCRIPTION
## Summary
- **Trigger:** commit `c463cbf`
- **File updated:** `CLAUDE.md`
- **Confidence:** 🟢 0.80
- **Reason:** The sdui-runtime package dropped the legacy `creator.*` node-type namespace entirely in v2.9.0, meaning engineers working in this repo must know that renderer registries are now exclusively keyed `sdui.*` and any remaining `creator.*` references will no longer resolve.

This is an automated documentation update by Zenith. Auto-merge eligible.

---
Generated by [Zenith AI CTO](https://github.com/one-impression/zenith-coding-agent)