### PR TITLE
fix(sdui-runtime): ui_component Chip trailing remove × when selected

### DIFF
--- a/.changeset/sdui-runtime-chip-remove-x.md
+++ b/.changeset/sdui-runtime-chip-remove-x.md
@@ -1,0 +1,7 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+ui_component Chip now renders a trailing remove × when `selected` — the
+conventional multi-select / filter-chip affordance (matches the snippet Chip).
+Reactive to the render-bound `selected`, so the × appears/disappears instantly.

--- a/packages/sdui-runtime/src/ui_components/Chip/Chip.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Chip/Chip.renderer.tsx
@@ -41,6 +41,11 @@ export function ChipRenderer(node: Node): React.ReactElement {
               <IconGlyph name={v.icon.name} size={v.icon.size} color={v.icon.color} />
             ) : undefined
           }
+          // A selected (multi-select / filter) chip shows a remove × as a
+          // TRAILING icon — the conventional remove affordance. Reactive
+          // because `selected` is render-bound, so the × appears/disappears the
+          // instant the chip toggles. (Matches the snippet Chip renderer.)
+          trailingIcon={v.selected ? <IconGlyph name="close" size={14} /> : undefined}
         />
       )}
     </SduiNode>


### PR DESCRIPTION
Selected ui_component chips (e.g. Explore filter chips) now render a trailing remove **×** — the conventional multi-select affordance, matching the snippet Chip renderer. Reactive to the render-bound `selected`. Build verified; changeset (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)