### PR TITLE
feat(sdui-runtime,ui-native): addressable surfaces + apply-checklist UI

### DIFF
--- a/.changeset/addressable-surfaces.md
+++ b/.changeset/addressable-surfaces.md
@@ -1,0 +1,12 @@
+---
+"@one-impression/sdui-runtime": major
+"@one-impression/ui-native": minor
+---
+
+Addressable surfaces + runtime-owned navigation. `sdui-runtime` now owns the
+native-stack host (`SduiNavigationHost`), reload-by-name + path-direct actions,
+sheet content-fetched-from-own-API, action-driven header chrome, and the
+`BlinkerDot` indicator; reload/sheet handlers and InfoRow/SectionHeader/Separator
+renderers updated. Peers on `@one-impression/sdk-native-sdui` `^5.0.0` (breaking).
+
+`ui-native`: `Separator` gains `variant` (solid/dashed/dotted) + per-state tinting.

--- a/apps/sdui-playground/package.json
+++ b/apps/sdui-playground/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@gorhom/bottom-sheet": "^5.2.14",
-    "@one-impression/sdk-native-sdui": "^4.0.0",
+    "@one-impression/sdk-native-sdui": "^5.0.0",
     "@one-impression/sdui-runtime": "^3.0.0",
     "@one-impression/tokens-creator": "*",
     "@one-impression/ui-native": "*",

--- a/apps/sdui-playground/server/fixture-server.mjs
+++ b/apps/sdui-playground/server/fixture-server.mjs
@@ -109,7 +109,8 @@ const boundContext = {
 const reload = (uiZones, debounceMs) => ({
   type: "reload",
   ...(debounceMs ? { debounce_ms: debounceMs } : {}),
-  payload: { endpoint: "creator.campaigns.list", method: "GET", ui_zones: uiZones, query_params: { ...boundContext } },
+  // Path-direct: the BFF emits the concrete path; no client endpoint-id registry.
+  payload: { path: "/v1/creator/campaigns", method: "GET", ui_zones: uiZones, query_params: { ...boundContext } },
 });
 
 function campaignCard(c) {
@@ -410,6 +411,173 @@ function buildPartial(uiZones, tab, filters) {
   return out;
 }
 
+// ─── Addressable surfaces + cross-surface reload demo ────────────────────────
+// Exercises the addressable-surfaces feature end to end, BFF-driven, with zero
+// per-surface frontend code:
+//   (a) reload-by-name (nearest): the address-form submit fires
+//       reload{ page: "address-select" } — refreshes the surface one below it.
+//   (b) a sheet that fetches its OWN content on open: the entry page opens a
+//       sheet shell carrying content_path → /v1/demo/apply-checklist; the sheet
+//       fetches that doc on mount (B4).
+//   (c) a 3-level back+reload chain: apply-checklist sheet → address-select page
+//       → address-form page; submit pops to address-select (reload-by-name) and
+//       selecting an address pops to the apply-checklist sheet (reload-by-name).
+//
+// Mutable in-memory state proves the refetch actually happened: adding an
+// address grows the list; selecting one stamps the checklist. Both surfaces are
+// re-fetched (not re-rendered from a cache), so the new state appears only
+// because reload-by-name refetched the named surface's own path.
+const ADDR_PATH = "/v1/demo/address-select";
+const FORM_PATH = "/v1/demo/address-form";
+const CHECKLIST_PATH = "/v1/demo/apply-checklist";
+const ADDR_UPSERT_PATH = "/v1/demo/address/upsert";
+
+const addressState = {
+  addresses: [
+    { id: "a1", label: "Home", line: "12 Linking Road, Bandra, Mumbai 400050" },
+    { id: "a2", label: "Office", line: "WeWork, BKC, Mumbai 400051" },
+  ],
+  selectedId: null,
+};
+
+const infoRowNode = (id, title, subtitle, onClick) => ({
+  type: "sdui.snippet.info_row",
+  id,
+  ...(onClick ? { on_click: onClick } : {}),
+  data: {
+    title: { text: title, font_weight: "medium", font_size: "sdui.font-size.md" },
+    ...(subtitle
+      ? { subtitle: { text: subtitle, color: "sdui.color.neutral-medium", font_size: "sdui.font-size.sm" } }
+      : {}),
+    right_icon: { name: "chevron-right", color: "sdui.color.neutral-medium" },
+  },
+});
+
+// (b) The apply-checklist SHEET document — fetched by the sheet on open and
+// refetched by reload{ page: "apply-checklist" }. The selected address (set by
+// picking a row on address-select) shows here, proving the refetch ran.
+function buildChecklistDoc() {
+  const selected = addressState.addresses.find((a) => a.id === addressState.selectedId);
+  return {
+    id: "apply-checklist",
+    title: "Complete your application",
+    size: "large",
+    items: [
+      {
+        type: "sdui.snippet.section_header",
+        id: "ck-h",
+        data: { title: { text: "Checklist", font_weight: "bold", font_size: "sdui.font-size.lg" } },
+      },
+      infoRowNode(
+        "ck-address",
+        selected ? `Address: ${selected.label}` : "Add billing & shipping",
+        selected ? selected.line : "Tap to choose an address",
+        // Opens the address-select PAGE path-direct (navigate carries the path).
+        { type: "navigate", payload: { op: "push", target: "demo.address-select", params: { path: ADDR_PATH } } },
+      ),
+      {
+        type: "sdui.snippet.info_row",
+        id: "ck-status",
+        data: {
+          title: {
+            text: selected ? "✓ Address selected" : "Address pending",
+            color: selected ? "sdui.color.positive" : "sdui.color.notice",
+            font_size: "sdui.font-size.sm",
+          },
+        },
+      },
+    ],
+  };
+}
+
+// (c) The address-select PAGE — single-select list + "Add a new address". Each
+// row, on tap, persists the selection then back+reload the apply-checklist
+// sheet (reload-by-name). Refetched after the form adds an address (the new row
+// appears only because submit fired reload{ page: "address-select" }).
+function buildAddressSelectPage() {
+  const rows = addressState.addresses.map((a) =>
+    infoRowNode("addr-" + a.id, a.label, a.line, {
+      type: "compound",
+      payload: {
+        actions: [
+          // Persist the selection server-side, then pop back to the sheet and
+          // refetch it by name so the checklist shows the chosen address.
+          { type: "bff_call", payload: { method: "POST", path: ADDR_UPSERT_PATH, request_body: { select: a.id } } },
+          { type: "navigate", payload: { op: "pop", target: "" } },
+          { type: "reload", payload: { page: "apply-checklist", scope: "nearest" } },
+        ],
+      },
+    }),
+  );
+  return {
+    id: "demo.address-select",
+    title: "Select an address",
+    protocol_version: "1.0.0",
+    layout: "standard",
+    items: [
+      {
+        type: "sdui.snippet.section_header",
+        id: "as-h",
+        data: { title: { text: `Your addresses (${addressState.addresses.length})`, font_weight: "bold", font_size: "sdui.font-size.lg" } },
+      },
+      ...rows,
+      infoRowNode("as-add", "+ Add a new address", "Opens the address form", {
+        type: "navigate",
+        payload: { op: "push", target: "demo.address-form", params: { path: FORM_PATH } },
+      }),
+    ],
+    on_back_press: { type: "navigate", payload: { op: "pop", target: "" } },
+  };
+}
+
+// (c) The address-form PAGE — submit POSTs the upsert path, then on_success
+// back+reload the address-select page by name (the 3rd level of the chain).
+function buildAddressFormPage() {
+  return {
+    id: "demo.address-form",
+    title: "Add a new address",
+    protocol_version: "1.0.0",
+    layout: "standard",
+    items: [
+      {
+        type: "sdui.snippet.form",
+        id: "address-form",
+        data: {
+          items: [
+            { type: "sdui.snippet.input", id: "f-label", data: { name: "label", label: { text: "Label" }, placeholder: { text: "Home / Office" } } },
+            { type: "sdui.snippet.input", id: "f-line", data: { name: "line", label: { text: "Address" }, placeholder: { text: "Street, area, city, PIN" } } },
+          ],
+        },
+      },
+      {
+        type: "sdui.ui_component.button",
+        id: "f-submit",
+        data: { label: { text: "Save address" }, variant: "primary" },
+        on_click: {
+          type: "submit",
+          payload: {
+            form_id: "address-form",
+            endpoint: ADDR_UPSERT_PATH,
+            method: "POST",
+            // After the upsert: pop back to address-select and refetch it by
+            // name so the new address appears (reload-by-name, nearest).
+            on_success: {
+              type: "compound",
+              payload: {
+                actions: [
+                  { type: "navigate", payload: { op: "pop", target: "" } },
+                  { type: "reload", payload: { page: "demo.address-select", scope: "nearest" } },
+                ],
+              },
+            },
+          },
+        },
+      },
+    ],
+    on_back_press: { type: "navigate", payload: { op: "pop", target: "" } },
+  };
+}
+
 const server = createServer(async (req, res) => {
   const url = req.url ?? "/";
   // eslint-disable-next-line no-console
@@ -464,6 +632,43 @@ const server = createServer(async (req, res) => {
     return;
   }
 
+  // ── Addressable surfaces: path-direct documents fetched on open / reload ──
+  // The sheet fetches CHECKLIST_PATH on open; address-select / address-form are
+  // pages fetched by their navigate `path`; reload-by-name refetches each.
+  const cleanUrl = url.split("?")[0];
+  if (req.method === "GET" && cleanUrl === CHECKLIST_PATH) {
+    json(res, 200, buildChecklistDoc());
+    return;
+  }
+  if (req.method === "GET" && cleanUrl === ADDR_PATH) {
+    json(res, 200, buildAddressSelectPage());
+    return;
+  }
+  if (req.method === "GET" && cleanUrl === FORM_PATH) {
+    json(res, 200, buildAddressFormPage());
+    return;
+  }
+  // Upsert: a form submit ({label,line}) adds an address; a row tap ({select})
+  // sets the selection. Pure state mutation — the follow-up reload-by-name is
+  // what makes the change visible, so we just return ok.
+  if (req.method === "POST" && cleanUrl === ADDR_UPSERT_PATH) {
+    const body = await readJsonBody(req);
+    if (typeof body.select === "string") {
+      addressState.selectedId = body.select;
+    } else if (body.label || body.line) {
+      const id = "a" + (addressState.addresses.length + 1);
+      addressState.addresses.push({
+        id,
+        label: String(body.label ?? "New address"),
+        line: String(body.line ?? ""),
+      });
+      addressState.selectedId = id;
+    }
+    console.log(`[fixture-server] address upsert →`, JSON.stringify(addressState));
+    json(res, 200, { ok: true });
+    return;
+  }
+
   if (url.startsWith(PAGE_PREFIX)) {
     const target = decodeURIComponent(url.slice(PAGE_PREFIX.length));
     // Generated campaigns feed (shell-first region demo) — overrides any on-disk
@@ -471,6 +676,17 @@ const server = createServer(async (req, res) => {
     // skeletons); on_load streams in the default tab via reload.
     if (target === "demo.feed") {
       json(res, 200, buildShell());
+      return;
+    }
+    // Addressable-surface pages are dynamic (state-dependent), so they're
+    // generated rather than read off disk. The initial navigate fetches them by
+    // target here; reload-by-name later refetches them by their path (same doc).
+    if (target === "demo.address-select") {
+      json(res, 200, buildAddressSelectPage());
+      return;
+    }
+    if (target === "demo.address-form") {
+      json(res, 200, buildAddressFormPage());
       return;
     }
     // Guard against path traversal — target is a flat page id, never a path.

--- a/apps/sdui-playground/server/pages/catalog.home.json
+++ b/apps/sdui-playground/server/pages/catalog.home.json
@@ -169,6 +169,36 @@
     },
     {
       "type": "sdui.snippet.info_row",
+      "id": "launcher-addressable",
+      "on_click": {
+        "type": "navigate",
+        "payload": {
+          "op": "push",
+          "target": "demo.addressable"
+        }
+      },
+      "data": {
+        "title": {
+          "text": "Addressable surfaces",
+          "font_weight": "medium",
+          "font_size": "sdui.font-size.md"
+        },
+        "subtitle": {
+          "text": "self-fetching sheet · cross-surface reload-by-name",
+          "color": "sdui.color.text-muted",
+          "font_size": "sdui.font-size.sm"
+        },
+        "card": {},
+        "left_media": {
+          "type": "icon",
+          "icon": {
+            "name": "document"
+          }
+        }
+      }
+    },
+    {
+      "type": "sdui.snippet.info_row",
       "id": "launcher-5",
       "on_click": {
         "type": "navigate",

--- a/apps/sdui-playground/server/pages/demo.addressable.json
+++ b/apps/sdui-playground/server/pages/demo.addressable.json
@@ -1,0 +1,31 @@
+{
+  "id": "demo.addressable",
+  "title": "Addressable surfaces",
+  "protocol_version": "1.0.0",
+  "layout": "standard",
+  "items": [
+    {
+      "type": "sdui.snippet.section_header",
+      "id": "ad-h",
+      "data": { "title": { "text": "Cross-surface reload demo", "font_weight": "bold", "font_size": "sdui.font-size.lg" } }
+    },
+    {
+      "type": "sdui.snippet.info_row",
+      "id": "ad-explain",
+      "data": {
+        "title": { "text": "Open the apply checklist", "font_weight": "medium" },
+        "subtitle": { "text": "Sheet fetches its own content on open; address picks reload it by name", "color": "sdui.color.neutral-medium", "font_size": "sdui.font-size.sm" }
+      }
+    },
+    {
+      "type": "sdui.ui_component.button",
+      "id": "ad-open",
+      "data": { "label": { "text": "Open apply checklist" }, "variant": "primary" },
+      "on_click": {
+        "type": "sheet",
+        "payload": { "sheet_id": "apply-checklist", "content_path": "/v1/demo/apply-checklist" }
+      }
+    }
+  ],
+  "on_back_press": { "type": "navigate", "payload": { "op": "pop", "target": "" } }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@gorhom/bottom-sheet": "^5.2.14",
-        "@one-impression/sdk-native-sdui": "^4.0.0",
+        "@one-impression/sdk-native-sdui": "^5.0.0",
         "@one-impression/sdui-runtime": "^3.0.0",
         "@one-impression/tokens-creator": "*",
         "@one-impression/ui-native": "*",
@@ -5073,9 +5073,9 @@
       "link": true
     },
     "node_modules/@one-impression/sdk-native-sdui": {
-      "version": "4.5.0",
-      "resolved": "https://npm.pkg.github.com/download/@one-impression/sdk-native-sdui/4.5.0/ad7723478771d29901e140ec427fb9470ee4a994",
-      "integrity": "sha512-d0v0FLdmLgIP0O2xlNs6GRmjZV1YIVFriVBEZJqqw0gAgdcjRiMAN5sfV3CT09DgGEk/H5/BL+4V11E9GYnXIA==",
+      "version": "5.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@one-impression/sdk-native-sdui/5.0.0/f734a2bb345bd6812e02f20a84e6181b8869cba2",
+      "integrity": "sha512-8tEOz6okTDdg5vJyohDq9h87PJ+qFiEW0lCKlTgqLz2wy41rct/if8xrste1rpWqhjpOhgaSGCp67K1SF42BSQ==",
       "dependencies": {
         "zod": "^3.23.0"
       }
@@ -20255,20 +20255,20 @@
     },
     "packages/sdui-runtime": {
       "name": "@one-impression/sdui-runtime",
-      "version": "3.1.2",
+      "version": "3.2.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "zod": "^3.22.0",
         "zustand": "^4.5.0"
       },
       "devDependencies": {
-        "@one-impression/sdk-native-sdui": "^4.5.0",
+        "@one-impression/sdk-native-sdui": "^5.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.5.0"
       },
       "peerDependencies": {
         "@gorhom/bottom-sheet": "^5.0.0",
-        "@one-impression/sdk-native-sdui": "^4.5.0",
+        "@one-impression/sdk-native-sdui": "^5.0.0",
         "@one-impression/tokens-creator": ">=3.0.0",
         "@one-impression/ui-native": ">=2.0.2",
         "@react-navigation/native": ">=7.0.0",

--- a/packages/sdui-runtime/ADDRESSABLE-SURFACES-DESIGN.md
+++ b/packages/sdui-runtime/ADDRESSABLE-SURFACES-DESIGN.md
@@ -1,0 +1,135 @@
+# Addressable Surfaces + Cross-Surface Reload — Design
+
+Status: **design locked, not yet built**
+Related: [`UI-ZONE-PAGE-MODEL.md`](./UI-ZONE-PAGE-MODEL.md) (the existing zone-reload model), [`BFF-CONTRACT.md`](./BFF-CONTRACT.md)
+
+## Why
+
+We need a surface (page **or** bottom sheet) to be able to refresh **another, already-open surface anywhere in the stack** — driven entirely by the BFF, with no new frontend code per surface. The motivating flow:
+
+> apply sheet → "Add billing & shipping" → **address-select** (single-select list) → "Add a new address" → **add-address form** → submit → *back + refresh the address list* → select an address → *back + refresh the apply sheet*.
+
+Today's `reload` action is **UI-zone-scoped on the live page only** (see `UI-ZONE-PAGE-MODEL.md`); it cannot target a *different* surface in the stack, and bottom-sheet content is **statically embedded** in the parent page document, so a sheet can't be refreshed independently. This design adds **addressable surfaces** + **reload-by-name** + **sheet-content-from-its-own-API**.
+
+## Principles (reconciled)
+
+1. **No frontend endpoint-id → path registry.** Actions carry the **API path directly**. The current `EndpointPaths`/`getEndpoint` lookup (`action-engine/handlers/_shared/bff-request.ts`, `bff-call.ts`, `reload.ts`) is the legacy anti-pattern: it forces a frontend release before the BFF can use a new endpoint. New surfaces/actions are **path-direct**; migrating the existing id-based actions is a tracked follow-up.
+2. **Surfaces are addressed by a backend-provided name, which is a pure reference handle — never resolved to a path by the frontend.** The name reuses each surface's existing canonical identity: **`page.id` / `sheet.id`** (already the page-store key and the bottom-sheet registry key respectively). This does **not** reintroduce id→path coupling, because the name only matches an *already-open* surface; it is never turned into an endpoint.
+3. **Uniqueness per open instance comes from `route.key`** (React Navigation, minted free on push). The **route stack is the single source of truth for presence, order, and uniqueness.** A name (`page.id`/`sheet.id`) may map to multiple open `route.key`s.
+
+## Data structure — addressing model
+
+The custom route stack (`navigation/SduiNavigationHost.tsx` + `navigationRef`) already interleaves `SduiPage` and `SduiSheet` routes on one ordered stack. We extend it with a derived by-name index — **no parallel registry object**:
+
+| Concept | Source |
+|---|---|
+| unique id (per open instance) | `route.key` (React Navigation) |
+| referenceable name | `page.id` / `sheet.id` (= the `screenId`/`sheetId` route param) |
+| order / "nearest" tiebreak | route **index** in `navigationRef.getState().routes` |
+| refetch handle | the route's own fetch (by **path**) |
+
+```ts
+// Derived from a single navigationRef.addListener('state', …) — the route stack
+// stays the single source of truth; this is a read index, not a second store.
+byName: Map<string /* name */, string[] /* route.key[], in stack order */>
+// read by id  → routes.find(r => r.key === id)   (stacks are shallow; effectively O(1))
+// read by name → byName.get(name)                (O(1))
+```
+
+### Resolving one-name → many-ids
+`reload { page }` carries the **caller's `route.key`** (the caller knows its own). Policy:
+- **`nearest` (default)** — the matching route with the highest index **below the caller** = the surface you return to via `back`.
+- **`top`** — most-recently opened instance.
+- **`all`** — every open instance (surfaces legitimately mirrored in two places).
+
+> Why `route.key`-keyed, not `id`-keyed: the existing `useBottomSheetStore.registry` and the page store key by `sheet.id`/`pageId` and therefore **collide on same-id** (last-write-wins). They are fine for static single-instance sheets, but cannot support "same name, multiple open instances." The new index keys on `route.key` and uses the name only as a secondary lookup.
+
+## Sheet content from its own API
+
+Today a bottom sheet's content is embedded in the parent page's `bottom_sheets[]` and registered into `useBottomSheetStore.registry[sheet.id]`. New addressable sheets instead **fetch their own content on open**:
+
+- the parent only *opens* a sheet shell (`sheet` action carries the content **path** + the sheet's name);
+- the sheet fetches its document via `on_load` (path-direct) — fresh every open;
+- `reload { page: "<sheet name>" }` re-fetches it.
+
+### Coexistence + deprecation (do NOT rip out the id-keyed registry)
+`useBottomSheetStore.registry` is load-bearing (inline `bottom_sheet` snippet, page `bottom_sheets[]`, `SduiSheetScreen` content, `useBottomSheetData`, `sheetPresenter`, `BottomSheetHost`). It is correct for **static, single-instance** sheets.
+
+- **Keep** it as a content cache for static sheets.
+- **Add** the `route.key`-keyed index + fetch-on-open **additively**, scoped to addressable surfaces (apply-checklist, address-select).
+- **One hard rule:** presence/uniqueness/order live in the **route stack only**. The id-keyed registry is demoted to *content*; it must not also own "is this open." (Today presence is split between `openSheets[sheet.id]` in `BottomSheetHost` and route existence in `SduiSheetScreen` — that split is the footgun; new surfaces use route presence exclusively.)
+- **Gradual deprecation target:** the store-based presence host (`BottomSheetHost` + `openSheets`), once all sheets are route-based. The content registry can remain a harmless cache.
+
+## The `reload` action (extended)
+
+```
+reload { page: "<page.id | sheet.id>", scope?: "nearest" | "top" | "all" }   // default: nearest
+```
+Resolves to `route.key`(s) via the by-name index, then refetches each (by the route's own path). The existing zone-scoped `reload` (no `page`) is unchanged.
+
+### Action chains (the flow)
+- **Form submit** → `submit { form_id, endpoint: "<upsert path>", on_success: compound[ navigate{op:back}, reload{page:"address-select"} ] }`
+- **Select an address** → `compound[ <persist selection>, navigate{op:back}, reload{page:"apply-checklist"} ]`
+
+## BFF layering (non-negotiable)
+
+Every new BFF surface follows the **same three-layer split as the Explore / My-Campaigns tabs** — no shortcuts:
+1. **Adapter** — domain-shaped data, mock/real swappable (e.g. `mockCampaignsAdapter`).
+2. **View-model deriver** — pure `domain → view-model`, no SDUI nodes (e.g. `deriveExploreCard`, `deriveMyCampaignCard`).
+3. **SDUI builder** — `view-model → nodes`, owns design tokens (e.g. `buildCampaignCard`).
+
+`apply-checklist`, `address-select`, and `address-form` each get their own adapter + deriver + SDUI layer.
+
+## Surfaces (BFF, amplify-gateway)
+
+- **`apply-checklist`** (`page.id`) — the apply checkpoint content (section header + checkpoint rows + separators), moved **out** of the detail's static `bottom_sheets[]` into its own endpoint; the detail opens a sheet shell that fetches it.
+- **`address-select`** (`page.id`) — single-select radio list of addresses + "Add a new address" → form. (The apply flow uses this.)
+- **`addresses`** (existing) — the **generic** view/edit/add list, reachable from anywhere.
+- **`address-form`** — already built; fix submit to carry `endpoint` + `on_success` chain.
+
+## Open items / carried context
+- **Path-direct migration** of existing endpoint-id actions (`EndpointPaths` removal) — separate, larger follow-up; new surfaces are path-direct from day one.
+- **In-sheet tap gesture** — content-area taps in `SduiSheetScreen` (@gorhom) are flaky; fold the fix into the sheet-host work.
+- **Dev patches needing permanent homes:** `resolvePath` `{}`-token support and the `addressForm` `EndpointPaths` entry (both currently `node_modules` patches in the creator app).
+
+---
+
+# Build Plan
+
+Build order: **A → B in `sdui-runtime` + the playground first** (the keystone, testable without a publish cycle), then **C** (gateway BFF), then **D** (creator-app wiring). Each stage is independently verifiable.
+
+## Stage A — Contract (`sdk-native-sdui` in **amplify-schemas** → publish)
+> **Path-direct is already in the schema source.** `reload` / `bff_call` / `reload_section` already carry an optional **`path: z.string()`** ("fetch `bffBaseUrl + path` verbatim, no client-catalog lookup; preferred over the legacy optional `endpoint` id"), `submit.endpoint` is already a free `z.string()`, and `navigate.target` is a free `z.string()`. So new surfaces are called **by path** with **no frontend endpoint registry** — that work is done. (Earlier confusion came from reading a stale published `4.0.0` dist; the dep is `^4.5.0` and the source is migrated.)
+- **A1.** The **only** schema change: add two optional fields to `ReloadPayloadSchema` for reload-by-name:
+  - `page: z.string().optional()` — target an open surface by its name (`page.id`/`sheet.id`); absent = current surface (today's behaviour).
+  - `scope: z.enum(["nearest","top","all"]).default("nearest")` — which instance when a name has multiple open.
+  `ui_zones` is unchanged; it names the zones of whichever surface `page` resolves to.
+- **A2.** Publish amplify-schemas; bump `sdui-runtime` + the creator app to consume (also pulls the already-migrated `path` field through to consumers stuck on an older version).
+
+**No frontend endpoint registry — hard rule (already the contract).** The runtime fetches `bffBaseUrl + path` directly. `EndpointPaths` / `resolveEndpointUrl` id→path resolution survives only as legacy for already-shipped `endpoint`-id callers and is deleted as those migrate; new surfaces emit `path` and never touch it.
+- **A2.** Confirm `page.id` / `sheet.id` are emitted on every page/sheet envelope (already required on `page.schema`); document them as the addressable **name**.
+- **A3.** Ensure `sheet`/`navigate`/`bff_call`/`reload` payloads can carry an **endpoint path** directly (path-direct), not only an id. (New field or relax `endpoint` to accept a path.)
+
+## Stage B — Runtime (`sdui-runtime`, verify in playground)
+- **B1.** By-name index: `Map<name, route.key[]>` derived from a single `navigationRef.addListener('state', …)`. Read-by-id via `getState().routes`. No parallel store.
+- **B2.** `reload`-by-name: resolve `{page, scope}` → `route.key`(s) (nearest/top/all relative to the caller's `route.key`) → refetch each by its path.
+- **B3.** Path-direct fetch path for new surfaces in `_shared/bff-request.ts` (accept a path without `EndpointPaths` lookup); leave the id-path intact for legacy callers.
+- **B4.** Sheet-content-from-own-API: `SduiSheetScreen` fetches its document via the sheet's `on_load` (path) instead of (or falling back from) `registry[sheetId]`; route presence stays authoritative.
+- **B5.** Make route presence the single source of truth; stop new surfaces from using `openSheets[sheet.id]`. (Do not remove the legacy path yet.)
+- **B6.** Playground fixtures exercising: reload-by-name (nearest), a sheet that fetches its own content, and a 3-level back+reload chain.
+
+## Stage C — BFF (`amplify-gateway`)
+- **C1.** `apply-checklist` endpoint (`page.id: "apply-checklist"`) — move the checkpoint snippets out of the detail's static `bottom_sheets[]`; detail opens a sheet shell with `on_load` → this path.
+- **C2.** `address-select` endpoint (`page.id: "address-select"`) — single-select radio rows + "Add a new address" (→ form path); each row's `on_click = compound[persist, back, reload{page:"apply-checklist"}]`.
+- **C3.** `address-form` submit → add `endpoint` (upsert path) + `on_success: compound[back, reload{page:"address-select"}]`.
+- **C4.** Keep `addresses` as the generic view/edit/add list.
+- **C5.** All new actions are path-direct (no endpoint-id).
+
+## Stage D — Creator app (`amplify-creator-app`)
+- **D1.** Adopt the new runtime (publish or `patch-package`); fold in the carried dev patches (`resolvePath` `{}`, `EndpointPaths`).
+- **D2.** Sheet host renders content from the fetched sheet document; register each surface's `page.id`/`sheet.id` name.
+- **D3.** Fix the in-sheet content-tap gesture (@gorhom) so checkpoint/list rows navigate reliably.
+- **D4.** On-device E2E: apply sheet → address-select → form → submit (list refreshes) → select (sheet refreshes) → checkpoint shows ✓.
+
+## Definition of done
+The full address-selection flow works on-device with **zero per-surface frontend code** (all surfaces, names, paths, and reload chains BFF-driven), multiple same-name instances resolve correctly, and the legacy id-keyed registry remains intact for static sheets.

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -40,7 +40,7 @@
     "react": ">=18.0.0",
     "react-native": ">=0.72.0",
     "react-native-svg": ">=13.0.0",
-    "@one-impression/sdk-native-sdui": "^4.5.0",
+    "@one-impression/sdk-native-sdui": "^5.0.0",
     "@one-impression/ui-native": ">=2.0.2",
     "@one-impression/tokens-creator": ">=3.0.0",
     "@gorhom/bottom-sheet": "^5.0.0",
@@ -83,7 +83,7 @@
     }
   },
   "devDependencies": {
-    "@one-impression/sdk-native-sdui": "^4.5.0",
+    "@one-impression/sdk-native-sdui": "^5.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.5.0"
   },

--- a/packages/sdui-runtime/package.json
+++ b/packages/sdui-runtime/package.json
@@ -34,7 +34,7 @@
     "build": "tsup && tsc --emitDeclarationOnly --noCheck",
     "dev": "tsup --watch",
     "lint": "eslint src/",
-    "test": "tsx --test src/action-engine/__tests__/*.test.ts src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/bottom-sheet/__tests__/*.test.ts src/snippets/_shared/__tests__/*.test.ts src/state/__tests__/*.test.ts src/snippets/Form/__tests__/*.test.ts src/sdui-node/__tests__/*.test.ts src/registries/__tests__/*.test.ts src/snippets/Steps/__tests__/*.test.ts src/pages/PageFeed/__tests__/*.test.ts src/snippets/TabsFooter/__tests__/*.test.ts src/__tests__/*.test.ts"
+    "test": "tsx --test src/action-engine/__tests__/*.test.ts src/action-engine/cond/__tests__/*.test.ts src/action-engine/handlers/__tests__/*.test.ts src/bottom-sheet/__tests__/*.test.ts src/snippets/_shared/__tests__/*.test.ts src/state/__tests__/*.test.ts src/snippets/Form/__tests__/*.test.ts src/sdui-node/__tests__/*.test.ts src/registries/__tests__/*.test.ts src/snippets/Steps/__tests__/*.test.ts src/pages/PageFeed/__tests__/*.test.ts src/snippets/TabsFooter/__tests__/*.test.ts src/navigation/__tests__/*.test.ts src/__tests__/*.test.ts"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/sdui-runtime/src/SduiRuntimeProvider.tsx
+++ b/packages/sdui-runtime/src/SduiRuntimeProvider.tsx
@@ -2,6 +2,8 @@ import React, { useMemo } from "react";
 import type { ReactNode } from "react";
 import { createActionEngine } from "./action-engine/action-engine.js";
 import { ActionEngineContext } from "./action-engine/useActionEngine.js";
+import { BffConfigContext } from "./action-engine/useBffConfig.js";
+import type { BffConfigValue } from "./action-engine/useBffConfig.js";
 import { TelemetryContext } from "./telemetry/useTelemetry.js";
 import type { TelemetryEmitter } from "./telemetry/useTelemetry.js";
 import type { ActionEngineConfig } from "./action-engine/types.js";
@@ -56,6 +58,14 @@ export function SduiRuntimeProvider({
     return createActionEngine(config);
   }, [bffConfig.baseUrl, authConfig.getToken, onNavigate, onToast, onDeeplink]);
 
+  // Mirror the two BFF connection facts a path-direct screen-level document
+  // fetch needs (addressable sheet content, reload-by-name refetch) into
+  // context — handlers get the config by argument, screens get it here.
+  const bffConfigValue = useMemo<BffConfigValue>(
+    () => ({ bffBaseUrl: bffConfig.baseUrl, authToken: authConfig.getToken }),
+    [bffConfig.baseUrl, authConfig.getToken],
+  );
+
   // Route unknown-type warnings from the renderer registry through the
   // same telemetry emitter as the rest of the runtime. Memoised on the
   // emitter so swapping it (e.g. test rigs) re-wires the sink.
@@ -67,9 +77,11 @@ export function SduiRuntimeProvider({
 
   return (
     <TelemetryContext.Provider value={telemetryConfig.emitter}>
-      <ActionEngineContext.Provider value={actionEngine}>
-        {children}
-      </ActionEngineContext.Provider>
+      <BffConfigContext.Provider value={bffConfigValue}>
+        <ActionEngineContext.Provider value={actionEngine}>
+          {children}
+        </ActionEngineContext.Provider>
+      </BffConfigContext.Provider>
     </TelemetryContext.Provider>
   );
 }

--- a/packages/sdui-runtime/src/action-engine/action-engine.ts
+++ b/packages/sdui-runtime/src/action-engine/action-engine.ts
@@ -24,10 +24,12 @@ const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 /** Stable key for coalescing repeat dispatches of "the same" action. */
 function debounceKey(action: Action): string {
   const payload = action.payload as
-    | { endpoint?: string; target?: string }
+    | { endpoint?: string; target?: string; path?: string; page?: string }
     | undefined;
   const target = action.target ?? payload?.target ?? "";
-  const endpoint = payload?.endpoint ?? "";
+  // Path-direct actions key on `path` (current surface) or `page` (named
+  // surface); the legacy `endpoint` id is kept as a fallback for old callers.
+  const endpoint = payload?.path ?? payload?.page ?? payload?.endpoint ?? "";
   return `${action.type}|${target}|${endpoint}`;
 }
 

--- a/packages/sdui-runtime/src/action-engine/handlers/__tests__/bff-call.test.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/__tests__/bff-call.test.ts
@@ -55,12 +55,14 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
+// Path-direct: actions carry the concrete request `path` (no endpoint-id
+// registry). The default path mirrors the old `creator.events.track` endpoint.
 const bffAction = (overrides: Record<string, unknown> = {}): Action =>
   ({
     type: "bff_call",
     payload: {
       method: "POST",
-      endpoint: "creator.events.track",
+      path: "/v1/creator/events/track",
       ...overrides,
     },
   }) as Action;
@@ -213,37 +215,35 @@ test("bff_call — prod BFF + devIdentity set → no X-Dev-Identity header (defe
 });
 
 // ---------------------------------------------------------------------------
-// URL resolution (FIX 2): the endpoint id is a LOGICAL id, not a path. It must
-// be resolved through EndpointPaths (id → "/v1/..."), with no double slash and
-// path-param substitution applied to the resolved path.
+// URL resolution (path-direct): the action carries the concrete request `path`.
+// The runtime fetches `bffBaseUrl + path` verbatim — no endpoint-id registry,
+// no double slash, with `{param}` / `:param` substitution from path_params.
 // ---------------------------------------------------------------------------
 
-test("bff_call — resolves logical endpoint id to its path via EndpointPaths (no double slash)", async () => {
+test("bff_call — fetches bffBaseUrl + path verbatim (no double slash)", async () => {
   let capturedUrl: string | undefined;
   installFetch(async (input) => {
     capturedUrl = input as string;
     return jsonResponse({ ok: true });
   });
-  // creator.events.track → /v1/creator/events/track
   await handleBffCall(
-    bffAction({ endpoint: "creator.events.track" }),
+    bffAction({ path: "/v1/creator/events/track" }),
     noopConfig,
     makeSpyEngine(),
   );
   assert.equal(capturedUrl, "https://bff.example.test/v1/creator/events/track");
 });
 
-test("bff_call — substitutes path params into the resolved path", async () => {
+test("bff_call — substitutes path params into the path (:param and {param})", async () => {
   let capturedUrl: string | undefined;
   installFetch(async (input) => {
     capturedUrl = input as string;
     return jsonResponse({ ok: true });
   });
-  // creator.campaigns.detail → /v1/creator/campaigns/{id}
   await handleBffCall(
     bffAction({
       method: "GET",
-      endpoint: "creator.campaigns.detail",
+      path: "/v1/creator/campaigns/:id",
       path_params: { id: "abc-123" },
     }),
     noopConfig,
@@ -252,20 +252,19 @@ test("bff_call — substitutes path params into the resolved path", async () => 
   assert.equal(capturedUrl, "https://bff.example.test/v1/creator/campaigns/abc-123");
 });
 
-test("bff_call — throws on an unsubstituted path param (template declares {id}, action omits it)", async () => {
+test("bff_call — throws on an unsubstituted path param (path declares :id, action omits it)", async () => {
   installFetch(async () => jsonResponse({ ok: true }));
-  // creator.campaigns.detail → /v1/creator/campaigns/{id}; no path_params supplied.
   await assert.rejects(
     handleBffCall(
-      bffAction({ method: "GET", endpoint: "creator.campaigns.detail" }),
+      bffAction({ method: "GET", path: "/v1/creator/campaigns/:id" }),
       noopConfig,
       makeSpyEngine(),
     ),
-    /unsubstituted path param \{id\}/,
+    /unsubstituted path param :id/,
   );
 });
 
-test("bff_call — appends query params to the resolved path", async () => {
+test("bff_call — appends query params to the path", async () => {
   let capturedUrl: string | undefined;
   installFetch(async (input) => {
     capturedUrl = input as string;
@@ -274,7 +273,7 @@ test("bff_call — appends query params to the resolved path", async () => {
   await handleBffCall(
     bffAction({
       method: "GET",
-      endpoint: "creator.campaigns.list",
+      path: "/v1/creator/campaigns",
       query_params: { status: "open" },
     }),
     noopConfig,
@@ -290,7 +289,7 @@ test("bff_call — trims a trailing slash off bffBaseUrl (no double slash)", asy
     return jsonResponse({ ok: true });
   });
   await handleBffCall(
-    bffAction({ endpoint: "creator.events.track" }),
+    bffAction({ path: "/v1/creator/events/track" }),
     { ...noopConfig, bffBaseUrl: "https://bff.example.test/" },
     makeSpyEngine(),
   );

--- a/packages/sdui-runtime/src/action-engine/handlers/__tests__/reload.test.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/__tests__/reload.test.ts
@@ -5,6 +5,13 @@ import type { ActionEngine, ActionEngineConfig } from "../../types.ts";
 import type { Action, Node, Page } from "@one-impression/sdk-native-sdui";
 import { useLocalStore } from "../../../state/useLocalStore.ts";
 import { usePageStore } from "../../../state/usePageStore.ts";
+import {
+  rebuildSurfaceIndex,
+  registerSurfaceReload,
+  setNavigationAccessor,
+  __resetSurfaceRegistry,
+  type NavigationAccessor,
+} from "../../../navigation/surfaceRegistry.ts";
 
 const config: ActionEngineConfig = {
   bffBaseUrl: "https://bff.example.test",
@@ -107,7 +114,7 @@ const reloadAction = (payload: Record<string, unknown>): Action =>
 test("reload — content-only response replaces items, preserves chrome", async () => {
   installFetch({ items: [{ type: "sdui.snippet.composite", id: "c1", data: {} }] });
   await handleReload(
-    reloadAction({ endpoint: "creator.campaigns.list", ui_zones: ["content"] }),
+    reloadAction({ path: "/v1/creator/campaigns", ui_zones: ["content"] }),
     config,
     noopEngine,
   );
@@ -126,7 +133,7 @@ test("reload — header+content response merges data.header and replaces items",
     items: [{ type: "sdui.snippet.composite", id: "c1", data: {} }],
   });
   await handleReload(
-    reloadAction({ endpoint: "creator.campaigns.list", ui_zones: ["header", "content"] }),
+    reloadAction({ path: "/v1/creator/campaigns", ui_zones: ["header", "content"] }),
     config,
     noopEngine,
   );
@@ -142,7 +149,7 @@ test("reload — binds $.local refs into the query string", async () => {
   installFetch({ items: [] });
   await handleReload(
     reloadAction({
-      endpoint: "creator.campaigns.list",
+      path: "/v1/creator/campaigns",
       ui_zones: ["content"],
       query_params: { tab: { ref: "$.local.selected_tab" }, filter: { ref: "$.local.selected_filters" } },
     }),
@@ -157,7 +164,7 @@ test("reload — binds $.local refs into the query string", async () => {
 test("reload — clears loading even on a non-OK response (and throws)", async () => {
   installFetch({ error: "boom" }, 500);
   await assert.rejects(
-    () => handleReload(reloadAction({ endpoint: "creator.campaigns.list", ui_zones: ["content"] }), config, noopEngine),
+    () => handleReload(reloadAction({ path: "/v1/creator/campaigns", ui_zones: ["content"] }), config, noopEngine),
     /reload: BFF GET .* returned 500/,
   );
   assert.equal(usePageStore.getState().loadingUiZones.content, false);
@@ -165,8 +172,8 @@ test("reload — clears loading even on a non-OK response (and throws)", async (
 
 test("reload — chained same-zone reloads: latest wins, earlier aborted, skeleton held", async () => {
   const pendings = installDeferredFetch();
-  const a = reloadAction({ endpoint: "creator.campaigns.list", ui_zones: ["content"] });
-  const b = reloadAction({ endpoint: "creator.campaigns.list", ui_zones: ["content"] });
+  const a = reloadAction({ path: "/v1/creator/campaigns", ui_zones: ["content"] });
+  const b = reloadAction({ path: "/v1/creator/campaigns", ui_zones: ["content"] });
 
   const pA = handleReload(a, config, noopEngine);
   await flush(); // A reaches its fetch (pending)
@@ -192,9 +199,9 @@ test("reload — chained same-zone reloads: latest wins, earlier aborted, skelet
 
 test("reload — disjoint zones run in parallel, neither aborted", async () => {
   const pendings = installDeferredFetch();
-  const pH = handleReload(reloadAction({ endpoint: "creator.campaigns.list", ui_zones: ["header"] }), config, noopEngine);
+  const pH = handleReload(reloadAction({ path: "/v1/creator/campaigns", ui_zones: ["header"] }), config, noopEngine);
   await flush();
-  const pC = handleReload(reloadAction({ endpoint: "creator.campaigns.list", ui_zones: ["content"] }), config, noopEngine);
+  const pC = handleReload(reloadAction({ path: "/v1/creator/campaigns", ui_zones: ["content"] }), config, noopEngine);
   await flush();
 
   assert.equal(pendings.length, 2);
@@ -213,9 +220,9 @@ test("reload — disjoint zones run in parallel, neither aborted", async () => {
 test("reload — partial overlap: newer wins the shared zone, older still applies its own", async () => {
   const pendings = installDeferredFetch();
   // Tab switch: header + content. Filter: content only, lands mid-flight.
-  const pTab = handleReload(reloadAction({ endpoint: "creator.campaigns.list", ui_zones: ["header", "content"] }), config, noopEngine);
+  const pTab = handleReload(reloadAction({ path: "/v1/creator/campaigns", ui_zones: ["header", "content"] }), config, noopEngine);
   await flush();
-  const pFilter = handleReload(reloadAction({ endpoint: "creator.campaigns.list", ui_zones: ["content"] }), config, noopEngine);
+  const pFilter = handleReload(reloadAction({ path: "/v1/creator/campaigns", ui_zones: ["content"] }), config, noopEngine);
   await flush();
 
   // Filter took `content`; tab still owns `header`, so its fetch is NOT aborted.
@@ -232,4 +239,109 @@ test("reload — partial overlap: newer wins the shared zone, older still applie
   assert.equal(page.items[0].id, "filtered", "content from the filter reload won; tab's content dropped");
   assert.equal(usePageStore.getState().loadingUiZones.content, false);
   assert.equal(usePageStore.getState().loadingUiZones.header, false);
+});
+
+// ── reload-by-name (B2) ────────────────────────────────────────────────────
+// `reload { page }` resolves an already-open surface by name (relative to the
+// caller / current focused route) and signals THAT surface to refetch — it does
+// not fetch from the caller. We drive a fake route stack so the by-name index
+// resolves; each surface's refetch is its registered handler.
+
+interface FakeRoute {
+  key: string;
+  name: string;
+  params?: { screenId?: string; sheetId?: string; contentPath?: string };
+}
+
+function setStack(routes: FakeRoute[], focusedKey: string): void {
+  const accessor: NavigationAccessor = {
+    isReady: () => true,
+    getRoutes: () => routes,
+    getCurrentRouteKey: () => focusedKey,
+  };
+  setNavigationAccessor(accessor);
+  rebuildSurfaceIndex();
+}
+function clearStack(): void {
+  setNavigationAccessor({
+    isReady: () => false,
+    getRoutes: () => [],
+    getCurrentRouteKey: () => undefined,
+  });
+  __resetSurfaceRegistry();
+}
+const pageRoute = (key: string, screenId: string): FakeRoute => ({
+  key,
+  name: "SduiPage",
+  params: { screenId },
+});
+
+test("reload-by-name — nearest signals the surface just below the caller, not the caller", async () => {
+  __resetSurfaceRegistry();
+  try {
+    // home, address-select, address-form (focused). reload{page:"address-select"}
+    // from the form should refetch address-select, NOT re-fetch the form.
+    setStack(
+      [
+        pageRoute("k1", "home"),
+        pageRoute("k2", "address-select"),
+        pageRoute("k3", "address-form"),
+      ],
+      "k3",
+    );
+    let selectReloads = 0;
+    let formReloads = 0;
+    registerSurfaceReload("k2", () => { selectReloads += 1; });
+    registerSurfaceReload("k3", () => { formReloads += 1; });
+
+    await handleReload(
+      reloadAction({ page: "address-select", scope: "nearest" }),
+      config,
+      noopEngine,
+    );
+    assert.equal(selectReloads, 1, "the named ancestor refetched");
+    assert.equal(formReloads, 0, "the caller did not refetch itself");
+  } finally {
+    clearStack();
+  }
+});
+
+test("reload-by-name — scope:all signals every open instance of the name", async () => {
+  __resetSurfaceRegistry();
+  try {
+    setStack(
+      [pageRoute("k1", "home"), pageRoute("k2", "list"), pageRoute("k3", "list")],
+      "k3",
+    );
+    const hits: string[] = [];
+    registerSurfaceReload("k2", () => hits.push("k2"));
+    registerSurfaceReload("k3", () => hits.push("k3"));
+    await handleReload(reloadAction({ page: "list", scope: "all" }), config, noopEngine);
+    assert.deepEqual(hits.sort(), ["k2", "k3"]);
+  } finally {
+    clearStack();
+  }
+});
+
+test("reload-by-name — no open surface with that name is a no-op (no throw)", async () => {
+  __resetSurfaceRegistry();
+  try {
+    setStack([pageRoute("k1", "home")], "k1");
+    await handleReload(
+      reloadAction({ page: "nonexistent", scope: "nearest" }),
+      config,
+      noopEngine,
+    );
+    // No throw, no fetch — the caller's own page is untouched.
+    assert.ok(true);
+  } finally {
+    clearStack();
+  }
+});
+
+test("reload — requires path or page (schema refine rejects empty)", async () => {
+  await assert.rejects(
+    () => handleReload(reloadAction({}), config, noopEngine),
+    /reload payload requires/,
+  );
 });

--- a/packages/sdui-runtime/src/action-engine/handlers/_shared/bff-request.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/_shared/bff-request.ts
@@ -1,5 +1,3 @@
-import { EndpointPaths } from "@one-impression/sdk-native-sdui";
-import type { EndpointId } from "@one-impression/sdk-native-sdui";
 import { isLocalhostBffUrl } from "../../../bff/is-localhost.js";
 import { useDevConfigStore } from "../../../state/useDevConfigStore.js";
 import { useActiveSocialStore } from "../../../state/useActiveSocialStore.js";
@@ -7,45 +5,56 @@ import type { ActionEngineConfig } from "../../types.js";
 
 /**
  * Shared BFF request plumbing for the network action handlers (bff_call,
- * reload). Keeps endpoint-id → URL resolution and the standard header set
- * in one place so the handlers don't drift apart.
+ * reload). Keeps path → URL construction and the standard header set in one
+ * place so the handlers don't drift apart.
+ *
+ * **Path-direct only — no frontend endpoint-id registry.** Actions carry the
+ * concrete request `path` the BFF emits (e.g. `/v1/creator/campaigns/:id/apply`)
+ * and the runtime fetches `bffBaseUrl + path` verbatim. The old
+ * `EndpointPaths` / `resolveEndpointUrl` id→path lookup is gone (the enum was
+ * deleted from `@one-impression/sdk-native-sdui`): coupling a new endpoint to a
+ * frontend release was the anti-pattern this removes.
  */
 
 /**
- * Resolves a logical endpoint id to a full request URL: looks up the path
- * template, substitutes path params, appends the query string. Throws loudly
- * on an unregistered id or an unsubstituted `{param}` rather than silently
+ * Builds a full request URL from a path-direct `path`: substitutes `{param}` /
+ * `:param` placeholders from `path_params`, appends the query string. Throws
+ * loudly on a missing path or an unsubstituted placeholder rather than silently
  * constructing a wrong URL.
  */
-export function resolveEndpointUrl(
+export function resolveRequestUrl(
   config: ActionEngineConfig,
   opts: {
-    endpoint: EndpointId;
+    path: string;
     path_params?: Record<string, string>;
     query_params?: Record<string, string>;
   },
 ): string {
-  const path = EndpointPaths[opts.endpoint];
-  if (!path) {
-    throw new Error(`no path registered for endpoint id "${opts.endpoint}"`);
+  if (!opts.path) {
+    throw new Error(
+      "bff request requires a `path` (path-direct); no client-side endpoint registry exists",
+    );
   }
 
-  let endpointPath = path;
+  let requestPath = opts.path;
   if (opts.path_params) {
     for (const [key, value] of Object.entries(opts.path_params)) {
-      endpointPath = endpointPath.replace(`{${key}}`, encodeURIComponent(value));
+      // Support both `{param}` (legacy templates) and `:param` (path-direct).
+      requestPath = requestPath
+        .replace(`{${key}}`, encodeURIComponent(value))
+        .replace(`:${key}`, encodeURIComponent(value));
     }
   }
 
-  const unsubstituted = endpointPath.match(/\{[^}]+\}/);
+  const unsubstituted = requestPath.match(/\{[^}]+\}|:[A-Za-z_][A-Za-z0-9_]*/);
   if (unsubstituted) {
     throw new Error(
-      `unsubstituted path param ${unsubstituted[0]} in "${path}" for endpoint "${opts.endpoint}"`,
+      `unsubstituted path param ${unsubstituted[0]} in "${opts.path}"`,
     );
   }
 
   const base = config.bffBaseUrl.replace(/\/$/, "");
-  let url = `${base}${endpointPath}`;
+  let url = `${base}${requestPath}`;
   if (opts.query_params) {
     const qs = new URLSearchParams(opts.query_params).toString();
     if (qs) url += `?${qs}`;

--- a/packages/sdui-runtime/src/action-engine/handlers/bff-call.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/bff-call.ts
@@ -1,9 +1,9 @@
-import { BffCallPayloadSchema, EndpointPaths } from "@one-impression/sdk-native-sdui";
+import { BffCallPayloadSchema } from "@one-impression/sdk-native-sdui";
 import type { Action } from "@one-impression/sdk-native-sdui";
 import type { ActionEngineConfig, ActionEngine } from "../types.js";
 import { useLocalStore } from "../../state/useLocalStore.js";
 import { bindRequestPayload } from "../cond/resolve-request-refs.js";
-import { resolveEndpointUrl, buildBffHeaders } from "./_shared/bff-request.js";
+import { resolveRequestUrl, buildBffHeaders } from "./_shared/bff-request.js";
 
 /**
  * bff_call — fetches a BFF endpoint with auth, dispatches on_success/on_error
@@ -22,13 +22,12 @@ export async function handleBffCall(
   const bound = bindRequestPayload(action.payload, useLocalStore.getState().data);
   const payload = BffCallPayloadSchema.parse(bound);
 
-  // Resolve the endpoint id to a full URL (path lookup + param substitution +
-  // query string) and build the standard header set — shared with reload.
-  // The id is NOT a path; treating it as one would request "/creator.home.tab"
-  // and 404. Throws loudly on an unregistered id or unsubstituted "{param}".
-  const endpointPath = EndpointPaths[payload.endpoint];
-  const url = resolveEndpointUrl(config, {
-    endpoint: payload.endpoint,
+  // Build the full URL path-direct (path-param substitution + query string) and
+  // the standard header set — shared with reload. The BFF emits the concrete
+  // `path`; the runtime fetches `bffBaseUrl + path` verbatim (no id→path
+  // registry). Throws loudly on a missing path or unsubstituted "{param}".
+  const url = resolveRequestUrl(config, {
+    path: payload.path,
     path_params: payload.path_params,
     query_params: payload.query_params,
   });
@@ -55,7 +54,7 @@ export async function handleBffCall(
     });
 
     if (!res.ok) {
-      throw new Error(`BFF ${payload.method} ${endpointPath} returned ${res.status}`);
+      throw new Error(`BFF ${payload.method} ${payload.path} returned ${res.status}`);
     }
 
     // Server may bundle a follow-up action chain in the response body

--- a/packages/sdui-runtime/src/action-engine/handlers/reload-section.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/reload-section.ts
@@ -21,7 +21,11 @@ export async function handleReloadSection(
     headers["Authorization"] = `Bearer ${token}`;
   }
 
-  const url = `${config.bffBaseUrl}/${payload.endpoint}`;
+  // Path-direct: the BFF emits the concrete `path`; fetch `bffBaseUrl + path`
+  // verbatim (no endpoint-id registry). Trim a trailing slash off the base so
+  // we never produce a double slash with the leading-`/` path.
+  const base = config.bffBaseUrl.replace(/\/$/, "");
+  const url = `${base}${payload.path}`;
   const res = await fetch(url, {
     method: payload.payload ? "POST" : "GET",
     headers,
@@ -30,7 +34,7 @@ export async function handleReloadSection(
 
   if (!res.ok) {
     throw new Error(
-      `reload_section: BFF ${payload.endpoint} returned ${res.status}`,
+      `reload_section: BFF ${payload.path} returned ${res.status}`,
     );
   }
 

--- a/packages/sdui-runtime/src/action-engine/handlers/reload.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/reload.ts
@@ -3,7 +3,12 @@ import type { Action, Node } from "@one-impression/sdk-native-sdui";
 import type { ActionEngineConfig, ActionEngine } from "../types.js";
 import { useLocalStore } from "../../state/useLocalStore.js";
 import { bindRequestPayload } from "../cond/resolve-request-refs.js";
-import { resolveEndpointUrl, buildBffHeaders } from "./_shared/bff-request.js";
+import { resolveRequestUrl, buildBffHeaders } from "./_shared/bff-request.js";
+import {
+  resolveSurface,
+  signalSurfaceReload,
+  currentRouteKey,
+} from "../../navigation/surfaceRegistry.js";
 
 /**
  * Per-UI-zone in-flight registry — latest-wins concurrency for `reload`.
@@ -64,12 +69,58 @@ export async function handleReload(
   const bound = bindRequestPayload(action.payload, useLocalStore.getState().data);
   const payload = ReloadPayloadSchema.parse(bound);
 
+  // ── reload-by-name ──────────────────────────────────────────────────────
+  // `page` targets an already-OPEN surface (page.id / sheet.id) somewhere in
+  // the stack. Resolve it to route.key(s) via the by-name index, relative to
+  // the caller's route (the focused surface that dispatched this action), then
+  // signal each resolved surface to refetch ITS OWN document by the path it was
+  // opened with. The caller doesn't fetch here — each target surface owns its
+  // refetch (route stack stays authoritative).
+  if (payload.page) {
+    const callerKey = currentRouteKey();
+    const targets = resolveSurface(payload.page, payload.scope, callerKey);
+    if (targets.length === 0) {
+      console.warn(
+        `[reload] no open surface named "${payload.page}" to reload (scope=${payload.scope})`,
+      );
+      return;
+    }
+    // Forward both the zone hint AND any request params the action carried into
+    // each target's OWN refetch. `bindRequestPayload` above already resolved any
+    // `{ref}` bindings, so `query_params` here are concrete values the surface
+    // can append to its fetch path (e.g. a just-picked address id).
+    const reloadOpts = {
+      uiZones: payload.ui_zones,
+      queryParams: payload.query_params,
+    };
+    for (const key of targets) {
+      const signalled = signalSurfaceReload(key, reloadOpts);
+      if (!signalled) {
+        console.warn(
+          `[reload] surface "${payload.page}" (route ${key}) is not listening for refetch`,
+        );
+      }
+    }
+    return;
+  }
+
+  // ── zone reload (current surface) ───────────────────────────────────────
+  // `path`-direct refresh of the CURRENT surface's named UI zones. `ui_zones`
+  // is optional now; default to the content zone so an omitted-zones reload
+  // still has a concrete owner for the concurrency registry.
+  const path = payload.path;
+  if (!path) {
+    // The schema's refine guarantees path|page, but keep a clear runtime error.
+    throw new Error("reload: payload requires `path` or `page`");
+  }
+  const uiZones = payload.ui_zones ?? [CONTENT_UI_ZONE];
+
   // Tell the server which UI zones to return (so it answers with a matching
   // partial page) alongside the bound context.
-  const url = resolveEndpointUrl(config, {
-    endpoint: payload.endpoint,
+  const url = resolveRequestUrl(config, {
+    path,
     path_params: payload.path_params,
-    query_params: { ...(payload.query_params ?? {}), ui_zones: payload.ui_zones.join(",") },
+    query_params: { ...(payload.query_params ?? {}), ui_zones: uiZones.join(",") },
   });
   const headers = buildBffHeaders(config);
 
@@ -78,9 +129,9 @@ export async function handleReload(
   // still owns some is left to finish (and will apply only those).
   const token = ++reloadCounter;
   const controller = new AbortController();
-  requests.set(token, { uiZones: new Set(payload.ui_zones), controller });
+  requests.set(token, { uiZones: new Set(uiZones), controller });
   const superseded = new Set<number>();
-  for (const zone of payload.ui_zones) {
+  for (const zone of uiZones) {
     const prev = uiZoneOwners.get(zone);
     if (prev !== undefined && prev !== token) {
       requests.get(prev)?.uiZones.delete(zone);
@@ -95,10 +146,10 @@ export async function handleReload(
 
   /** UI zones this call still owns (not yet taken by a newer reload). */
   const ownedUiZones = () =>
-    payload.ui_zones.filter((z) => uiZoneOwners.get(z) === token);
+    uiZones.filter((z) => uiZoneOwners.get(z) === token);
 
   const { usePageStore } = await import("../../state/usePageStore.js");
-  usePageStore.getState().setUiZonesLoading(payload.ui_zones, true);
+  usePageStore.getState().setUiZonesLoading(uiZones, true);
 
   try {
     const res = await fetch(url, {

--- a/packages/sdui-runtime/src/action-engine/handlers/reload.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/reload.ts
@@ -80,7 +80,7 @@ export async function handleReload(
     const callerKey = currentRouteKey();
     const targets = resolveSurface(payload.page, payload.scope, callerKey);
     if (targets.length === 0) {
-      console.warn(
+      config.logger?.warn(
         `[reload] no open surface named "${payload.page}" to reload (scope=${payload.scope})`,
       );
       return;
@@ -96,7 +96,7 @@ export async function handleReload(
     for (const key of targets) {
       const signalled = signalSurfaceReload(key, reloadOpts);
       if (!signalled) {
-        console.warn(
+        config.logger?.warn(
           `[reload] surface "${payload.page}" (route ${key}) is not listening for refetch`,
         );
       }

--- a/packages/sdui-runtime/src/action-engine/handlers/sheet.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/sheet.ts
@@ -4,12 +4,22 @@ import type { ActionEngineConfig, ActionEngine } from "../types.js";
 import { presentSheet } from "../../navigation/sheetPresenter.js";
 
 /**
- * sheet — opens a previously-registered bottom sheet by id.
+ * sheet — opens a bottom sheet by id.
  *
- * The page renderer registers `page.bottom_sheets[]` entries on mount. This
- * handler opens the sheet by id (lookup pattern) — it does NOT stamp a new sheet
- * definition. `presentSheet` routes to the native-stack sheet route when
- * `SduiNavigationHost` is mounted, else to the legacy store-based host.
+ * Two flavours, decided by whether the action carries a `content_path`:
+ *  - **Static (legacy):** the page renderer registers `page.bottom_sheets[]`
+ *    entries on mount; this handler opens the sheet by id (lookup pattern) — it
+ *    does NOT stamp a new sheet definition. Content comes from
+ *    `useBottomSheetStore.registry[sheet_id]`.
+ *  - **Addressable (new):** the action carries `content_path` — a path-direct
+ *    URL the sheet fetches its own document from on open (`on_load`-style),
+ *    fresh every time. The parent only opens a shell; the sheet owns its content
+ *    and reload-by-name refetches it.
+ *
+ * `presentSheet` routes to the native-stack sheet route when `SduiNavigationHost`
+ * is mounted, else to the legacy store-based host. `content_path` is read off
+ * the raw payload (the schema's strip mode drops unknown keys, so it never
+ * reaches the parsed value — and a schema bump isn't required to thread it).
  */
 export async function handleSheet(
   action: Action,
@@ -17,5 +27,17 @@ export async function handleSheet(
   _engine: ActionEngine,
 ): Promise<void> {
   const payload = SheetPayloadSchema.parse(action.payload);
-  presentSheet(payload.sheet_id);
+  const raw = action.payload as
+    | { content_path?: unknown; content_title?: unknown; content_subtitle?: unknown }
+    | undefined;
+  const contentPath =
+    typeof raw?.content_path === "string" ? raw.content_path : undefined;
+  // Loading-phase header chrome (read off the raw payload alongside
+  // content_path — the schema strips unknown keys, so no schema bump needed):
+  // rendered above the shimmer while the sheet fetches its document.
+  const title =
+    typeof raw?.content_title === "string" ? raw.content_title : undefined;
+  const subtitle =
+    typeof raw?.content_subtitle === "string" ? raw.content_subtitle : undefined;
+  presentSheet(payload.sheet_id, contentPath, { title, subtitle });
 }

--- a/packages/sdui-runtime/src/action-engine/index.ts
+++ b/packages/sdui-runtime/src/action-engine/index.ts
@@ -1,5 +1,7 @@
 export { createActionEngine } from "./action-engine.js";
 export { ActionEngineContext, useActionEngine } from "./useActionEngine.js";
+export { BffConfigContext, useBffConfig } from "./useBffConfig.js";
+export type { BffConfigValue } from "./useBffConfig.js";
 export type {
   ActionEngineConfig,
   ActionEngine,

--- a/packages/sdui-runtime/src/action-engine/useBffConfig.ts
+++ b/packages/sdui-runtime/src/action-engine/useBffConfig.ts
@@ -1,0 +1,28 @@
+import { createContext, useContext } from "react";
+
+/**
+ * The BFF connection facts a screen needs to fetch its OWN document path-direct
+ * (addressable surfaces: a sheet fetching its content on open, a page/sheet
+ * refetching itself on reload-by-name). The action engine already holds these
+ * in its config, but handlers receive the config by argument while React
+ * screens need it from context — so the provider mirrors the two fields here.
+ *
+ * Intentionally minimal: only the two fields a path-direct document fetch
+ * needs. Header construction (X-Dev-Identity, X-Active-Influencer-Id) stays in
+ * `buildBffHeaders`; a screen-level fetch can stay GET-simple.
+ */
+export interface BffConfigValue {
+  bffBaseUrl: string;
+  authToken: () => string | null;
+}
+
+const defaultValue: BffConfigValue = {
+  bffBaseUrl: "",
+  authToken: () => null,
+};
+
+export const BffConfigContext = createContext<BffConfigValue>(defaultValue);
+
+export function useBffConfig(): BffConfigValue {
+  return useContext(BffConfigContext);
+}

--- a/packages/sdui-runtime/src/bff/endpoint-registry.ts
+++ b/packages/sdui-runtime/src/bff/endpoint-registry.ts
@@ -1,15 +1,16 @@
-import { EndpointPaths } from '@one-impression/sdk-native-sdui';
 /**
- * endpoint-registry — maps EndpointId strings to concrete HTTP
- * method + path templates.
+ * endpoint-registry — maps legacy endpoint-id strings to concrete HTTP
+ * method + path templates, for the legacy `BffClient` (`bff/client.ts`) and its
+ * hooks only.
  *
- * The EndpointId type comes from @one-impression/sdk-native-sdui. The
- * registry is used by the BFF client to resolve an endpoint identifier
- * (as received in SDUI action payloads) to a fetchable URL.
- *
- * In production this will be code-generated from the creator-bff
- * OpenAPI spec (amplify-schemas task 003). For now, this is a manually
- * maintained registry covering the core endpoints.
+ * NOTE: this id→path registry is the LEGACY anti-pattern the addressable-surface
+ * design retires. New surfaces are **path-direct** — the BFF emits a concrete
+ * `path` and the action handlers (`bff_call` / `reload`) fetch `bffBaseUrl +
+ * path` verbatim with NO client-side id→path lookup (see
+ * `action-engine/handlers/_shared/bff-request.ts`). This map survives only for
+ * already-shipped `BffClient` callers and is not extended for new work; the
+ * codegen'd `EndpointPaths` catalog it used to fall back to has been removed
+ * from `@one-impression/sdk-native-sdui` entirely.
  */
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
@@ -96,15 +97,9 @@ export const endpointRegistry: Record<string, EndpointDefinition> = {
 export function getEndpoint(endpointId: string): EndpointDefinition {
   const def = endpointRegistry[endpointId];
   if (def) return def;
-
-  // Fall back to the codegen'd catalog from the contracts package
-  // (EndpointPaths is generated from the creator-bff OpenAPI spec and
-  // covers the full endpoint surface). The catalog carries paths only,
-  // so non-GET endpoints that documents fetch directly must keep an
-  // explicit method entry in endpointRegistry above.
-  const catalogPath = (EndpointPaths as Record<string, string>)[endpointId];
-  if (catalogPath) {
-    return { method: 'GET', path: catalogPath };
-  }
+  // The codegen'd `EndpointPaths` catalog fallback was removed with the
+  // endpoint-id enum (addressable-surfaces, path-direct). Legacy ids not in the
+  // hand-maintained map above are now hard errors — migrate the caller to
+  // path-direct `bff_call` / `reload`.
   throw new Error(`[BFF] Unknown endpoint: "${endpointId}"`);
 }

--- a/packages/sdui-runtime/src/icon-store/BlinkerDot.tsx
+++ b/packages/sdui-runtime/src/icon-store/BlinkerDot.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useRef } from "react";
+import { Animated, StyleSheet, View } from "react-native";
+
+/** Blend a #RRGGBB colour toward white by `t` (0..1). Non-hex input passes through. */
+function lighten(hex: string, t: number): string {
+  const m = /^#?([0-9a-fA-F]{6})$/.exec(hex);
+  if (!m) return hex;
+  const n = parseInt(m[1], 16);
+  const mix = (c: number) => Math.round(c + (255 - c) * t);
+  const r = mix((n >> 16) & 255);
+  const g = mix((n >> 8) & 255);
+  const b = mix(n & 255);
+  return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`;
+}
+
+/**
+ * BlinkerDot — an animated "active/live" indicator, built like a map "you are
+ * here" pin (concentric, centre → out):
+ *   1. a solid centre dot,
+ *   2. a thin WHITE gap around it,
+ *   3. a circular outline ring (the "line") — sized to match the other icons,
+ *   4. a pulse that expands + fades OUTSIDE the ring, on a loop.
+ *
+ * Runtime component (a static SVG can't animate) but font-like — it takes a
+ * resolved `color` (tints the dot, ring, and pulse) and `size` px (the icon-size
+ * token). The dot + ring are lightened slightly; the pulse keeps the full tint
+ * as the accent. Native-driver loop (transform + opacity), off the JS thread.
+ */
+export function BlinkerDot({
+  color = "#6531FF",
+  size = 24,
+}: {
+  color?: string;
+  size?: number;
+}): React.ReactElement {
+  const pulse = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.timing(pulse, {
+        toValue: 1,
+        duration: 1600,
+        useNativeDriver: true,
+      }),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [pulse]);
+
+  const outer = Math.round(size * 0.8); // outline ring — matches other icons' footprint
+  const dot = Math.round(size * 0.34); // centre dot
+  const offset = (size - outer) / 2; // centre the absolute pulse in the size box
+  const soft = lighten(color, 0.18); // slightly-lighter tone for the dot + ring
+  const pulseScale = pulse.interpolate({ inputRange: [0, 1], outputRange: [1, 1.5] });
+  const pulseOpacity = pulse.interpolate({ inputRange: [0, 1], outputRange: [0.7, 0] });
+
+  return (
+    <View style={[styles.wrap, { width: size, height: size }]}>
+      {/* Pulse — expanding + fading disc, centred behind the ring; the part that
+          grows past the ring reads as a blinker around it. Full tint. */}
+      <Animated.View
+        style={{
+          position: "absolute",
+          top: offset,
+          left: offset,
+          width: outer,
+          height: outer,
+          borderRadius: outer / 2,
+          backgroundColor: color,
+          opacity: pulseOpacity,
+          transform: [{ scale: pulseScale }],
+        }}
+      />
+      {/* Outline ring + white interior (white gap shows between ring and dot). */}
+      <View
+        style={[
+          styles.center,
+          {
+            width: outer,
+            height: outer,
+            borderRadius: outer / 2,
+            borderWidth: 1.5,
+            borderColor: soft,
+            backgroundColor: "#FFFFFF",
+          },
+        ]}
+      >
+        <View
+          style={{ width: dot, height: dot, borderRadius: dot / 2, backgroundColor: soft }}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { alignItems: "center", justifyContent: "center" },
+  center: { alignItems: "center", justifyContent: "center" },
+});

--- a/packages/sdui-runtime/src/icon-store/IconGlyph.tsx
+++ b/packages/sdui-runtime/src/icon-store/IconGlyph.tsx
@@ -6,6 +6,10 @@ import {
 } from "@one-impression/ui-native";
 import { useIconStore } from "./useIconStore.js";
 import { parseSvg } from "./parseSvg.js";
+import { BlinkerDot } from "./BlinkerDot.js";
+
+/** Icon names rendered by an animated runtime component instead of a static glyph. */
+const ANIMATED_ICON = "blinker-dot";
 
 export interface IconGlyphProps {
   name: string;
@@ -29,6 +33,11 @@ export function IconGlyph({ name, color, size }: IconGlyphProps): React.ReactEle
   const SvgIcon = useMemo(() => parseSvg(name, getIcon(name)), [name, getIcon]);
   const px = (typeof size === "number" ? size : resolveIconSize(size ?? "md")) ?? 20;
   const tint = resolveColor(color ?? "neutralStrong") ?? "#1A1A1A";
+  // Animated indicators render as a runtime component (a static SVG can't pulse)
+  // but stay font-like — they take the same resolved colour + px size as a glyph.
+  if (name === ANIMATED_ICON) {
+    return <BlinkerDot color={tint} size={px} />;
+  }
   return (
     <DSIcon name={name} color={color} size={size}>
       <SvgIcon width={px} height={px} color={tint} />

--- a/packages/sdui-runtime/src/index.ts
+++ b/packages/sdui-runtime/src/index.ts
@@ -124,6 +124,7 @@ export {
   presentSheet,
   dismissSheet,
   setSheetPresenter,
+  fetchSurfaceDocument,
   SDUI_PAGE_ROUTE,
   SDUI_SHEET_ROUTE,
 } from "./navigation/index.js";

--- a/packages/sdui-runtime/src/navigation/SduiNavigationHost.tsx
+++ b/packages/sdui-runtime/src/navigation/SduiNavigationHost.tsx
@@ -20,6 +20,11 @@ import {
 } from "./navigationRef.js";
 import { SduiSheetScreen } from "./SduiSheetScreen.js";
 import { setSheetPresenter } from "./sheetPresenter.js";
+import {
+  rebuildSurfaceIndex,
+  registerSurfaceReload,
+  setNavigationAccessor,
+} from "./surfaceRegistry.js";
 
 /**
  * Resolve a screenId (a `navigate` target) to its Page envelope. May be
@@ -47,6 +52,33 @@ export interface SduiNavigationHostProps {
   screenOptions?: NativeStackNavigationOptions;
 }
 
+/**
+ * Stacked native-header title used when a navigate action supplies a subtitle
+ * (native-stack has no built-in subtitle). Rendered on the branded header bg, so
+ * it uses the inverse tint; the subtitle is the same color, dimmed. Only used
+ * when a subtitle is present — titles without one keep the plain string header.
+ */
+function SduiHeaderTitle({
+  title,
+  subtitle,
+}: {
+  title: string;
+  subtitle?: string;
+}): React.ReactElement {
+  return (
+    <View style={styles.headerTitleWrap}>
+      <Text style={styles.headerTitle} numberOfLines={1}>
+        {title}
+      </Text>
+      {subtitle ? (
+        <Text style={styles.headerSubtitle} numberOfLines={1}>
+          {subtitle}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
 const Stack = createNativeStackNavigator<SduiRootParamList>();
 
 type PageScreenProps = NativeStackScreenProps<SduiRootParamList, "SduiPage">;
@@ -57,20 +89,39 @@ function makePageScreen(resolvePage: ResolvePage) {
     navigation,
   }: PageScreenProps): React.ReactElement {
     const screenId = route.params?.screenId;
+    // The path-direct fetch handle. `screenId` is the surface NAME (used by the
+    // by-name index for reload-by-name); `contentPath` is the concrete BFF path
+    // the navigate action carried (`params.path` → route `contentPath`). Fetch
+    // by the path when present, falling back to screenId for surfaces whose
+    // name IS their path (e.g. the initial screen).
+    const contentPath = route.params?.contentPath;
+    const fetchKey = contentPath ?? screenId;
     const [page, setPage] = useState<Page | undefined>(undefined);
     const [error, setError] = useState<Error | null>(null);
     const [loading, setLoading] = useState(true);
+    // Bumped by reload-by-name to re-run the load effect (refetch this page
+    // instance). The route stack stays authoritative for presence; this only
+    // re-triggers the page's OWN fetch.
+    const [reloadNonce, setReloadNonce] = useState(0);
+
+    // Register this page route's refetch handler so reload-by-name targeting
+    // the page's name (screenId) can refresh it. Keyed by route.key so multiple
+    // open instances of the same page each refetch independently.
+    useEffect(
+      () => registerSurfaceReload(route.key, () => setReloadNonce((n) => n + 1)),
+      [route.key],
+    );
 
     // Load the page for this screenId. Re-runs if the route's screenId changes
-    // (it doesn't for a given screen instance, but this keeps it correct). A
-    // sync resolvePage resolves on the first microtask; an async one drives the
-    // skeleton → render / error transition.
+    // or a reload-by-name bumps the nonce. A sync resolvePage resolves on the
+    // first microtask; an async one drives the skeleton → render / error
+    // transition.
     useEffect(() => {
       let alive = true;
       setLoading(true);
       setError(null);
       setPage(undefined);
-      Promise.resolve(resolvePage(screenId))
+      Promise.resolve(resolvePage(fetchKey))
         .then((p) => {
           if (!alive) return;
           setPage(p ?? undefined);
@@ -84,7 +135,7 @@ function makePageScreen(resolvePage: ResolvePage) {
       return () => {
         alive = false;
       };
-    }, [screenId]);
+    }, [fetchKey, reloadNonce]);
 
     // Reflect the loaded page's title in the native header once it arrives
     // (the static screen options can't know it before the fetch resolves).
@@ -102,10 +153,24 @@ function makePageScreen(resolvePage: ResolvePage) {
         | undefined;
       const hasWireHeader = !!data?.header || !!data?.header_skeleton;
       navigation.setOptions({ headerShown: !hasWireHeader });
-      if (page?.title && !hasWireHeader) {
-        navigation.setOptions({ title: page.title });
+      if (!hasWireHeader) {
+        // Reconcile the loaded page into the native header: the page's own title
+        // wins for the title; the action-supplied subtitle (loading chrome)
+        // persists since the page has no wire-header subtitle of its own. With a
+        // subtitle present, render the stacked component; else the plain string.
+        const title = page?.title ?? route.params?.title;
+        const subtitle = route.params?.subtitle;
+        if (title && subtitle) {
+          navigation.setOptions({
+            headerTitle: () => (
+              <SduiHeaderTitle title={title} subtitle={subtitle} />
+            ),
+          });
+        } else if (title) {
+          navigation.setOptions({ title });
+        }
       }
-    }, [page, navigation]);
+    }, [page, navigation, route.params?.title, route.params?.subtitle]);
 
     if (loading) return <DefaultPageSkeleton />;
     if (error) {
@@ -162,15 +227,31 @@ function SduiNavigator({
         // The title starts as the screenId placeholder and is replaced with the
         // page's real title once the (possibly async) load resolves — see the
         // navigation.setOptions in SduiPageScreen.
-        options={({ route }) => ({
-          title: route.params?.screenId ?? "",
-          ...(route.params?.transition
-            ? { animation: route.params.transition as never }
-            : {}),
-          ...(route.params?.presentation
-            ? { presentation: route.params.presentation as never }
-            : {}),
-        })}
+        options={({ route }) => {
+          // Header chrome shown DURING the shimmer (synchronously, before the
+          // page document is fetched). Prefer the navigate-supplied title; fall
+          // back to the route name only when the action carried none (legacy).
+          // A subtitle upgrades the header to the stacked custom component; with
+          // no subtitle we keep the plain string title so existing pages render
+          // exactly as before.
+          const title = route.params?.title ?? route.params?.screenId ?? "";
+          const subtitle = route.params?.subtitle;
+          return {
+            ...(subtitle
+              ? {
+                  headerTitle: () => (
+                    <SduiHeaderTitle title={title} subtitle={subtitle} />
+                  ),
+                }
+              : { title }),
+            ...(route.params?.transition
+              ? { animation: route.params.transition as never }
+              : {}),
+            ...(route.params?.presentation
+              ? { presentation: route.params.presentation as never }
+              : {}),
+          };
+        }}
       />
       {/* Bottom sheets are routes too — presented over the page as a
           transparentModal so the page stays visible behind the dimmed
@@ -208,6 +289,27 @@ export function SduiNavigationHost({
   // focused route — no separate BackHandler needed.
   useEffect(() => setSheetPresenter(pushSheet, popSheet), []);
 
+  // Wire the surface registry's read accessor to the live navigationRef so the
+  // by-name index reads the real route stack (the single source of truth). Done
+  // here rather than in surfaceRegistry's module scope so that module stays free
+  // of the react-navigation import (keeps its resolution logic unit-testable).
+  useEffect(() => {
+    setNavigationAccessor({
+      isReady: () => navigationRef.isReady(),
+      getRoutes: () =>
+        navigationRef.isReady() ? (navigationRef.getState()?.routes ?? []) : [],
+      getCurrentRouteKey: () =>
+        navigationRef.isReady() ? navigationRef.getCurrentRoute()?.key : undefined,
+    });
+  }, []);
+
+  // Maintain the by-name surface index from a SINGLE navigation `state`
+  // listener. The route stack stays the single source of truth; the index is a
+  // derived read structure (see surfaceRegistry). `addListener('state', …)`
+  // fires on every push/pop/replace; we also rebuild once on `onReady` so the
+  // initial route is indexed before any reload-by-name can target it.
+  const handleStateChange = () => rebuildSurfaceIndex();
+
   const navigator = (
     <SduiNavigator
       resolvePage={resolvePage}
@@ -217,13 +319,52 @@ export function SduiNavigationHost({
   );
 
   return standalone ? (
-    <NavigationContainer ref={navigationRef}>{navigator}</NavigationContainer>
+    <NavigationContainer
+      ref={navigationRef}
+      onReady={handleStateChange}
+      onStateChange={handleStateChange}
+    >
+      {navigator}
+    </NavigationContainer>
   ) : (
-    navigator
+    // Nested mode: no container of our own to hang onReady/onStateChange on.
+    // Attach the same single `state` listener directly to the shared ref.
+    <NestedSurfaceIndexListener>{navigator}</NestedSurfaceIndexListener>
   );
 }
 
+/**
+ * Non-standalone host: the consumer owns the NavigationContainer, so we can't
+ * use its onReady/onStateChange. Attach the same single `state` listener to the
+ * shared `navigationRef` once it's ready, and rebuild immediately.
+ */
+function NestedSurfaceIndexListener({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  useEffect(() => {
+    if (!navigationRef.isReady()) return;
+    rebuildSurfaceIndex();
+    const unsub = navigationRef.addListener("state", () => rebuildSurfaceIndex());
+    return unsub;
+  }, []);
+  return <>{children}</>;
+}
+
 const styles = StyleSheet.create({
+  headerTitleWrap: { alignItems: "center", justifyContent: "center" },
+  headerTitle: {
+    color: sdui.color.neutralInverse,
+    fontSize: 17,
+    fontWeight: "600",
+  },
+  headerSubtitle: {
+    color: sdui.color.neutralInverse,
+    opacity: 0.8,
+    fontSize: 12,
+    marginTop: 1,
+  },
   missing: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
   missingTitle: { fontSize: 14, color: "#888" },
   missingId: { fontSize: 13, color: "#C00", marginTop: 6 },

--- a/packages/sdui-runtime/src/navigation/SduiSheetScreen.tsx
+++ b/packages/sdui-runtime/src/navigation/SduiSheetScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { StyleSheet, Text } from "react-native";
 import BottomSheet, {
   BottomSheetBackdrop,
@@ -8,12 +8,19 @@ import BottomSheet, {
   type BottomSheetFooterProps,
 } from "@gorhom/bottom-sheet";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
-import type { Action } from "@one-impression/sdk-native-sdui";
+import type { Action, Node } from "@one-impression/sdk-native-sdui";
 import { Interpreter } from "../interpreter/index.js";
 import { useActionEngine } from "../action-engine/useActionEngine.js";
+import { useBffConfig } from "../action-engine/useBffConfig.js";
 import { BottomSheetContext } from "../bottom-sheet/BottomSheetContext.js";
-import { useBottomSheetStore } from "../bottom-sheet/useBottomSheetStore.js";
+import {
+  useBottomSheetStore,
+  type SheetEntry,
+} from "../bottom-sheet/useBottomSheetStore.js";
 import type { SduiRootParamList } from "./navigationRef.js";
+import { registerSurfaceReload } from "./surfaceRegistry.js";
+import { fetchSurfaceDocument } from "./fetchSurfaceDocument.js";
+import { ListRowsSkeleton } from "../loaders/index.js";
 
 const SIZE_TO_SNAP: Record<string, string[]> = {
   small: ["25%"],
@@ -42,12 +49,84 @@ export function SduiSheetScreen({
   navigation,
 }: Props): React.ReactElement | null {
   const sheetId = route.params?.sheetId;
-  const sheet = useBottomSheetStore((s) => s.registry[sheetId]);
+  // Addressable sheets carry a content `path`: they fetch their OWN document on
+  // open instead of reading the static registry. The route's existence is
+  // authoritative for presence either way (B5).
+  const contentPath = route.params?.contentPath;
+  const isAddressable = !!contentPath;
+
+  const staticSheet = useBottomSheetStore((s) => s.registry[sheetId]);
   const actionEngine = useActionEngine();
+  const { bffBaseUrl, authToken } = useBffConfig();
   const sheetRef = useRef<BottomSheet>(null);
   // goBack() is idempotent-guarded: drag-close fires onClose AND the route may
   // already be popping, so guard against a double-pop.
   const poppedRef = useRef(false);
+
+  // Fetched document for an addressable sheet (null until the first fetch
+  // resolves). Static sheets ignore this and read the registry directly.
+  const [fetched, setFetched] = useState<SheetEntry | null>(null);
+
+  // Fetch the sheet's own document path-direct. Used on open and by
+  // reload-by-name. Maps the fetched JSON into the SheetEntry render shape.
+  // `queryParams` (reload-by-name only) ride into the refetch so the document
+  // can reflect what the triggering action passed (e.g. a just-picked address);
+  // the initial open passes none.
+  const fetchContent = useCallback(
+    (queryParams?: Record<string, unknown>) => {
+    if (!contentPath) return;
+    // Clear to the loading state on EVERY fetch — initial open AND reload-by-name
+    // — so the sheet shows its shimmer as feedback that it's (re)loading, matching
+    // the page screen's reload behavior. Content swaps back in when the fetch
+    // resolves.
+    setFetched(null);
+    fetchSurfaceDocument<Partial<SheetEntry> & { items?: Node[] }>(
+      bffBaseUrl,
+      authToken,
+      contentPath,
+      queryParams,
+    )
+      .then((doc) => {
+        setFetched({
+          id: doc.id ?? sheetId,
+          title: doc.title,
+          size: doc.size ?? "medium",
+          items: doc.items ?? [],
+          header: doc.header,
+          footer: doc.footer,
+          on_dismiss: doc.on_dismiss,
+          on_open: doc.on_open,
+          overlay_on_click: doc.overlay_on_click,
+        });
+      })
+      .catch((e: unknown) => {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[SduiSheetScreen] failed to fetch content for "${sheetId}" (${contentPath}):`,
+          e,
+        );
+      });
+  }, [contentPath, bffBaseUrl, authToken, sheetId]);
+
+  // The effective sheet: the fetched document for addressable sheets, else the
+  // static registry entry (legacy path — kept working untouched).
+  const sheet = isAddressable ? fetched ?? undefined : staticSheet;
+
+  // Addressable sheets fetch their content once on mount (on_load-style).
+  useEffect(() => {
+    if (isAddressable) fetchContent();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Register a reload handler keyed by this route so reload-by-name targeting
+  // this sheet's name refetches its document. Only addressable sheets refetch;
+  // static sheets have no own-document to refresh.
+  useEffect(() => {
+    if (!isAddressable) return;
+    return registerSurfaceReload(route.key, (opts) =>
+      fetchContent(opts?.queryParams),
+    );
+  }, [isAddressable, route.key, fetchContent]);
 
   const snapPoints = useMemo(
     () => SIZE_TO_SNAP[sheet?.size ?? "medium"] ?? SIZE_TO_SNAP["medium"],
@@ -60,16 +139,25 @@ export function SduiSheetScreen({
     if (navigation.canGoBack()) navigation.goBack();
   }, [navigation]);
 
-  // on_open lifecycle — once, on mount.
+  // on_open lifecycle. Static sheets: fire once on mount (definition is already
+  // in the registry). Addressable sheets: fire once the fetched document
+  // arrives (its on_open ships in that document).
+  const openFiredRef = useRef(false);
   useEffect(() => {
+    if (openFiredRef.current) return;
+    if (isAddressable && !fetched) return; // wait for the document
     if (sheet?.on_open) actionEngine.dispatch(sheet.on_open as Action);
+    openFiredRef.current = true;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isAddressable, fetched]);
 
-  // Defensive: a sheet id with no registered definition just closes the route.
+  // Defensive: a STATIC sheet id with no registered definition just closes the
+  // route. Addressable sheets are intentionally empty until their fetch
+  // resolves — never auto-pop them while the document is loading.
   useEffect(() => {
+    if (isAddressable) return;
     if (!sheet) pop();
-  }, [sheet, pop]);
+  }, [isAddressable, sheet, pop]);
 
   // Backdrop tap: fire the overlay click-action (server-driven) — gorhom's
   // pressBehavior="close" handles the actual close → onClose → pop.
@@ -113,7 +201,12 @@ export function SduiSheetScreen({
     [sheet?.footer],
   );
 
-  if (!sheet) return null;
+  // Addressable sheet still fetching its document → PRESENT the sheet now (so it
+  // animates open immediately) showing a shimmer skeleton; swap in content when
+  // the fetch resolves. Only a STATIC sheet with no definition renders nothing
+  // (its auto-pop effect closes the route).
+  const loading = isAddressable && !fetched;
+  if (!loading && !sheet) return null;
 
   return (
     <BottomSheet
@@ -124,28 +217,46 @@ export function SduiSheetScreen({
       enableDynamicSizing={false}
       onClose={handleClose}
       backdropComponent={renderBackdrop}
-      footerComponent={sheet.footer ? renderFooter : undefined}
+      footerComponent={!loading && sheet?.footer ? renderFooter : undefined}
     >
       <BottomSheetContext.Provider value={{ insideSheet: true }}>
-        {/* Pinned header SLOT — a wire `bottom_sheet_header` snippet rendered
-            OUTSIDE the scroll area so it (and any search field it carries)
-            stays put as `items` scroll. Symmetric with the footer slot.
-            Replaces the plain `title` text when present. */}
-        {sheet.header ? <Interpreter node={sheet.header} /> : null}
-        <BottomSheetScrollView
-          contentContainerStyle={[
-            styles.content,
-            // Reserve room so the last item isn't hidden behind the pinned footer.
-            sheet.footer && styles.contentWithFooter,
-          ]}
-        >
-          {!sheet.header && sheet.title ? (
-            <Text style={styles.title}>{sheet.title}</Text>
-          ) : null}
-          {sheet.items.map((node, i) => (
-            <Interpreter key={node.id ?? i} node={node} />
-          ))}
-        </BottomSheetScrollView>
+        {loading || !sheet ? (
+          // Loading state: sheet is open, content is in flight → show the
+          // action-supplied title/subtitle (so the opening sheet reads properly,
+          // not blank) above the shimmer rows. The fetched document's own
+          // header/title takes over once it arrives.
+          <BottomSheetScrollView contentContainerStyle={styles.content}>
+            {route.params?.title ? (
+              <Text style={styles.title}>{route.params.title}</Text>
+            ) : null}
+            {route.params?.subtitle ? (
+              <Text style={styles.subtitle}>{route.params.subtitle}</Text>
+            ) : null}
+            <ListRowsSkeleton />
+          </BottomSheetScrollView>
+        ) : (
+          <>
+            {/* Pinned header SLOT — a wire `bottom_sheet_header` snippet rendered
+                OUTSIDE the scroll area so it (and any search field it carries)
+                stays put as `items` scroll. Symmetric with the footer slot.
+                Replaces the plain `title` text when present. */}
+            {sheet.header ? <Interpreter node={sheet.header} /> : null}
+            <BottomSheetScrollView
+              contentContainerStyle={[
+                styles.content,
+                // Reserve room so the last item isn't hidden behind the pinned footer.
+                sheet.footer && styles.contentWithFooter,
+              ]}
+            >
+              {!sheet.header && sheet.title ? (
+                <Text style={styles.title}>{sheet.title}</Text>
+              ) : null}
+              {sheet.items.map((node, i) => (
+                <Interpreter key={node.id ?? i} node={node} />
+              ))}
+            </BottomSheetScrollView>
+          </>
+        )}
       </BottomSheetContext.Provider>
     </BottomSheet>
   );
@@ -154,5 +265,6 @@ export function SduiSheetScreen({
 const styles = StyleSheet.create({
   content: { paddingHorizontal: 16, paddingBottom: 32 },
   contentWithFooter: { paddingBottom: 96 },
-  title: { fontSize: 18, fontWeight: "700", paddingVertical: 12 },
+  title: { fontSize: 18, fontWeight: "700", paddingTop: 12 },
+  subtitle: { fontSize: 13, color: "#666", paddingBottom: 8 },
 });

--- a/packages/sdui-runtime/src/navigation/__tests__/surfaceRegistry.test.ts
+++ b/packages/sdui-runtime/src/navigation/__tests__/surfaceRegistry.test.ts
@@ -1,0 +1,165 @@
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  rebuildSurfaceIndex,
+  resolveSurface,
+  registerSurfaceReload,
+  signalSurfaceReload,
+  pathForRouteKey,
+  setNavigationAccessor,
+  __resetSurfaceRegistry,
+  type NavigationAccessor,
+} from "../surfaceRegistry.ts";
+
+/**
+ * Drive the by-name index directly off a fake route stack via the injected
+ * navigation accessor — no real NavigationContainer (and no react-navigation /
+ * react-native import). Each route mirrors the live shape:
+ * `{ key, name, params: { screenId | sheetId, contentPath } }`.
+ */
+interface FakeRoute {
+  key: string;
+  name: string;
+  params?: { screenId?: string; sheetId?: string; contentPath?: string };
+}
+
+function setStack(routes: FakeRoute[], focusedKey?: string): void {
+  const accessor: NavigationAccessor = {
+    isReady: () => true,
+    getRoutes: () => routes,
+    getCurrentRouteKey: () => focusedKey ?? routes[routes.length - 1]?.key,
+  };
+  setNavigationAccessor(accessor);
+  rebuildSurfaceIndex();
+}
+
+const page = (key: string, screenId: string, contentPath?: string): FakeRoute => ({
+  key,
+  name: "SduiPage",
+  params: { screenId, contentPath },
+});
+const sheet = (key: string, sheetId: string, contentPath?: string): FakeRoute => ({
+  key,
+  name: "SduiSheet",
+  params: { sheetId, contentPath },
+});
+
+beforeEach(() => {
+  __resetSurfaceRegistry();
+});
+
+afterEach(() => {
+  __resetSurfaceRegistry();
+  setNavigationAccessor({
+    isReady: () => false,
+    getRoutes: () => [],
+    getCurrentRouteKey: () => undefined,
+  });
+});
+
+test("resolveSurface — name not open → []", () => {
+  setStack([page("k1", "home")]);
+  assert.deepEqual(resolveSurface("nope", "nearest", "k1"), []);
+});
+
+test("resolveSurface — top picks the most-recently-opened instance", () => {
+  setStack([
+    page("k1", "home"),
+    page("k2", "list"),
+    page("k3", "detail"),
+    page("k4", "list"),
+  ]);
+  assert.deepEqual(resolveSurface("list", "top", "k1"), ["k4"]);
+});
+
+test("resolveSurface — all returns every open instance in stack order", () => {
+  setStack([page("k1", "home"), page("k2", "list"), page("k3", "list")]);
+  assert.deepEqual(resolveSurface("list", "all", "k1"), ["k2", "k3"]);
+});
+
+test("resolveSurface — nearest = highest-index match strictly below the caller", () => {
+  // home, list#1, detail, list#2, form. Caller = form (k5). The surface you
+  // return to via `back` and want to refresh is list#2 (k4), not list#1.
+  setStack(
+    [
+      page("k1", "home"),
+      page("k2", "list"),
+      page("k3", "detail"),
+      page("k4", "list"),
+      page("k5", "form"),
+    ],
+    "k5",
+  );
+  assert.deepEqual(resolveSurface("list", "nearest", "k5"), ["k4"]);
+});
+
+test("resolveSurface — nearest with no match below the caller falls back to topmost", () => {
+  setStack(
+    [page("k1", "home"), page("k2", "list"), page("k3", "detail"), page("k4", "list")],
+    "k2",
+  );
+  // Caller is list#1 (k2); no 'list' strictly below it → fall back to topmost (k4).
+  assert.deepEqual(resolveSurface("list", "nearest", "k2"), ["k4"]);
+});
+
+test("resolveSurface — nearest with unknown caller falls back to topmost match", () => {
+  setStack([page("k1", "home"), page("k2", "list"), page("k3", "list")]);
+  assert.deepEqual(resolveSurface("list", "nearest", "ghost"), ["k3"]);
+});
+
+test("by-name index keys on screenId AND sheetId; pathForRouteKey reads contentPath", () => {
+  setStack([
+    page("k1", "apply-checklist", "/v1/creator/apply/overview"),
+    sheet("k2", "address-select", "/v1/creator/profile/addresses"),
+  ]);
+  assert.deepEqual(resolveSurface("apply-checklist", "top", "k2"), ["k1"]);
+  assert.deepEqual(resolveSurface("address-select", "top", "k1"), ["k2"]);
+  assert.equal(pathForRouteKey("k1"), "/v1/creator/apply/overview");
+  assert.equal(pathForRouteKey("k2"), "/v1/creator/profile/addresses");
+});
+
+test("signalSurfaceReload — fires the registered handler; returns false when none", () => {
+  setStack([page("k1", "home"), page("k2", "list")]);
+  let calls = 0;
+  const dispose = registerSurfaceReload("k2", () => {
+    calls += 1;
+  });
+  assert.equal(signalSurfaceReload("k2"), true);
+  assert.equal(calls, 1);
+  assert.equal(signalSurfaceReload("k-unknown"), false);
+  dispose();
+  assert.equal(signalSurfaceReload("k2"), false, "disposed handler no longer fires");
+});
+
+test("signalSurfaceReload — forwards reload options (uiZones + queryParams) to the handler", () => {
+  // Reload-by-name carries the triggering action's request params into the
+  // target surface's OWN refetch — e.g. a just-picked address id flows
+  // address-select → reload{page:"apply-checklist", query_params} → the sheet's
+  // refetch, which appends it to its content path. The registry is the pipe;
+  // assert the opts arrive intact.
+  setStack([page("k1", "apply-checklist"), sheet("k2", "address-select")]);
+  let received: unknown;
+  registerSurfaceReload("k1", (opts) => {
+    received = opts;
+  });
+  signalSurfaceReload("k1", {
+    uiZones: ["content"],
+    queryParams: { selected_address_id: "addr-home" },
+  });
+  assert.deepEqual(received, {
+    uiZones: ["content"],
+    queryParams: { selected_address_id: "addr-home" },
+  });
+});
+
+test("rebuildSurfaceIndex prunes reload handlers for routes that left the stack", () => {
+  setStack([page("k1", "home"), page("k2", "list")]);
+  let calls = 0;
+  registerSurfaceReload("k2", () => {
+    calls += 1;
+  });
+  // Pop 'list' off the stack and rebuild — the handler for k2 must be dropped.
+  setStack([page("k1", "home")]);
+  assert.equal(signalSurfaceReload("k2"), false);
+  assert.equal(calls, 0);
+});

--- a/packages/sdui-runtime/src/navigation/fetchSurfaceDocument.ts
+++ b/packages/sdui-runtime/src/navigation/fetchSurfaceDocument.ts
@@ -1,0 +1,48 @@
+import { buildBffHeaders } from "../action-engine/handlers/_shared/bff-request.js";
+import type { ActionEngineConfig } from "../action-engine/types.js";
+
+/**
+ * Fetch an addressable surface's OWN document path-direct: `bffBaseUrl + path`,
+ * verbatim, with the standard BFF headers (auth + dev/active-social). Used by
+ * sheets that fetch their content on open and by reload-by-name refetch — the
+ * same plumbing the `bff_call` / `reload` handlers use, lifted so a React screen
+ * can call it without going through the action engine (whose response contract
+ * is an action chain, not a full document).
+ *
+ * Returns the parsed JSON document (a Page envelope for a page surface, a
+ * sheet-content document for a sheet). Throws on a non-OK response so the
+ * caller can render an error state.
+ *
+ * `queryParams` (optional) are appended to the path as a query string — used by
+ * reload-by-name to carry the triggering action's request params into the
+ * surface's own refetch (e.g. a just-picked address id). Null/undefined values
+ * are skipped; if `path` already has a query string the params merge onto it.
+ */
+export async function fetchSurfaceDocument<T = unknown>(
+  bffBaseUrl: string,
+  authToken: () => string | null,
+  path: string,
+  queryParams?: Record<string, unknown>,
+): Promise<T> {
+  if (!path) {
+    throw new Error("fetchSurfaceDocument: missing path (path-direct only)");
+  }
+  // buildBffHeaders reads bffBaseUrl off the config to localhost-gate
+  // X-Dev-Identity; pass a minimal config carrying just what it needs.
+  const config = { bffBaseUrl, authToken } as ActionEngineConfig;
+  const base = bffBaseUrl.replace(/\/$/, "");
+  let url = `${base}${path}`;
+  if (queryParams) {
+    const qs = new URLSearchParams();
+    for (const [k, v] of Object.entries(queryParams)) {
+      if (v != null) qs.append(k, String(v));
+    }
+    const s = qs.toString();
+    if (s) url += (url.includes("?") ? "&" : "?") + s;
+  }
+  const res = await fetch(url, { method: "GET", headers: buildBffHeaders(config) });
+  if (!res.ok) {
+    throw new Error(`surface fetch GET ${url} returned ${res.status}`);
+  }
+  return (await res.json()) as T;
+}

--- a/packages/sdui-runtime/src/navigation/index.ts
+++ b/packages/sdui-runtime/src/navigation/index.ts
@@ -21,3 +21,14 @@ export {
   type SheetPresenter,
   type SheetDismisser,
 } from "./sheetPresenter.js";
+export {
+  rebuildSurfaceIndex,
+  resolveSurface,
+  subscribeSurfaceIndex,
+  pathForRouteKey,
+  registerSurfaceReload,
+  signalSurfaceReload,
+  currentRouteKey,
+  __resetSurfaceRegistry,
+} from "./surfaceRegistry.js";
+export { fetchSurfaceDocument } from "./fetchSurfaceDocument.js";

--- a/packages/sdui-runtime/src/navigation/navigationRef.ts
+++ b/packages/sdui-runtime/src/navigation/navigationRef.ts
@@ -16,9 +16,28 @@ export type SduiRootParamList = {
     // simple_push | none. presentation: card | modal | transparentModal | formSheet.
     transition?: string;
     presentation?: string;
+    // Path the surface was fetched with (addressable, path-direct surfaces).
+    // Carried so reload-by-name can reuse it to refetch this exact instance.
+    contentPath?: string;
+    // Header chrome the navigate action supplies for the LOADING phase: shown in
+    // the native header synchronously (before the page document is fetched), so
+    // the shimmer screen reads a proper title/subtitle instead of the raw route
+    // name. The loaded page's own title / wire header reconciles in afterward.
+    title?: string;
+    subtitle?: string;
   };
   SduiSheet: {
     sheetId: string;
+    // When set, the sheet fetches its own document from this path on open
+    // (`on_load`-style) instead of reading the static `useBottomSheetStore`
+    // registry. Also the refetch handle for reload-by-name on the sheet.
+    contentPath?: string;
+    // Header chrome the sheet action supplies for the LOADING phase: rendered
+    // above the shimmer rows while the sheet fetches its document, so an opening
+    // sheet reads a proper title/subtitle. The fetched doc's own header/title
+    // takes over once it arrives.
+    title?: string;
+    subtitle?: string;
   };
 };
 
@@ -39,10 +58,25 @@ export function goBack(): void {
   }
 }
 
-/** Push a bottom sheet as a `transparentModal` route. */
-export function pushSheet(sheetId: string): void {
+/**
+ * Push a bottom sheet as a `transparentModal` route. `contentPath` (optional)
+ * makes this an ADDRESSABLE sheet that fetches its own document from that path
+ * on open instead of reading the static registry — see `SduiSheetScreen`.
+ */
+export function pushSheet(
+  sheetId: string,
+  contentPath?: string,
+  chrome?: { title?: string; subtitle?: string },
+): void {
   if (!navigationRef.isReady()) return;
-  navigationRef.dispatch(StackActions.push(SDUI_SHEET_ROUTE, { sheetId }));
+  navigationRef.dispatch(
+    StackActions.push(SDUI_SHEET_ROUTE, {
+      sheetId,
+      contentPath,
+      title: chrome?.title,
+      subtitle: chrome?.subtitle,
+    }),
+  );
 }
 
 /**
@@ -70,6 +104,13 @@ export function applyNavigate(
     screenId: target,
     transition: params?.transition as string | undefined,
     presentation: params?.presentation as string | undefined,
+    // Path-direct surfaces carry the path they were fetched with so
+    // reload-by-name can refetch this exact instance.
+    contentPath: params?.path as string | undefined,
+    // Loading-phase header chrome (server-driven): shown during the shimmer
+    // before the page document resolves. See SduiRootParamList.SduiPage.
+    title: params?.title as string | undefined,
+    subtitle: params?.subtitle as string | undefined,
   };
   switch (op) {
     case "pop":

--- a/packages/sdui-runtime/src/navigation/sheetPresenter.ts
+++ b/packages/sdui-runtime/src/navigation/sheetPresenter.ts
@@ -16,7 +16,12 @@ import { useBottomSheetStore } from "../bottom-sheet/useBottomSheetStore.js";
  *    using `SduiNavigationHost`), calls fall back to the zustand store's
  *    open()/close() that the gorhom modal host bridges imperatively.
  */
-export type SheetPresenter = (sheetId: string) => void;
+export type SheetChrome = { title?: string; subtitle?: string };
+export type SheetPresenter = (
+  sheetId: string,
+  contentPath?: string,
+  chrome?: SheetChrome,
+) => void;
 export type SheetDismisser = (sheetId?: string) => void;
 
 let _present: SheetPresenter | null = null;
@@ -39,12 +44,21 @@ export function setSheetPresenter(
   };
 }
 
-/** Open a previously-registered sheet by id. Route-based if a host is mounted. */
-export function presentSheet(sheetId: string): void {
+/**
+ * Open a sheet by id. Route-based if a host is mounted. `contentPath` (optional)
+ * makes it an addressable sheet that fetches its own document from that path on
+ * open; the legacy store host ignores it (static sheets only).
+ */
+export function presentSheet(
+  sheetId: string,
+  contentPath?: string,
+  chrome?: SheetChrome,
+): void {
   if (_present) {
-    _present(sheetId);
+    _present(sheetId, contentPath, chrome);
     return;
   }
+  // Legacy store host has no fetch-on-open path; static registry sheets only.
   useBottomSheetStore.getState().open(sheetId);
 }
 

--- a/packages/sdui-runtime/src/navigation/surfaceRegistry.ts
+++ b/packages/sdui-runtime/src/navigation/surfaceRegistry.ts
@@ -1,0 +1,220 @@
+/**
+ * Addressable-surface registry — a DERIVED by-name index over the one ordered
+ * route stack. It is NOT a parallel store: the route stack is the single source
+ * of truth for presence, order, and uniqueness; this index is rebuilt from the
+ * navigation state on every navigation `state` change so a name → route.key[]
+ * lookup is O(1) without walking the stack each time.
+ *
+ * The registry reads the live route stack through an injected accessor
+ * ({@link setNavigationAccessor}) rather than importing the React-Navigation
+ * `navigationRef` directly — so the resolution logic is unit-testable in Node
+ * without pulling react-navigation / react-native into the transform.
+ * `SduiNavigationHost` wires the real `navigationRef` accessor on mount.
+ *
+ * Addressing model (locked):
+ *  - **unique id (per open instance)** = `route.key` (React-Navigation-minted).
+ *  - **referenceable name** = `page.id` / `sheet.id`, carried as the
+ *    `screenId` / `sheetId` route param.
+ *  - **order / "nearest" tiebreak** = the route's index in `getState().routes`.
+ *
+ * A name may map to MANY open `route.key`s (the same surface opened twice). The
+ * index keeps them in stack order (low index → high index) so callers can pick
+ * `nearest` / `top` / `all` deterministically.
+ */
+
+/** The shape of a single route entry we read off the navigation state. */
+interface RouteLike {
+  key: string;
+  name?: string;
+  params?: { screenId?: string; sheetId?: string; contentPath?: string };
+}
+
+/**
+ * Read accessor over the live route stack. Production wires this from
+ * `navigationRef`; tests inject a fake. Returns `undefined` route list when the
+ * navigation container isn't ready.
+ */
+export interface NavigationAccessor {
+  isReady: () => boolean;
+  getRoutes: () => RouteLike[];
+  getCurrentRouteKey: () => string | undefined;
+}
+
+let accessor: NavigationAccessor = {
+  isReady: () => false,
+  getRoutes: () => [],
+  getCurrentRouteKey: () => undefined,
+};
+
+/** Wire the live navigation accessor (called once by `SduiNavigationHost`). */
+export function setNavigationAccessor(next: NavigationAccessor): void {
+  accessor = next;
+}
+
+/** name (`page.id` / `sheet.id`) → route.key[], in stack order (oldest → newest). */
+let byName = new Map<string, string[]>();
+
+/**
+ * The path each route was fetched with, keyed by `route.key`. Addressable
+ * surfaces (pages opened path-direct, sheets that fetch their own content) carry
+ * a `contentPath` route param; reload-by-name reuses it to refetch the surface.
+ * Kept here (rather than walking params on read) so resolution is a single map
+ * lookup. Entries are pruned when their route leaves the stack.
+ */
+let pathByKey = new Map<string, string>();
+
+/** Subscribers notified after each rebuild (so screens can re-resolve presence). */
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+/**
+ * Reload bus — reload-by-name resolves target `route.key`(s) and signals each to
+ * refetch. The owning screen (page or sheet) subscribes by its own `route.key`
+ * and re-runs its fetch when signalled. This keeps the route stack authoritative
+ * (the index only *finds* the surface; the surface owns its own refetch) and
+ * mirrors the existing zustand-store handler shape — no imperative ref bridge.
+ */
+/**
+ * What a reload-by-name carries to the target surface's refetch:
+ * - `uiZones` — which zones to mark loading (page zone-reload; sheets refetch whole).
+ * - `queryParams` — request params the triggering action passed (already bound
+ *   from any `{ref}` by the reload handler), appended to the surface's OWN fetch
+ *   path so the refetched document can reflect them (e.g. a just-picked id).
+ */
+export interface SurfaceReloadOptions {
+  uiZones?: string[];
+  queryParams?: Record<string, unknown>;
+}
+type ReloadHandler = (opts?: SurfaceReloadOptions) => void;
+const reloadHandlers = new Map<string, ReloadHandler>();
+
+/**
+ * Rebuild the by-name index + path map from the current route stack. Called from
+ * the single `navigationRef.addListener('state', …)` wired in
+ * `SduiNavigationHost`; also exported for tests that drive the stack directly.
+ */
+export function rebuildSurfaceIndex(): void {
+  const routes = accessor.isReady() ? accessor.getRoutes() : [];
+
+  const nextByName = new Map<string, string[]>();
+  const nextPathByKey = new Map<string, string>();
+
+  for (const route of routes) {
+    const name = route.params?.screenId ?? route.params?.sheetId;
+    if (name) {
+      const keys = nextByName.get(name);
+      if (keys) keys.push(route.key);
+      else nextByName.set(name, [route.key]);
+    }
+    if (route.params?.contentPath) {
+      nextPathByKey.set(route.key, route.params.contentPath);
+    }
+  }
+
+  byName = nextByName;
+  pathByKey = nextPathByKey;
+
+  // Drop reload handlers whose route has left the stack so we don't signal a
+  // dead screen (the screen also unsubscribes on unmount; this is belt-and-braces).
+  const live = new Set(routes.map((r) => r.key));
+  for (const key of reloadHandlers.keys()) {
+    if (!live.has(key)) reloadHandlers.delete(key);
+  }
+
+  for (const l of listeners) l();
+}
+
+/** Subscribe to index rebuilds. Returns an unsubscribe disposer. */
+export function subscribeSurfaceIndex(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/**
+ * Resolve a name to open `route.key`(s) per `scope`, relative to the caller's
+ * `route.key`:
+ *  - `nearest` — the matching route with the highest index strictly BELOW the
+ *    caller (the surface you return to via `back`). Falls back to the topmost
+ *    match when the caller isn't found (e.g. resolution relative to the focused
+ *    route) or has no match below it.
+ *  - `top` — the most-recently opened matching instance (highest index).
+ *  - `all` — every open instance of that name.
+ *
+ * Returns `[]` when no instance of `name` is open.
+ */
+export function resolveSurface(
+  name: string,
+  scope: "nearest" | "top" | "all",
+  callerKey?: string,
+): string[] {
+  const keys = byName.get(name);
+  if (!keys || keys.length === 0) return [];
+
+  if (scope === "all") return [...keys];
+  if (scope === "top") return [keys[keys.length - 1]!];
+
+  // nearest: matches are already in stack order. Find the caller's stack index;
+  // pick the highest-index match strictly below it. If the caller can't be
+  // located (no key, or not on the stack), nearest degrades to the topmost match.
+  const routes = accessor.isReady() ? accessor.getRoutes() : [];
+  const callerIndex =
+    callerKey != null ? routes.findIndex((r) => r.key === callerKey) : -1;
+  if (callerIndex < 0) return [keys[keys.length - 1]!];
+
+  let best: string | undefined;
+  let bestIndex = -1;
+  for (const k of keys) {
+    const idx = routes.findIndex((r) => r.key === k);
+    if (idx >= 0 && idx < callerIndex && idx > bestIndex) {
+      bestIndex = idx;
+      best = k;
+    }
+  }
+  // Nothing below the caller (e.g. caller is the only/oldest instance) — fall
+  // back to the topmost match so reload-by-name is never a silent no-op.
+  return best != null ? [best] : [keys[keys.length - 1]!];
+}
+
+/** The path a route was fetched with, if it carried a `contentPath` param. */
+export function pathForRouteKey(key: string): string | undefined {
+  return pathByKey.get(key);
+}
+
+/** Register the focused route's reload handler so reload-by-name can signal it. */
+export function registerSurfaceReload(
+  routeKey: string,
+  handler: ReloadHandler,
+): () => void {
+  reloadHandlers.set(routeKey, handler);
+  return () => {
+    if (reloadHandlers.get(routeKey) === handler) reloadHandlers.delete(routeKey);
+  };
+}
+
+/**
+ * Signal a resolved route to refetch its own document. Returns true if a handler
+ * was registered for that key (the surface is mounted and listening).
+ */
+export function signalSurfaceReload(
+  routeKey: string,
+  opts?: SurfaceReloadOptions,
+): boolean {
+  const handler = reloadHandlers.get(routeKey);
+  if (!handler) return false;
+  handler(opts);
+  return true;
+}
+
+/** The current focused route's key, or undefined if the stack isn't ready. */
+export function currentRouteKey(): string | undefined {
+  if (!accessor.isReady()) return undefined;
+  return accessor.getCurrentRouteKey();
+}
+
+/** Test-only: clear the index + handlers between cases. */
+export function __resetSurfaceRegistry(): void {
+  byName = new Map();
+  pathByKey = new Map();
+  reloadHandlers.clear();
+  listeners.clear();
+}

--- a/packages/sdui-runtime/src/snippets/InfoRow/InfoRow.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/InfoRow/InfoRow.renderer.tsx
@@ -32,10 +32,18 @@ export function InfoRowRenderer(node: Node): React.ReactElement {
             {v.left_media && renderMedia(v.left_media)}
             <Box flex={1}>
               <Stack direction="column" gap={2}>
+                {/* Default the title larger + heavier than the subtitle so the
+                    row's primary line reads with emphasis (semibold/600 — bold
+                    reads too heavy here). Both overridable per-node. NB: use the
+                    WIRE-FORM token "sdui.font-weight.semibold", not the short
+                    "semiBold": the fontWeight map is keyed lowercase, so the
+                    short camelCase token misses the lookup and falls through as
+                    an invalid RN fontWeight (renders normal). The wire form
+                    resolves via the prefix-stripping path → "600". */}
                 <Text
                   color={v.title.color}
-                  size={v.title.font_size}
-                  weight={v.title.font_weight}
+                  size={v.title.font_size ?? "lg"}
+                  weight={v.title.font_weight ?? "sdui.font-weight.semibold"}
                 >
                   {v.title.text}
                 </Text>

--- a/packages/sdui-runtime/src/snippets/SectionHeader/SectionHeader.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/SectionHeader/SectionHeader.renderer.tsx
@@ -19,7 +19,7 @@ export function SectionHeaderRenderer(node: Node): React.ReactElement {
       load_events={node.load_events}
     >
       {(v) => (
-        <Box>
+        <Box mb="md">
           <Stack direction="row" align="center" justify="space-between">
             <Stack direction="column" gap={2}>
               <Text

--- a/packages/sdui-runtime/src/snippets/Separator/Separator.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/Separator/Separator.renderer.tsx
@@ -19,7 +19,7 @@ export function SeparatorRenderer(node: Node): React.ReactElement {
     >
       {(v) => (
         <DSSeparator
-          orientation={v.variant}
+          variant={v.variant}
           thickness={v.thickness}
           color={v.color}
           spacing={v.margin_vertical}

--- a/packages/sdui-runtime/src/ui_components/Separator/Separator.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Separator/Separator.renderer.tsx
@@ -19,7 +19,7 @@ export function SeparatorRenderer(node: Node): React.ReactElement {
     >
       {(v) => (
         <DSSeparator
-          orientation={v.variant}
+          variant={v.variant}
           thickness={v.thickness}
           color={v.color}
           spacing={v.margin_vertical}

--- a/packages/ui-native/src/primitives/Separator/Separator.test.tsx
+++ b/packages/ui-native/src/primitives/Separator/Separator.test.tsx
@@ -39,4 +39,62 @@ describe('Separator', () => {
       : el.props.style;
     expect(flatStyle.marginVertical).toBe(12);
   });
+
+  it('renders solid via backgroundColor by default', () => {
+    render(<Separator testID="sep" color="primary" thickness={2} />);
+    const el = screen.getByTestId('sep');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.backgroundColor).toBe('#7C3AED');
+    expect(flatStyle.height).toBe(2);
+    expect(flatStyle.borderStyle).toBeUndefined();
+    expect(flatStyle.borderTopWidth).toBeUndefined();
+  });
+
+  it('renders dashed via a horizontal border, not a background', () => {
+    render(<Separator testID="sep" variant="dashed" color="primary" thickness={2} />);
+    const el = screen.getByTestId('sep');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.borderStyle).toBe('dashed');
+    expect(flatStyle.borderTopWidth).toBe(2);
+    expect(flatStyle.borderColor).toBe('#7C3AED');
+    expect(flatStyle.height).toBe(0);
+    expect(flatStyle.backgroundColor).toBeUndefined();
+  });
+
+  it('renders dotted via a horizontal border, not a background', () => {
+    render(<Separator testID="sep" variant="dotted" color="primary" thickness={2} />);
+    const el = screen.getByTestId('sep');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.borderStyle).toBe('dotted');
+    expect(flatStyle.borderTopWidth).toBe(2);
+    expect(flatStyle.borderColor).toBe('#7C3AED');
+    expect(flatStyle.height).toBe(0);
+    expect(flatStyle.backgroundColor).toBeUndefined();
+  });
+
+  it('renders dashed vertical via a left border', () => {
+    render(
+      <Separator
+        testID="sep"
+        orientation="vertical"
+        variant="dashed"
+        color="primary"
+        thickness={2}
+      />,
+    );
+    const el = screen.getByTestId('sep');
+    const flatStyle = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style.filter(Boolean))
+      : el.props.style;
+    expect(flatStyle.borderStyle).toBe('dashed');
+    expect(flatStyle.borderLeftWidth).toBe(2);
+    expect(flatStyle.width).toBe(0);
+    expect(flatStyle.backgroundColor).toBeUndefined();
+  });
 });

--- a/packages/ui-native/src/primitives/Separator/Separator.tsx
+++ b/packages/ui-native/src/primitives/Separator/Separator.tsx
@@ -11,6 +11,7 @@ export const Separator = React.forwardRef<View, SeparatorProps>(
   (
     {
       orientation = 'horizontal',
+      variant = 'solid',
       color = 'neutralSubtle',
       thickness = 1,
       spacing,
@@ -23,18 +24,44 @@ export const Separator = React.forwardRef<View, SeparatorProps>(
     const resolvedSpacing = resolveSpacing(spacing);
     const isHorizontal = orientation === 'horizontal';
 
+    // The spacing/margin logic is identical across all variants.
+    const spacingStyle = {
+      marginVertical: isHorizontal ? resolvedSpacing : undefined,
+      marginHorizontal: isHorizontal ? undefined : resolvedSpacing,
+    };
+
+    // 'solid' keeps the filled-View approach: a backgroundColor fills the
+    // thickness-sized box. A filled view cannot be dashed/dotted, so
+    // 'dashed'/'dotted' instead draw a border (the line) on a zero-extent,
+    // transparent View.
+    const lineStyle =
+      variant === 'solid'
+        ? {
+            backgroundColor: resolvedColor,
+            [isHorizontal ? 'height' : 'width']: thickness,
+          }
+        : isHorizontal
+          ? {
+              height: 0,
+              borderTopWidth: thickness,
+              borderStyle: variant,
+              borderColor: resolvedColor,
+            }
+          : {
+              width: 0,
+              borderLeftWidth: thickness,
+              borderStyle: variant,
+              borderColor: resolvedColor,
+            };
+
     return (
       <View
         ref={ref}
         accessibilityRole="none"
         style={[
           isHorizontal ? styles.horizontal : styles.vertical,
-          {
-            backgroundColor: resolvedColor,
-            [isHorizontal ? 'height' : 'width']: thickness,
-            marginVertical: isHorizontal ? resolvedSpacing : undefined,
-            marginHorizontal: isHorizontal ? undefined : resolvedSpacing,
-          },
+          lineStyle,
+          spacingStyle,
           style,
         ]}
         {...props}

--- a/packages/ui-native/src/primitives/Separator/Separator.types.ts
+++ b/packages/ui-native/src/primitives/Separator/Separator.types.ts
@@ -4,6 +4,8 @@ import type { ColorToken, SpacingToken } from '../../tokens';
 export interface SeparatorProps extends Omit<ViewProps, 'style'> {
   /** Orientation. Defaults to 'horizontal'. */
   orientation?: 'horizontal' | 'vertical';
+  /** Line style. Defaults to 'solid'. */
+  variant?: 'solid' | 'dashed' | 'dotted';
   /** Color token or raw color string. Defaults to 'neutralSubtle'. */
   color?: ColorToken | string;
   /** Thickness in pixels. Defaults to 1. */


### PR DESCRIPTION
Addressable surfaces + apply-checklist UI (nav host/sheet/registry, reload-by-name, InfoRow/SectionHeader/Separator renderers, IconGlyph + BlinkerDot, ui-native Separator variant). Bumps sdk-native-sdui to ^5.0.0 (path-direct contract). Publishes ui-native + sdui-runtime via changesets on merge.

Part of the addressable-surfaces / creator-SDUI delivery. sdk-native-sdui@5.0.0 already published (#361/#363).