### PR TITLE
fix(sdui-runtime): migrate submit action to path-direct

### DIFF
--- a/.changeset/submit-action-path-direct.md
+++ b/.changeset/submit-action-path-direct.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+Fix the `submit` action: it was left on the old endpoint-id contract during the path-direct migration, reading `payload.endpoint` (always undefined now that builders emit `payload.path`) and hand-building the URL with a bare `Authorization` header. Every form submit silently no-op'd (the validity gate passed, then it aborted on the missing endpoint). It now resolves the URL via the shared path-direct plumbing (`resolveRequestUrl`) and uses `buildBffHeaders` — so it carries the same auth, dev-identity, and active-social headers as `bff_call` / `reload`.

--- a/packages/sdui-runtime/src/action-engine/handlers/__tests__/submit.test.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/__tests__/submit.test.ts
@@ -1,0 +1,145 @@
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { handleSubmit } from "../submit.ts";
+import type { ActionEngine, ActionEngineConfig } from "../../types.ts";
+import type { Action } from "@one-impression/sdk-native-sdui";
+import { useFormStore } from "../../../state/useFormStore.ts";
+
+const noopConfig: ActionEngineConfig = {
+  bffBaseUrl: "https://bff.example.test",
+  authToken: () => null,
+  onNavigate: () => undefined,
+  onToast: () => undefined,
+  onDeeplink: () => undefined,
+};
+
+interface SpyEngine extends ActionEngine {
+  log: Array<{ type: string; tag?: string }>;
+}
+
+function makeSpyEngine(): SpyEngine {
+  const log: SpyEngine["log"] = [];
+  return {
+    log,
+    dispatch: async (action: Action) => {
+      const tag = (action.payload?.tag as string | undefined) ?? undefined;
+      log.push({ type: action.type, tag });
+    },
+  };
+}
+
+type FetchStub = (input: unknown, init?: unknown) => Promise<Response>;
+let originalFetch: typeof globalThis.fetch | undefined;
+
+function installFetch(stub: FetchStub): void {
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = stub as unknown as typeof globalThis.fetch;
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  // Start each test from a clean form store.
+  useFormStore.setState({ forms: {} });
+});
+
+afterEach(() => {
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// A registered form with one valid (un-erroring) field — the submit gate
+// passes only when the form has no errors.
+function seedValidForm(formId = "f1"): void {
+  const store = useFormStore.getState();
+  store.register(formId);
+  store.setField(formId, "pan", "ABCDE1234F");
+}
+
+// Path-direct: the submit action carries the concrete request `path`, mirroring
+// bff_call / reload — there is no client-side endpoint-id registry.
+const submitAction = (overrides: Record<string, unknown> = {}): Action =>
+  ({
+    type: "submit",
+    payload: {
+      form_id: "f1",
+      path: "/v1/creator/kyc/verify",
+      ...overrides,
+    },
+  }) as Action;
+
+test("submit — POSTs to bffBaseUrl + path (path-direct) and runs on_success", async () => {
+  seedValidForm();
+  let lastUrl: string | undefined;
+  installFetch(async (input) => {
+    lastUrl = String(input);
+    return jsonResponse({});
+  });
+  const engine = makeSpyEngine();
+  await handleSubmit(
+    submitAction({ on_success: { type: "toast", payload: { tag: "ok" } } }),
+    noopConfig,
+    engine,
+  );
+  assert.equal(lastUrl, "https://bff.example.test/v1/creator/kyc/verify");
+  assert.deepEqual(engine.log.map((e) => e.tag), ["ok"]);
+});
+
+test("submit — missing path is a no-op (no request, no chain)", async () => {
+  seedValidForm();
+  let fetched = false;
+  installFetch(async () => {
+    fetched = true;
+    return jsonResponse({});
+  });
+  const engine = makeSpyEngine();
+  await handleSubmit(
+    { type: "submit", payload: { form_id: "f1" } } as Action,
+    noopConfig,
+    engine,
+  );
+  assert.equal(fetched, false, "must not fetch without a path");
+  assert.deepEqual(engine.log, [], "must not chain without a path");
+});
+
+test("submit — body merges form values OVER request_body (form wins)", async () => {
+  seedValidForm();
+  let body: Record<string, unknown> | undefined;
+  installFetch(async (_input, init) => {
+    body = JSON.parse((init as { body: string }).body) as Record<string, unknown>;
+    return jsonResponse({});
+  });
+  await handleSubmit(
+    submitAction({ request_body: { source: "manual", pan: "SERVER-DEFAULT" } }),
+    noopConfig,
+    makeSpyEngine(),
+  );
+  assert.equal(body?.["source"], "manual", "server-known constant rides along");
+  assert.equal(body?.["pan"], "ABCDE1234F", "form value wins over request_body");
+});
+
+test("submit — non-2xx writes server field errors and runs on_error", async () => {
+  seedValidForm();
+  installFetch(async () =>
+    jsonResponse({ errors: { pan: "Invalid PAN" } }, 422),
+  );
+  const engine = makeSpyEngine();
+  await handleSubmit(
+    submitAction({ on_error: { type: "toast", payload: { tag: "err" } } }),
+    noopConfig,
+    engine,
+  );
+  assert.deepEqual(engine.log.map((e) => e.tag), ["err"]);
+  assert.equal(
+    useFormStore.getState().getForm("f1")?.errors["pan"],
+    "Invalid PAN",
+    "server field error is written into the form's error map",
+  );
+});

--- a/packages/sdui-runtime/src/action-engine/handlers/submit.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/submit.ts
@@ -1,6 +1,7 @@
 import type { Action } from "@one-impression/sdk-native-sdui";
 import type { ActionEngineConfig, ActionEngine } from "../types.js";
 import { useFormStore, selectFormIsValid } from "../../state/useFormStore.js";
+import { resolveRequestUrl, buildBffHeaders } from "./_shared/bff-request.js";
 
 /**
  * `submit` action payload (a runtime wire extension — promote to the SDK with
@@ -9,8 +10,16 @@ import { useFormStore, selectFormIsValid } from "../../state/useFormStore.js";
 interface SubmitPayload {
   /** Which form's values to collect (keyed in useFormStore). */
   form_id: string;
-  /** Request path (raw for the playground; a registered endpoint id in prod). */
-  endpoint: string;
+  /**
+   * Path-direct request target — the concrete BFF path the handler emits (e.g.
+   * `/v1/creator/kyc/verify`), fetched as `bffBaseUrl + path`. Shares the
+   * `bff_call` / `reload` plumbing; there is NO client-side endpoint registry.
+   */
+  path: string;
+  /** `{param}` / `:param` substitutions for the path. */
+  path_params?: Record<string, string>;
+  /** Query-string params appended to the path. */
+  query_params?: Record<string, string>;
   /** HTTP method; defaults to POST. */
   method?: string;
   /** Server-known constants merged UNDER the form values (design D3/D4). */
@@ -45,8 +54,8 @@ export async function handleSubmit(
 ): Promise<void> {
   const payload = (action.payload ?? {}) as unknown as SubmitPayload;
   const formId = payload.form_id;
-  if (!formId || !payload.endpoint) {
-    config.logger?.warn("submit: missing form_id or endpoint");
+  if (!formId || !payload.path) {
+    config.logger?.warn("submit: missing form_id or path");
     return;
   }
 
@@ -62,11 +71,15 @@ export async function handleSubmit(
   const values = store.getForm(formId)?.values ?? {};
   const body = { ...(payload.request_body ?? {}), ...values };
 
-  const base = config.bffBaseUrl.replace(/\/$/, "");
-  const url = `${base}${payload.endpoint}`;
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
-  const token = config.authToken();
-  if (token) headers["Authorization"] = `Bearer ${token}`;
+  // 3. Path-direct URL + the shared BFF header set (auth + dev identity +
+  //    active-social), identical to bff_call / reload — keeps form submits on
+  //    the same plumbing rather than a bespoke, header-light path.
+  const url = resolveRequestUrl(config, {
+    path: payload.path,
+    path_params: payload.path_params,
+    query_params: payload.query_params,
+  });
+  const headers = buildBffHeaders(config);
 
   try {
     const res = await fetch(url, {


### PR DESCRIPTION
## Problem

The `submit` action handler was left on the **old endpoint-id contract** during the path-direct migration. While `bff_call` and `reload` moved to `payload.path` + the shared `resolveRequestUrl` / `buildBffHeaders` plumbing, `submit` still:

- read `payload.endpoint` — **always `undefined`** now that every BFF builder emits `payload.path`, so the handler hit `if (!formId || !payload.endpoint) return;` and bailed;
- hand-built the URL and set a bare `Authorization` header, **skipping `X-Dev-Identity`** (the local-dev identity bridge) and `X-Active-Influencer-Id`.

Net effect: **every form submit silently no-op'd** — the validity gate passed, then it aborted on the missing endpoint, so neither `on_success` nor `on_error` fired. Affects PAN verify, KYC submit, address upsert, personal-details, and about-me.

## Fix

- Read `payload.path` (+ optional `path_params` / `query_params`).
- Build the URL via the shared `resolveRequestUrl` and headers via `buildBffHeaders` — identical plumbing to `bff_call` / `reload`, so submit now carries auth + dev-identity + active-social headers.
- Validity gate, value merge, and success/error routing are unchanged.

## Tests

New `submit.test.ts` (mirrors `bff-call.test.ts`): path-direct URL construction, no-op on missing path, form-value-over-`request_body` merge precedence, and server field-error handling. All 60 handler tests pass.

Changeset: `patch` for `@one-impression/sdui-runtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)