### PR TITLE
fix(sdui-runtime): leading inset for scrollable group_chips

### DIFF
--- a/.changeset/sdui-runtime-scroll-chip-leading-pad.md
+++ b/.changeset/sdui-runtime-scroll-chip-leading-pad.md
@@ -1,0 +1,7 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+GroupChips `layout: "scroll"` now insets the scroll content horizontally so the
+first/last chip don't sit flush against the screen edge (and align with a
+full-bleed header title). The wrap layout stays gutter-less (caller owns inset).

--- a/packages/sdui-runtime/src/snippets/GroupChips/GroupChips.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/GroupChips/GroupChips.renderer.tsx
@@ -57,5 +57,9 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     gap: 8,
     paddingVertical: 8,
+    // Leading/trailing inset so the first/last chip don't sit flush against the
+    // screen edge. A horizontal scroll row is typically caller-gutter-less (it
+    // scrolls edge-to-edge), so the inset lives on the scroll content itself.
+    paddingHorizontal: 16,
   },
 });


### PR DESCRIPTION
Scrollable `group_chips` now insets its scroll content horizontally so chips don't sit flush against the screen edge (and align with a full-bleed header title). Wrap layout unchanged. Needed for filter chips living in the header zone. Build verified; patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)