### PR TITLE
chore(sdui-runtime): sweep stale "region" wording in docs + comments

### DIFF
--- a/packages/sdui-runtime/BFF-CONTRACT.md
+++ b/packages/sdui-runtime/BFF-CONTRACT.md
@@ -2,19 +2,19 @@
 
 How a backend emits SDUI pages the runtime can render. The wire types + typed
 builders live in `@one-impression/sdk-native-sdui` — **prefer the builders** over
-hand-written JSON; they validate shape at construction. The *why* behind the region
-model is in [`REGION-PAGE-MODEL.md`](./REGION-PAGE-MODEL.md); this is the reference.
+hand-written JSON; they validate shape at construction. The *why* behind the
+UI-zone model is in [`UI-ZONE-PAGE-MODEL.md`](./UI-ZONE-PAGE-MODEL.md); this is the reference.
 
 ## 1. Page envelope
 
 ```jsonc
 {
   "id": "demo.feed",              // screen id (the navigate target)
-  "title": "My Campaigns",        // native-header title (used only if no header region)
+  "title": "My Campaigns",        // native-header title (used only if no header zone)
   "protocol_version": "1.0.0",
   "layout": "feed",               // selects the layout renderer (standard | feed | sticky_footer | web_view | …)
-  "data": { /* chrome regions + skeletons — see §2 */ },
-  "items": [ /* the content region — see §2 */ ],
+  "data": { /* chrome zones + skeletons — see §2 */ },
+  "items": [ /* the content zone — see §2 */ ],
   "on_load":    { /* Action — fires once when the screen mounts */ },
   "on_refresh": { /* Action — pull-to-refresh */ },
   "on_dismount":{ /* Action */ },
@@ -26,34 +26,34 @@ model is in [`REGION-PAGE-MODEL.md`](./REGION-PAGE-MODEL.md); this is the refere
 Only `id` / `title` / `protocol_version` / `layout` / `items` are always meaningful; the
 rest are optional. A page that just renders content needs only `layout` + `items`.
 
-## 2. Regions
+## 2. UI zones
 
-A page is composed of **regions**. The convention:
-- `data.<region>` — a chrome region (a `Node` or `Node[]`), e.g. `data.header`, `data.footer`.
-- `items` — the **content** region (top-level).
-- `data.<region>_skeleton` — the region's loading placeholder.
+A page is composed of **UI zones**. The convention:
+- `data.<zone>` — a chrome zone (a single `Node`), e.g. `data.header`, `data.footer`. When a zone needs several nodes (e.g. a page header + filter chips), wrap them in one container node.
+- `items` — the **content** zone (top-level).
+- `data.<zone>_skeleton` — the zone's loading placeholder.
 
-Which region renders in which on-screen **zone** (pinned top / scroll body / pinned bottom)
+Which zone renders where on screen (pinned top / scroll body / pinned bottom)
 is owned by the layout renderer, not the wire. For the `feed` layout: `header` → pinned top,
 `content` (= `items`) → scroll body, `footer` → pinned bottom.
 
 ## 3. Shell-first + reload scopes
 
-A page can render a **shell** first (chrome + skeletons), then stream regions in via
+A page can render a **shell** first (chrome + skeletons), then stream zones in via
 `reload` from `on_load`. The `reload` response is a **partial page**:
 
-- `response.data` is **shallow-merged** into the live page's `data` (unrefreshed regions + skeletons survive).
+- `response.data` is **shallow-merged** into the live page's `data` (unrefreshed zones + skeletons survive).
 - `response.items` **replaces** `items`.
-- The action's `regions` names which regions are refreshing → the runtime shows each one's skeleton while in flight; unnamed regions (e.g. a footer shell) stay mounted.
+- The action's `ui_zones` names which zones are refreshing → the runtime shows each one's skeleton while in flight; unnamed zones (e.g. a footer shell) stay mounted.
 
-| Trigger | `reload` regions | Response |
-|---------|------------------|----------|
-| first load / tab switch | `["header","content"]` | `{ data: { header: [...] }, items: [...] }` |
+| Trigger | `reload` `ui_zones` | Response |
+|---------|---------------------|----------|
+| first load / tab switch | `["header","content"]` | `{ data: { header: {...} }, items: [...] }` |
 | filter / pull-refresh | `["content"]` | `{ items: [...] }` |
 
-The runtime sends `regions` + the bound context as query params; return exactly the named regions. Full model + worked example: [`REGION-PAGE-MODEL.md`](./REGION-PAGE-MODEL.md).
+The runtime sends `ui_zones` + the bound context as query params; return exactly the named zones. Full model + worked example: [`UI-ZONE-PAGE-MODEL.md`](./UI-ZONE-PAGE-MODEL.md).
 
-**Latest-wins per region.** Reloads are coordinated by the regions they target: a new `reload` of a region takes ownership from any in-flight `reload` of that region, so only the most recent response is applied — chained tab switches render just the latest tab, never a flicker through every response in arrival order. Reloads targeting *disjoint* regions run in parallel untouched. An in-flight reload is aborted only when *all* its regions have been superseded; if only some were (e.g. a `["content"]` filter landing over an in-flight `["header","content"]` tab switch), it still applies the regions it owns. This is automatic — the BFF declares no concurrency flag.
+**Latest-wins per UI zone.** Reloads are coordinated by the zones they target: a new `reload` of a zone takes ownership from any in-flight `reload` of that zone, so only the most recent response is applied — chained tab switches render just the latest tab, never a flicker through every response in arrival order. Reloads targeting *disjoint* zones run in parallel untouched. An in-flight reload is aborted only when *all* its zones have been superseded; if only some were (e.g. a `["content"]` filter landing over an in-flight `["header","content"]` tab switch), it still applies the zones it owns. This is automatic — the BFF declares no concurrency flag.
 
 ## 4. Action vocabulary
 
@@ -63,11 +63,11 @@ Every interactive field (`on_click`, `on_load`, `on_refresh`, a chip's `on_click
 |------|----------------------|--------|
 | `navigate` | `{ target, op, params }` | Push/replace a screen (via the app's `onNavigate`). |
 | `bff_call` | `{ endpoint, method?, query_params?, request_body?, on_success?, on_error? }` | Fetch; may dispatch a follow-up action from the response body. |
-| `reload` | `{ endpoint, regions[], method?, query_params?, request_body? }` | Region-scoped partial-page refresh (§3). |
+| `reload` | `{ endpoint, ui_zones[], method?, query_params?, request_body? }` | UI-zone-scoped partial-page refresh (§3). |
 | `set_local` | `{ key, op, value? }` | Mutate local store. `op`: `set` / `merge` / `toggle` / `increment` / `remove` / **`array_toggle`** (add/remove a value from an array — multi-select). |
 | `compound` | `{ actions: Action[], mode? }` | Run actions in sequence (default) or parallel. |
 | `append_items` | `{ target, items, has_more? }` | Append raw nodes to a container (infinite scroll). |
-| `reload_section` / `replace_section` | `{ target, endpoint?/data }` | Swap a single node by id. |
+| `reload_section` / `replace_section` | `{ target, endpoint?/data }` | Swap a single node by id (distinct from a UI zone, which is a whole page area). |
 | `toast` / `dismiss` / `deeplink` / `emit_telemetry` / `branch` / `submit` | — | As named. |
 
 Any action may carry **`debounce_ms`** (backend-controlled): the engine coalesces a burst of
@@ -111,7 +111,7 @@ compose the shape:
 - `card` — wrap each group in a card surface.
 - `padding` — horizontal inset (match the content's gutter).
 
-Compose a skeleton that *resembles* the region it replaces (header = title + icon + chip row; card = media + logo + tag + lines), and declare it as `data.<region>_skeleton`.
+Compose a skeleton that *resembles* the zone it replaces (header = title + icon + chip row; card = media + logo + tag + lines), and declare it as `data.<zone>_skeleton`.
 
 ## 7. Use the SDK builders
 
@@ -122,7 +122,7 @@ validated node/action.
 
 ```ts
 import { reload } from "@one-impression/sdk-native-sdui";
-reload({ endpoint: "creator.campaigns.list", regions: ["content"], debounceMs: 400,
+reload({ endpoint: "creator.campaigns.list", uiZones: ["content"], debounceMs: 400,
          queryParams: { tab: { ref: "$.local.selected_tab" }, filter: { ref: "$.local.selected_filters" } } });
 ```
 
@@ -139,4 +139,4 @@ The campaigns feed (`apps/sdui-playground/server/fixture-server.mjs`) is the can
 example: a shell (footer + header/content skeletons + `on_load → reload(["header","content"])`),
 a tab tap (`compound[set_local tab, set_local filters=[], reload(["header","content"])]`), and
 a filter tap (`compound[set_local array_toggle, reload(["content"], debounce 400)]`), with the
-endpoint returning the matching partial page per requested `regions`.
+endpoint returning the matching partial page per requested `ui_zones`.

--- a/packages/sdui-runtime/INTEGRATION.md
+++ b/packages/sdui-runtime/INTEGRATION.md
@@ -131,7 +131,7 @@ export default function App() {
 
 `resolvePage` is the only wired seam — every `navigate` target round-trips through it, so
 navigation stays fully data-driven. The host hides its native header automatically when a
-page declares a header region (`data.header` or `data.header_skeleton`).
+page declares a header zone (`data.header` or `data.header_skeleton`).
 
 ## 6. Registering app-specific snippets
 

--- a/packages/sdui-runtime/src/action-engine/cond/__tests__/eval-cond.test.ts
+++ b/packages/sdui-runtime/src/action-engine/cond/__tests__/eval-cond.test.ts
@@ -85,14 +85,14 @@ test("cond:local eq — structural equality across plain objects", () => {
     type: "cond:local",
     key: "filters",
     op: "eq",
-    value: { tier: "pro", region: "in" },
+    value: { tier: "pro", country: "in" },
   };
   assert.equal(
-    evaluateCond(cond, reader({ filters: { tier: "pro", region: "in" } })),
+    evaluateCond(cond, reader({ filters: { tier: "pro", country: "in" } })),
     true,
   );
   assert.equal(
-    evaluateCond(cond, reader({ filters: { tier: "free", region: "in" } })),
+    evaluateCond(cond, reader({ filters: { tier: "free", country: "in" } })),
     false,
   );
 });

--- a/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
@@ -29,10 +29,10 @@ const styles = StyleSheet.create({
 });
 
 /**
- * Feed layout — pure zone geometry over {@link usePageScaffold}. Three zones:
- * a pinned `header` (region), a scrolling `content` body (region = top-level
- * `items`, virtualized via FlatList), and a pinned `footer` (region — the shell).
- * The scaffold decides content-vs-skeleton per region; this renderer only places
+ * Feed layout — pure zone geometry over {@link usePageScaffold}. Three UI zones:
+ * a pinned `header`, a scrolling `content` body (= top-level `items`, virtualized
+ * via FlatList), and a pinned `footer` (the shell).
+ * The scaffold decides content-vs-skeleton per zone; this renderer only places
  * each zone and owns content virtualization + viewport-driven infinite scroll.
  */
 export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
@@ -105,7 +105,7 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
     <View style={containerStyle}>
       {gradient ? <Gradient item={gradient} /> : null}
 
-      {/* Pinned header zone — region nodes (page_header + filters) or skeleton. */}
+      {/* Pinned header zone — its node (page_header + filters) or skeleton. */}
       {headerNodes.length > 0 ? (
         <View style={[styles.header, headerIsSkeleton ? { paddingTop: insets.top } : null]}>
           {headerNodes.map((node, i) => (

--- a/packages/sdui-runtime/src/snippets/Composite/Composite.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/Composite/Composite.renderer.tsx
@@ -104,7 +104,7 @@ function CoverLayout({ v }: { v: Record<string, unknown> }): React.ReactElement 
         </Box>
       ) : null}
 
-      {/* Media region — full-bleed, clipped by the surface. Overlay chips sit
+      {/* Media area — full-bleed, clipped by the surface. Overlay chips sit
           on top, pinned to the top corners. */}
       {media ? (
         <View>


### PR DESCRIPTION
Doc/comment-only follow-up to the region→ui_zone rename (sdui-runtime@3.0.0). Notably fixes a **broken link** in BFF-CONTRACT.md (REGION-PAGE-MODEL.md → UI-ZONE-PAGE-MODEL.md) and documents the header zone as a single Node. No behavior change, no changeset. CHANGELOG history left intact. 🤖 Generated with [Claude Code](https://claude.com/claude-code)