### PR TITLE
docs(zenith): update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,28 @@ Build script (`scripts/build-tokens.js`) generates CSS variables, SCSS, JSON, JS
 4. **ESLint rules** exist in `packages/eslint-config/rules/` but are NOT enforced in product repos yet
 5. **Breaking changes** to CSS variable names or values require a migration note in the PR description
 
+
+
+## sdui-runtime: PageHeader & Snippet Elevation Pattern
+
+## sdui-runtime: PageHeader & Snippet Elevation Pattern
+
+**Package**: `packages/sdui-runtime` (`@one-impression/sdui-runtime` v3.1.2)
+**Peer dep bump**: requires `@one-impression/sdk-native-sdui ^4.5.0` (was ^4.4.0)
+
+### PageHeader capabilities (as of v3.1.2)
+
+- **`sub_row` slot**: nodes in `data.sub_row` render below the title, inside the header `View`, so the background (solid color or gradient) spans the full header surface — title + sub_row as one cohesive unit.
+- **Intrinsic bottom-edge elevation**: `PageHeader` now carries a built-in bottom shadow (`elevation: 4`, `shadowRadius: 4`). No wire flag needed — it is always present.
+
+### Header/footer elevation symmetry
+
+`PageHeader` (bottom shadow) and `TabsFooter` (top shadow) are now symmetric snippets — each owns its own surface and its own edge shadow. This is the established pattern for full-bleed snippet surfaces in `sdui-runtime`. Follow it for any new header/footer-style snippets.
+
+### Migration note
+
+Product apps consuming `@one-impression/sdui-runtime` must update their `sdk-native-sdui` peer dependency to `^4.5.0`. Older versions will not include the `sub_row` schema field.
+
 ## Oportunities theme (newest product line)
 
 Oportunities is the newest product theme in this monorepo. It ships as the


### PR DESCRIPTION
## Summary
- **Trigger:** commit `471b179`
- **File updated:** `CLAUDE.md`
- **Confidence:** 🟡 0.63
- **Reason:** PageHeader gains a new `sub_row` slot and intrinsic bottom elevation, and now requires sdk-native-sdui ^4.5.0 — engineers working in this repo need to know about the new component capability, peer dependency bump, and the symmetric header/footer elevation pattern.

This is an automated documentation update by Zenith. Needs human review.

---
Generated by [Zenith AI CTO](https://github.com/one-impression/zenith-coding-agent)