### PR TITLE
feat(sdui-runtime): PageHeader sub_row + intrinsic bottom elevation

### DIFF
--- a/.changeset/sdui-runtime-header-subrow-elevation.md
+++ b/.changeset/sdui-runtime-header-subrow-elevation.md
@@ -1,0 +1,9 @@
+---
+"@one-impression/sdui-runtime": minor
+---
+
+`PageHeader` renders a `sub_row` (content below the title, inside the header
+surface — e.g. a filter chip row) and now has an intrinsic bottom-edge shadow
+(elevation), the symmetric counterpart to TabsFooter's top-edge shadow. The
+background (solid or gradient) fills the whole header, title + sub_row included,
+so the header reads as one cohesive surface. Requires sdk-native-sdui ^4.5.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5073,9 +5073,9 @@
       "link": true
     },
     "node_modules/@one-impression/sdk-native-sdui": {
-      "version": "4.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@one-impression/sdk-native-sdui/4.4.0/e11a5cdb5de381d1073fbd2d7491cf44bec65eb9",
-      "integrity": "sha512-BwWvBvZRb7NZ8EhBuXuzrrlV6DceoWOV45p7iQKMPKekjjykGT27VR23u0CUaNX5bQa27rvajGce5fHszC18Qw==",
+      "version": "4.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@one-impression/sdk-native-sdui/4.5.0/ad7723478771d29901e140ec427fb9470ee4a994",
+      "integrity": "sha512-d0v0FLdmLgIP0O2xlNs6GRmjZV1YIVFriVBEZJqqw0gAgdcjRiMAN5sfV3CT09DgGEk/H5/BL+4V11E9GYnXIA==",
       "dependencies": {
         "zod": "^3.23.0"
       }
@@ -20255,20 +20255,20 @@
     },
     "packages/sdui-runtime": {
       "name": "@one-impression/sdui-runtime",
-      "version": "3.0.0",
+      "version": "3.1.2",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "zod": "^3.22.0",
         "zustand": "^4.5.0"
       },
       "devDependencies": {
-        "@one-impression/sdk-native-sdui": "^4.4.0",
+        "@one-impression/sdk-native-sdui": "^4.5.0",
         "tsup": "^8.0.0",
         "typescript": "^5.5.0"
       },
       "peerDependencies": {
         "@gorhom/bottom-sheet": "^5.0.0",
-        "@one-impression/sdk-native-sdui": "^4.4.0",
+        "@one-impression/sdk-native-sdui": "^4.5.0",
         "@one-impression/tokens-creator": ">=3.0.0",
         "@one-impression/ui-native": ">=2.0.2",
         "@react-navigation/native": ">=7.0.0",

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -40,7 +40,7 @@
     "react": ">=18.0.0",
     "react-native": ">=0.72.0",
     "react-native-svg": ">=13.0.0",
-    "@one-impression/sdk-native-sdui": "^4.4.0",
+    "@one-impression/sdk-native-sdui": "^4.5.0",
     "@one-impression/ui-native": ">=2.0.2",
     "@one-impression/tokens-creator": ">=3.0.0",
     "@gorhom/bottom-sheet": "^5.0.0",
@@ -83,7 +83,7 @@
     }
   },
   "devDependencies": {
-    "@one-impression/sdk-native-sdui": "^4.4.0",
+    "@one-impression/sdk-native-sdui": "^4.5.0",
     "tsup": "^8.0.0",
     "typescript": "^5.5.0"
   },

--- a/packages/sdui-runtime/src/snippets/PageHeader/PageHeader.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/PageHeader/PageHeader.renderer.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { View, Pressable } from "react-native";
+import { View, Pressable, StyleSheet } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { PageHeaderSchema } from "@one-impression/sdk-native-sdui";
@@ -68,7 +68,13 @@ export function PageHeaderRenderer(node: Node): React.ReactElement {
       load_events={node.load_events}
     >
       {(v) => (
-        <View style={[{ paddingTop: insets.top }, solidBg ? { backgroundColor: solidBg } : null]}>
+        <View
+          style={[
+            styles.header,
+            { paddingTop: insets.top },
+            solidBg ? { backgroundColor: solidBg } : null,
+          ]}
+        >
           {gradient ? (
             <Gradient item={{ colors: gradient.colors, angle: gradient.angle ?? 90 }} />
           ) : null}
@@ -114,8 +120,33 @@ export function PageHeaderRenderer(node: Node): React.ReactElement {
               </Stack>
             </Stack>
           </Box>
+          {v.sub_row && v.sub_row.length > 0 ? (
+            <View style={styles.subRow}>
+              {v.sub_row.map((n: Node, i: number) => (
+                <Interpreter key={n.id || i} node={n} />
+              ))}
+            </View>
+          ) : null}
         </View>
       )}
     </SduiNode>
   );
 }
+
+const styles = StyleSheet.create({
+  // Soft bottom-edge elevation so the header lifts off the content below it
+  // (the symmetric counterpart to TabsFooter's top-edge shadow). Intrinsic to
+  // the snippet — no wire flag needed.
+  header: {
+    backgroundColor: "transparent",
+    shadowColor: "rgba(0, 0, 0, 0.15)",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 1,
+    shadowRadius: 4,
+    elevation: 4,
+    zIndex: 1,
+  },
+  subRow: {
+    paddingBottom: 8,
+  },
+});


### PR DESCRIPTION
Renders `page_header.sub_row` (e.g. a filter chip row) **inside** the header surface, below the title — so the background (solid or **gradient**, an absolute-fill) spans the **whole header**, title + sub_row. Adds an intrinsic **bottom-edge shadow** (mirrors TabsFooter's top-edge), no wire flag. Header + footer are now symmetric snippets owning their surface + edge elevation. Requires `sdk-native-sdui ^4.5.0`. Build verified; changeset (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)