### PR TITLE
fix(sdui-runtime): chip on_click via DSChip.onPress + scrollable group_chips

### DIFF
--- a/.changeset/sdui-runtime-chip-tap-scroll.md
+++ b/.changeset/sdui-runtime-chip-tap-scroll.md
@@ -1,0 +1,18 @@
+---
+"@one-impression/sdui-runtime": minor
+---
+
+Fix chip taps + add scrollable chip rows.
+
+- `ChipRenderer` (ui_component.chip) now dispatches `on_click` via `DSChip.onPress`
+  instead of relying on SduiNode's outer Clickable — which the inner Pressable
+  swallowed, so a chip's `on_click` never fired (e.g. filter chips were dead).
+  Mirrors the Tab / snippet-Chip renderers. Also resolves the chip icon via
+  `IconGlyph` (was a no-op `Interpreter`).
+- `GroupChipsRenderer` honors `data.layout`: `scroll` renders a single
+  horizontally-scrolling row; `wrap` (default) keeps the multi-line row. Removes
+  the hardcoded `paddingHorizontal` that double-padded the row on top of the
+  caller's gutter.
+
+Requires `@one-impression/sdk-native-sdui ^4.4.0` (the `groupChips.layout` field
++ chip `selected` render-binding).

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@gorhom/bottom-sheet": "^5.2.14",
-        "@one-impression/sdk-native-sdui": "^3.4.0",
-        "@one-impression/sdui-runtime": "*",
+        "@one-impression/sdk-native-sdui": "^4.0.0",
+        "@one-impression/sdui-runtime": "^3.0.0",
         "@one-impression/tokens-creator": "*",
         "@one-impression/ui-native": "*",
         "@react-navigation/native": "^7.3.1",
@@ -5073,9 +5073,9 @@
       "link": true
     },
     "node_modules/@one-impression/sdk-native-sdui": {
-      "version": "3.5.0",
-      "resolved": "https://npm.pkg.github.com/download/@one-impression/sdk-native-sdui/3.5.0/1d7acccf6391563581b0d2d01da379b45cebd2dc",
-      "integrity": "sha512-VZBxydHzy15AhZhDktovPOL0gtZuqUpNN7evmn1r/JggAITHnIP5zSlKzucm5/bG5Gua3I6ViKeFe0f6xe2f6A==",
+      "version": "4.4.0",
+      "resolved": "https://npm.pkg.github.com/download/@one-impression/sdk-native-sdui/4.4.0/e11a5cdb5de381d1073fbd2d7491cf44bec65eb9",
+      "integrity": "sha512-BwWvBvZRb7NZ8EhBuXuzrrlV6DceoWOV45p7iQKMPKekjjykGT27VR23u0CUaNX5bQa27rvajGce5fHszC18Qw==",
       "dependencies": {
         "zod": "^3.23.0"
       }
@@ -20255,20 +20255,20 @@
     },
     "packages/sdui-runtime": {
       "name": "@one-impression/sdui-runtime",
-      "version": "2.9.0",
+      "version": "3.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "zod": "^3.22.0",
         "zustand": "^4.5.0"
       },
       "devDependencies": {
-        "@one-impression/sdk-native-sdui": "^4.0.0",
+        "@one-impression/sdk-native-sdui": "^4.4.0",
         "tsup": "^8.0.0",
         "typescript": "^5.5.0"
       },
       "peerDependencies": {
         "@gorhom/bottom-sheet": "^5.0.0",
-        "@one-impression/sdk-native-sdui": "^4.0.0",
+        "@one-impression/sdk-native-sdui": "^4.4.0",
         "@one-impression/tokens-creator": ">=3.0.0",
         "@one-impression/ui-native": ">=2.0.2",
         "@react-navigation/native": ">=7.0.0",
@@ -20306,15 +20306,6 @@
         "react-native-webview": {
           "optional": true
         }
-      }
-    },
-    "packages/sdui-runtime/node_modules/@one-impression/sdk-native-sdui": {
-      "version": "4.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@one-impression/sdk-native-sdui/4.0.0/0b06582c672f7388f027cc5a5df813fb7d33b342",
-      "integrity": "sha512-ePtaQf/+y6UH5DUPLnPkdaURDfgXbtl0gU6uobY9KimwpWNdCbolcnEZG1HhyjzlUBNfZU+WT+xx4J1lNOfB7w==",
-      "dev": true,
-      "dependencies": {
-        "zod": "^3.23.0"
       }
     },
     "packages/storybook": {

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -40,7 +40,7 @@
     "react": ">=18.0.0",
     "react-native": ">=0.72.0",
     "react-native-svg": ">=13.0.0",
-    "@one-impression/sdk-native-sdui": "^4.0.0",
+    "@one-impression/sdk-native-sdui": "^4.4.0",
     "@one-impression/ui-native": ">=2.0.2",
     "@one-impression/tokens-creator": ">=3.0.0",
     "@gorhom/bottom-sheet": "^5.0.0",
@@ -83,7 +83,7 @@
     }
   },
   "devDependencies": {
-    "@one-impression/sdk-native-sdui": "^4.0.0",
+    "@one-impression/sdk-native-sdui": "^4.4.0",
     "tsup": "^8.0.0",
     "typescript": "^5.5.0"
   },

--- a/packages/sdui-runtime/src/snippets/GroupChips/GroupChips.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/GroupChips/GroupChips.renderer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { StyleSheet, View } from "react-native";
+import { ScrollView, StyleSheet, View } from "react-native";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { GroupChipsSchema } from "@one-impression/sdk-native-sdui";
 import { SduiNode } from "../../sdui-node/index.js";
@@ -18,28 +18,44 @@ export function GroupChipsRenderer(node: Node): React.ReactElement {
       view_events={node.view_events}
       load_events={node.load_events}
     >
-      {(v) => (
-        // A wrapping row that sizes to its content height. (Previously a
-        // ui-native ScrollView whose `flex: 1` base collapsed to zero height in
-        // a column with no fixed height — e.g. a pinned page header — leaving
-        // the chips invisible. A plain row View has no such viewport-height
-        // dependency and wraps if the chips overflow.)
-        <View style={styles.row}>
-          {v.items?.map((item: Node, i: number) => (
-            <Interpreter key={item.id || i} node={item} />
-          ))}
-        </View>
-      )}
+      {(v) => {
+        const chips = v.items?.map((item: Node, i: number) => (
+          <Interpreter key={item.id || i} node={item} />
+        ));
+        // No horizontal padding here — the caller's layout (the feed content
+        // gutter, an enclosing section, etc.) owns horizontal inset. Adding it
+        // here double-pads the chip row.
+        if (v.layout === "scroll") {
+          // A single row that scrolls horizontally. A horizontal ScrollView's
+          // height is content-driven (it does NOT collapse the way a vertical
+          // `flex: 1` ScrollView did in a no-height column), so chips stay
+          // visible.
+          return (
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.scrollRow}
+            >
+              {chips}
+            </ScrollView>
+          );
+        }
+        return <View style={styles.wrapRow}>{chips}</View>;
+      }}
     </SduiNode>
   );
 }
 
 const styles = StyleSheet.create({
-  row: {
+  wrapRow: {
     flexDirection: "row",
     flexWrap: "wrap",
     gap: 8,
-    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  scrollRow: {
+    flexDirection: "row",
+    gap: 8,
     paddingVertical: 8,
   },
 });

--- a/packages/sdui-runtime/src/ui_components/Chip/Chip.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Chip/Chip.renderer.tsx
@@ -3,15 +3,25 @@ import type { Node } from "@one-impression/sdk-native-sdui";
 import { ChipComponentSchema } from "@one-impression/sdk-native-sdui";
 import { Chip as DSChip } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
-import { Interpreter } from "../../interpreter/index.js";
+import { IconGlyph } from "../../icon-store/index.js";
+import { useActionEngine } from "../../action-engine/useActionEngine.js";
 
 export function ChipRenderer(node: Node): React.ReactElement {
+  const actionEngine = useActionEngine();
+  // DSChip is itself a Pressable, so a wrapping Clickable in SduiNode would be
+  // swallowed by the inner Pressable (taps land on the deepest Pressable
+  // first). Dispatch on_click here and pass it directly as DSChip.onPress;
+  // intentionally do NOT forward on_click to SduiNode so the outer wrap is
+  // skipped. on_load / on_view / on_dismount still go through SduiNode.
+  // (Mirrors TabRenderer / the snippet Chip — without this a chip's on_click
+  // never fired.)
+  const onClick = node.on_click;
+  const onPress = onClick ? () => actionEngine.dispatch(onClick) : undefined;
   return (
     <SduiNode
       data={node.data}
       schema={ChipComponentSchema.shape.data}
       id={node.id}
-      on_click={node.on_click}
       on_load={node.on_load}
       on_view={node.on_view}
       on_dismount={node.on_dismount}
@@ -21,9 +31,16 @@ export function ChipRenderer(node: Node): React.ReactElement {
       {(v) => (
         <DSChip
           label={v.label.text}
-          selected={v.selected}
+          // `selected` may be a render-binding ref in the wire contract; the
+          // runtime resolves it to a boolean before this renderer sees it.
+          selected={v.selected as boolean | undefined}
           disabled={v.disabled}
-          icon={v.icon ? <Interpreter node={v.icon} /> : undefined}
+          onPress={onPress}
+          icon={
+            v.icon ? (
+              <IconGlyph name={v.icon.name} size={v.icon.size} color={v.icon.color} />
+            ) : undefined
+          }
         />
       )}
     </SduiNode>


### PR DESCRIPTION
Two fixes the Explore filter chips need:

**1. Chip taps were dead.** `ChipRenderer` (ui_component.chip) rendered `DSChip` with no `onPress` and relied on `SduiNode`'s outer Clickable — but `DSChip` is itself a `Pressable`, which swallows the tap (the deepest Pressable wins). So a chip's `on_click` never fired. Now it dispatches `on_click` via `DSChip.onPress` and skips the dead outer wrap — exactly the pattern the `Tab` and snippet-`Chip` renderers already use. Also fixes the chip icon (`IconGlyph`, was a no-op `Interpreter node={icon}`).

**2. Chips couldn't scroll.** `GroupChipsRenderer` now honors `data.layout`: `scroll` → a single horizontally-scrolling row; `wrap` (default) → the multi-line row. Also removes the hardcoded `paddingHorizontal: 16` that **double-padded** the row on top of the caller's content gutter.

Requires `sdk-native-sdui ^4.4.0`. Build verified (tsup); changeset (minor).

Follow-up: creator-app bumps the runtime + sets `layout: "scroll"` on the Explore filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)