### PR TITLE
docs(zenith): update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,10 +52,19 @@ packages/
   tokens-atmosphere/  — Atmosphere tokens (gold accent, dark-first themes)
   tokens-creator/     — Creator App tokens (SDUI mappings, mobile-optimized)
   ui/                 — Shared React components (Button, Badge, Card, EmptyState, Skeleton)
+  sdui-runtime/       — SDUI renderer components (Chip, etc.) — server-driven UI primitives
   storybook/          — Component documentation and visual testing
   eslint-config/      — Design system lint rules (no-hardcoded-colors, no-raw-spacing, prefer-token-import)
   feature-flags/      — Feature flag utilities
 ```
+
+### SDUI Runtime — Chip
+
+`packages/sdui-runtime/src/ui_components/Chip/Chip.renderer.tsx`
+
+- When `selected` is `true`, the Chip automatically renders a trailing `×` (close) icon (`IconGlyph name="close" size={14}`) — the conventional multi-select / filter-chip remove affordance.
+- The trailing icon is **reactive to the render-bound `selected` state** — it appears/disappears instantly as the chip toggles, with no extra wiring required.
+- Do not manually pass a trailing close icon for selected state; it is injected by the renderer automatically.
 
 ## Token File Format
 


### PR DESCRIPTION
## Summary
- **Trigger:** commit `ce68ce9`
- **File updated:** `CLAUDE.md`
- **Confidence:** 🟡 0.73
- **Reason:** The Chip component now has a new behavioral pattern — automatically rendering a trailing remove × icon when selected — which engineers working in this repo need to know about when using or extending the SDUI Chip renderer.

This is an automated documentation update by Zenith. Needs human review.

---
Generated by [Zenith AI CTO](https://github.com/one-impression/zenith-coding-agent)