### PR TITLE
docs(zenith): update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,13 @@ packages/
   storybook/          — Component documentation and visual testing
   eslint-config/      — Design system lint rules (no-hardcoded-colors, no-raw-spacing, prefer-token-import)
   feature-flags/      — Feature flag utilities
+  sdui-runtime/       — SDUI runtime interpreter, action engine, bottom-sheet manager, loaders, providers
 ```
+
+### sdui-runtime notable behaviours
+
+- **`PageHeader` `sub_row`** (v3.2.0): `PageHeader` accepts a `sub_row` slot — content rendered below the title but inside the header surface (e.g. a filter chip row). The header background (solid or gradient) spans the full surface including `sub_row`. The header also carries an intrinsic **bottom-edge shadow (elevation)**, the symmetric counterpart to `TabsFooter`'s top-edge shadow.
+  - Requires peer dependency **`sdk-native-sdui ^4.5.0`**.
 
 ## Token File Format
 


### PR DESCRIPTION
## Summary
- **Trigger:** commit `671846e`
- **File updated:** `CLAUDE.md`
- **Confidence:** 🟡 0.67
- **Reason:** PageHeader now supports a `sub_row` slot and bottom-edge elevation (shadow), and requires sdk-native-sdui ^4.5.0 — new component behavior and a peer dependency constraint engineers need to know about.

This is an automated documentation update by Zenith. Needs human review.

---
Generated by [Zenith AI CTO](https://github.com/one-impression/zenith-coding-agent)