### PR TITLE
fix(sdui-runtime): render button icons; surface render errors in dev fallback

### DIFF
--- a/.changeset/button-icon-render.md
+++ b/.changeset/button-icon-render.md
@@ -1,0 +1,9 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+Fix `Button` icon rendering and surface render errors in the dev fallback.
+
+The Button renderer routed `icon_left` / `icon_right` (bare `{ name, color?, size? }` specs, not nodes) straight through the Interpreter, whose `resolveRenderer` does `type.includes(...)` on the absent `type` — so ANY button with an icon threw "Cannot read property 'includes' of undefined" and fell back. Render them with `IconGlyph` directly (the same icon-store path `InfoRow` / `renderMedia` use), which resolves a default size/colour and feeds the parsed SVG concrete dimensions.
+
+Also surface the caught error message in the dev `SduiFallback` for render-time throws (previously only schema-parse failures showed the message; render throws showed a bare label, making them hard to diagnose).

--- a/packages/sdui-runtime/src/sdui-node/SduiErrorBoundary.tsx
+++ b/packages/sdui-runtime/src/sdui-node/SduiErrorBoundary.tsx
@@ -3,12 +3,18 @@ import type { ReactNode } from "react";
 
 interface Props {
   nodeId: string;
-  fallback: ReactNode;
+  /**
+   * Render the fallback for a caught render error. Receives the error so dev
+   * fallbacks can surface the message (a static node can't — only schema-parse
+   * fallbacks had the message before, render-throws showed a bare label).
+   */
+  renderFallback: (error?: Error) => ReactNode;
   children: ReactNode;
 }
 
 interface State {
   hasError: boolean;
+  error?: Error;
 }
 
 export class SduiErrorBoundary extends React.Component<Props, State> {
@@ -17,8 +23,8 @@ export class SduiErrorBoundary extends React.Component<Props, State> {
     this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError(): State {
-    return { hasError: true };
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
   }
 
   componentDidCatch(error: Error): void {
@@ -31,7 +37,7 @@ export class SduiErrorBoundary extends React.Component<Props, State> {
 
   render(): ReactNode {
     if (this.state.hasError) {
-      return this.props.fallback;
+      return this.props.renderFallback(this.state.error);
     }
     return this.props.children;
   }

--- a/packages/sdui-runtime/src/sdui-node/SduiNode.tsx
+++ b/packages/sdui-runtime/src/sdui-node/SduiNode.tsx
@@ -132,7 +132,9 @@ export function SduiNode<TSchema extends z.ZodTypeAny>(
   return (
     <SduiErrorBoundary
       nodeId={props.id}
-      fallback={<SduiFallback nodeId={props.id} nodeType={props.type} />}
+      renderFallback={(error) => (
+        <SduiFallback nodeId={props.id} nodeType={props.type} error={error} />
+      )}
     >
       {viewportManaged ? (
         // Managed surface owns the view lifecycle (real visibility) — render the

--- a/packages/sdui-runtime/src/ui_components/Button/Button.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Button/Button.renderer.tsx
@@ -7,7 +7,7 @@ import {
   buttonVariantColors,
 } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
-import { Interpreter } from "../../interpreter/index.js";
+import { IconGlyph } from "../../icon-store/IconGlyph.js";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";
 
 /**
@@ -52,7 +52,20 @@ export function ButtonRenderer(node: Node): React.ReactElement {
             node.on_click ? () => actionEngine.dispatch(node.on_click!) : undefined
           }
         >
-          {v.icon_left && <Interpreter node={v.icon_left} />}
+          {/* icon_left / icon_right are bare { name, color?, size? } specs, NOT
+              nodes — render them with IconGlyph directly (the same icon-store
+              path InfoRow uses), which resolves a default size/colour and feeds
+              the parsed SVG concrete dimensions. Routing the bare spec through
+              the Interpreter crashed resolveRenderer (`type.includes(...)` on an
+              absent `type`); routing it through the node IconRenderer left the
+              glyph dimensionless. */}
+          {v.icon_left && (
+            <IconGlyph
+              name={v.icon_left.name}
+              color={v.icon_left.color}
+              size={v.icon_left.size}
+            />
+          )}
           {/* label is TextSchema ({ text, color?, font_size? }), not a Node —
               ButtonComponentSchema types it that way, so render it directly
               instead of routing through the Interpreter (which requires a
@@ -74,7 +87,13 @@ export function ButtonRenderer(node: Node): React.ReactElement {
           >
             {v.label.text}
           </DSText>
-          {v.icon_right && <Interpreter node={v.icon_right} />}
+          {v.icon_right && (
+            <IconGlyph
+              name={v.icon_right.name}
+              color={v.icon_right.color}
+              size={v.icon_right.size}
+            />
+          )}
         </DSButton>
         );
       }}


### PR DESCRIPTION
## Problem

Any `Button` with an icon crashed and fell back to the SDUI placeholder. The Button renderer routed `icon_left` / `icon_right` — which the schema types as **bare** `{ name, color?, size? }` specs (not nodes) — straight through the `Interpreter`. `resolveRenderer` then does `type.includes(".ui_component.")` on the spec's absent `type`, throwing **"Cannot read property 'includes' of undefined"**.

Surfaced by the new creator **social-connect** "Login with Instagram" button (the first button with an icon to render).

## Fix

- Render `icon_left` / `icon_right` with **`IconGlyph`** directly — the same icon-store path `InfoRow` and `renderMedia` already use. It resolves a default size/colour and passes the parsed SVG concrete dimensions, so a bare spec with no size/colour renders correctly.
- **`SduiErrorBoundary`** now passes the caught error to a `renderFallback(error)` callback so the dev `SduiFallback` shows the render-error message. Previously only schema-parse failures surfaced a message; render throws showed only a bare node label — which is what made this bug hard to diagnose.

## Verified on-device

The social-connect "Login with Instagram" button now renders with its icon (no fallback box); the rest of the screen (Skip, sparkle benefit bullets, social proof, footer) renders cleanly.

Changeset: `patch` for `@one-impression/sdui-runtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)