### PR TITLE
fix(sdui-runtime): creator KYC/social flow — submit path-direct, button icons, per-instance page store, sticky-footer reach

### DIFF
--- a/.changeset/button-icon-render.md
+++ b/.changeset/button-icon-render.md
@@ -1,0 +1,9 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+Fix `Button` icon rendering and surface render errors in the dev fallback.
+
+The Button renderer routed `icon_left` / `icon_right` (bare `{ name, color?, size? }` specs, not nodes) straight through the Interpreter, whose `resolveRenderer` does `type.includes(...)` on the absent `type` — so ANY button with an icon threw "Cannot read property 'includes' of undefined" and fell back. Render them with `IconGlyph` directly (the same icon-store path `InfoRow` / `renderMedia` use), which resolves a default size/colour and feeds the parsed SVG concrete dimensions.
+
+Also surface the caught error message in the dev `SduiFallback` for render-time throws (previously only schema-parse failures showed the message; render throws showed a bare label, making them hard to diagnose).

--- a/.changeset/per-instance-page-store.md
+++ b/.changeset/per-instance-page-store.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+Make the page store **per-navigation-instance** (keyed by `route.key`) instead of a single shared page. Previously every mounted screen wrote to one `page`/`pageId`, so pushing a detail page clobbered the feed behind it — returning to the feed showed a permanent skeleton (its content was overwritten and `on_load` never re-fired). Each screen now keeps its own entry, re-claims active focus on navigation back (so its actions and reload/replace/append target its own tree), and drops it on unmount. Two instances of the same page id (e.g. two campaign details on the stack) no longer collide.

--- a/.changeset/replace-section-reaches-footer.md
+++ b/.changeset/replace-section-reaches-footer.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+`replace_section` (and `replaceNode`) now reach nodes in the page's sticky header/footer slots, not just `items` — so a section reload can swap the pinned footer (e.g. a KYC verify step revealing the declaration + Submit footer). Also: `page_footer_with_checkbox` renders its primary CTA full-width when there's no secondary button, matching the plain `page_footer` bar.

--- a/.changeset/standard-page-reload-keyboard.md
+++ b/.changeset/standard-page-reload-keyboard.md
@@ -1,0 +1,9 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+Make `reload_section` / `replace_section` / `append_items` re-render standard and sticky-footer pages, and let in-page actions fire while the keyboard is open.
+
+`PageStandard` and `PageStickyFooter` rendered straight from the `page` prop and never synced to `usePageStore` — so a section reload (e.g. KYC PAN verify swapping in the GST select) updated the store but never re-rendered the screen (only `PageFeed`, via `usePageScaffold`, read the live tree). Both now sync the page into the store on mount and read the live tree back, matching `PageFeed`.
+
+Also set `keyboardShouldPersistTaps="handled"` on the page scroll containers (standard, sticky-footer, feed) so a tap on an in-page action (e.g. an inline "Verify" beside a focused text field) fires instead of being swallowed to dismiss the keyboard.

--- a/.changeset/submit-action-path-direct.md
+++ b/.changeset/submit-action-path-direct.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+Fix the `submit` action: it was left on the old endpoint-id contract during the path-direct migration, reading `payload.endpoint` (always undefined now that builders emit `payload.path`) and hand-building the URL with a bare `Authorization` header. Every form submit silently no-op'd (the validity gate passed, then it aborted on the missing endpoint). It now resolves the URL via the shared path-direct plumbing (`resolveRequestUrl`) and uses `buildBffHeaders` — so it carries the same auth, dev-identity, and active-social headers as `bff_call` / `reload`.

--- a/packages/sdui-runtime/src/action-engine/handlers/__tests__/submit.test.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/__tests__/submit.test.ts
@@ -1,0 +1,145 @@
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { handleSubmit } from "../submit.ts";
+import type { ActionEngine, ActionEngineConfig } from "../../types.ts";
+import type { Action } from "@one-impression/sdk-native-sdui";
+import { useFormStore } from "../../../state/useFormStore.ts";
+
+const noopConfig: ActionEngineConfig = {
+  bffBaseUrl: "https://bff.example.test",
+  authToken: () => null,
+  onNavigate: () => undefined,
+  onToast: () => undefined,
+  onDeeplink: () => undefined,
+};
+
+interface SpyEngine extends ActionEngine {
+  log: Array<{ type: string; tag?: string }>;
+}
+
+function makeSpyEngine(): SpyEngine {
+  const log: SpyEngine["log"] = [];
+  return {
+    log,
+    dispatch: async (action: Action) => {
+      const tag = (action.payload?.tag as string | undefined) ?? undefined;
+      log.push({ type: action.type, tag });
+    },
+  };
+}
+
+type FetchStub = (input: unknown, init?: unknown) => Promise<Response>;
+let originalFetch: typeof globalThis.fetch | undefined;
+
+function installFetch(stub: FetchStub): void {
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = stub as unknown as typeof globalThis.fetch;
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  // Start each test from a clean form store.
+  useFormStore.setState({ forms: {} });
+});
+
+afterEach(() => {
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// A registered form with one valid (un-erroring) field — the submit gate
+// passes only when the form has no errors.
+function seedValidForm(formId = "f1"): void {
+  const store = useFormStore.getState();
+  store.register(formId);
+  store.setField(formId, "pan", "ABCDE1234F");
+}
+
+// Path-direct: the submit action carries the concrete request `path`, mirroring
+// bff_call / reload — there is no client-side endpoint-id registry.
+const submitAction = (overrides: Record<string, unknown> = {}): Action =>
+  ({
+    type: "submit",
+    payload: {
+      form_id: "f1",
+      path: "/v1/creator/kyc/verify",
+      ...overrides,
+    },
+  }) as Action;
+
+test("submit — POSTs to bffBaseUrl + path (path-direct) and runs on_success", async () => {
+  seedValidForm();
+  let lastUrl: string | undefined;
+  installFetch(async (input) => {
+    lastUrl = String(input);
+    return jsonResponse({});
+  });
+  const engine = makeSpyEngine();
+  await handleSubmit(
+    submitAction({ on_success: { type: "toast", payload: { tag: "ok" } } }),
+    noopConfig,
+    engine,
+  );
+  assert.equal(lastUrl, "https://bff.example.test/v1/creator/kyc/verify");
+  assert.deepEqual(engine.log.map((e) => e.tag), ["ok"]);
+});
+
+test("submit — missing path is a no-op (no request, no chain)", async () => {
+  seedValidForm();
+  let fetched = false;
+  installFetch(async () => {
+    fetched = true;
+    return jsonResponse({});
+  });
+  const engine = makeSpyEngine();
+  await handleSubmit(
+    { type: "submit", payload: { form_id: "f1" } } as Action,
+    noopConfig,
+    engine,
+  );
+  assert.equal(fetched, false, "must not fetch without a path");
+  assert.deepEqual(engine.log, [], "must not chain without a path");
+});
+
+test("submit — body merges form values OVER request_body (form wins)", async () => {
+  seedValidForm();
+  let body: Record<string, unknown> | undefined;
+  installFetch(async (_input, init) => {
+    body = JSON.parse((init as { body: string }).body) as Record<string, unknown>;
+    return jsonResponse({});
+  });
+  await handleSubmit(
+    submitAction({ request_body: { source: "manual", pan: "SERVER-DEFAULT" } }),
+    noopConfig,
+    makeSpyEngine(),
+  );
+  assert.equal(body?.["source"], "manual", "server-known constant rides along");
+  assert.equal(body?.["pan"], "ABCDE1234F", "form value wins over request_body");
+});
+
+test("submit — non-2xx writes server field errors and runs on_error", async () => {
+  seedValidForm();
+  installFetch(async () =>
+    jsonResponse({ errors: { pan: "Invalid PAN" } }, 422),
+  );
+  const engine = makeSpyEngine();
+  await handleSubmit(
+    submitAction({ on_error: { type: "toast", payload: { tag: "err" } } }),
+    noopConfig,
+    engine,
+  );
+  assert.deepEqual(engine.log.map((e) => e.tag), ["err"]);
+  assert.equal(
+    useFormStore.getState().getForm("f1")?.errors["pan"],
+    "Invalid PAN",
+    "server field error is written into the form's error map",
+  );
+});

--- a/packages/sdui-runtime/src/action-engine/handlers/submit.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/submit.ts
@@ -1,6 +1,7 @@
 import type { Action } from "@one-impression/sdk-native-sdui";
 import type { ActionEngineConfig, ActionEngine } from "../types.js";
 import { useFormStore, selectFormIsValid } from "../../state/useFormStore.js";
+import { resolveRequestUrl, buildBffHeaders } from "./_shared/bff-request.js";
 
 /**
  * `submit` action payload (a runtime wire extension — promote to the SDK with
@@ -9,8 +10,16 @@ import { useFormStore, selectFormIsValid } from "../../state/useFormStore.js";
 interface SubmitPayload {
   /** Which form's values to collect (keyed in useFormStore). */
   form_id: string;
-  /** Request path (raw for the playground; a registered endpoint id in prod). */
-  endpoint: string;
+  /**
+   * Path-direct request target — the concrete BFF path the handler emits (e.g.
+   * `/v1/creator/kyc/verify`), fetched as `bffBaseUrl + path`. Shares the
+   * `bff_call` / `reload` plumbing; there is NO client-side endpoint registry.
+   */
+  path: string;
+  /** `{param}` / `:param` substitutions for the path. */
+  path_params?: Record<string, string>;
+  /** Query-string params appended to the path. */
+  query_params?: Record<string, string>;
   /** HTTP method; defaults to POST. */
   method?: string;
   /** Server-known constants merged UNDER the form values (design D3/D4). */
@@ -45,8 +54,8 @@ export async function handleSubmit(
 ): Promise<void> {
   const payload = (action.payload ?? {}) as unknown as SubmitPayload;
   const formId = payload.form_id;
-  if (!formId || !payload.endpoint) {
-    config.logger?.warn("submit: missing form_id or endpoint");
+  if (!formId || !payload.path) {
+    config.logger?.warn("submit: missing form_id or path");
     return;
   }
 
@@ -62,11 +71,15 @@ export async function handleSubmit(
   const values = store.getForm(formId)?.values ?? {};
   const body = { ...(payload.request_body ?? {}), ...values };
 
-  const base = config.bffBaseUrl.replace(/\/$/, "");
-  const url = `${base}${payload.endpoint}`;
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
-  const token = config.authToken();
-  if (token) headers["Authorization"] = `Bearer ${token}`;
+  // 3. Path-direct URL + the shared BFF header set (auth + dev identity +
+  //    active-social), identical to bff_call / reload — keeps form submits on
+  //    the same plumbing rather than a bespoke, header-light path.
+  const url = resolveRequestUrl(config, {
+    path: payload.path,
+    path_params: payload.path_params,
+    query_params: payload.query_params,
+  });
+  const headers = buildBffHeaders(config);
 
   try {
     const res = await fetch(url, {

--- a/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
@@ -133,6 +133,9 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
               keyExtractor={keyExtractor}
               onViewableItemsChanged={handleViewableItemsChanged}
               viewabilityConfig={viewabilityConfigRef.current}
+              // Deliver taps to children while the keyboard is open (e.g. an
+              // inline field action) rather than swallowing the first tap.
+              keyboardShouldPersistTaps="handled"
               contentContainerStyle={{ paddingBottom: insets.bottom + sdui.spacing.lg }}
               refreshControl={
                 livePage.on_refresh ? (

--- a/packages/sdui-runtime/src/pages/PageStandard/PageStandard.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageStandard/PageStandard.renderer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
 import { BackHandler, ScrollView, RefreshControl, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { sdui } from "@one-impression/tokens-creator/react-native";
@@ -11,6 +11,7 @@ import { usePageRefresh } from "../../hooks/usePageRefresh.js";
 import { useAppStateSession } from "../../hooks/useAppStateSession.js";
 import { usePageStore } from "../../state/usePageStore.js";
 import { useShallow } from "zustand/react/shallow";
+import { useRoute, useFocusEffect } from "@react-navigation/native";
 
 interface PageProps {
   page: Page;
@@ -30,18 +31,23 @@ export function PageStandardRenderer({ page }: PageProps): React.ReactElement {
   const { refreshing, onRefresh } = usePageRefresh(page.on_refresh);
   const insets = useSafeAreaInsets();
 
-  // Live page from the store so reload_section / replace_node / append_items
-  // flow back into the render. The standard layout previously rendered straight
-  // from the `page` prop, so a section reload (e.g. KYC verify → reload the
-  // result container) updated the store but never re-rendered the screen. Sync
-  // the server page into the store on mount and read the live tree back; the
-  // prop is the fallback until that sync commits.
+  // Per-instance store entry (keyed by route.key) so reload_section /
+  // replace_node / append_items flow back into the render without clobbering
+  // other stacked screens. Register + activate on mount, drop on unmount,
+  // re-claim active focus on navigation back. Prop is the fallback until sync.
+  const instanceKey = useRoute().key;
   const livePage = usePageStore(
-    useShallow((s): Page => (s.pageId === page.id && s.page ? s.page : page)),
+    useShallow((s): Page => s.pagesByKey[instanceKey] ?? page),
   );
   useEffect(() => {
-    usePageStore.getState().setPageTree(page);
-  }, [page]);
+    usePageStore.getState().setPageTree(page, instanceKey);
+    return () => usePageStore.getState().dropPage(instanceKey);
+  }, [page, instanceKey]);
+  useFocusEffect(
+    useCallback(() => {
+      usePageStore.getState().activatePage(instanceKey);
+    }, [instanceKey]),
+  );
 
   // Register inline bottom sheets so sheet actions can open them later.
   // Sheets are pre-registered (not opened) — the sheet action handler

--- a/packages/sdui-runtime/src/pages/PageStandard/PageStandard.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageStandard/PageStandard.renderer.tsx
@@ -9,6 +9,8 @@ import { useActionEngine } from "../../action-engine/useActionEngine.js";
 import { useBottomSheetStore } from "../../bottom-sheet/useBottomSheetStore.js";
 import { usePageRefresh } from "../../hooks/usePageRefresh.js";
 import { useAppStateSession } from "../../hooks/useAppStateSession.js";
+import { usePageStore } from "../../state/usePageStore.js";
+import { useShallow } from "zustand/react/shallow";
 
 interface PageProps {
   page: Page;
@@ -27,6 +29,19 @@ export function PageStandardRenderer({ page }: PageProps): React.ReactElement {
   const unregister = useBottomSheetStore((s) => s.unregister);
   const { refreshing, onRefresh } = usePageRefresh(page.on_refresh);
   const insets = useSafeAreaInsets();
+
+  // Live page from the store so reload_section / replace_node / append_items
+  // flow back into the render. The standard layout previously rendered straight
+  // from the `page` prop, so a section reload (e.g. KYC verify → reload the
+  // result container) updated the store but never re-rendered the screen. Sync
+  // the server page into the store on mount and read the live tree back; the
+  // prop is the fallback until that sync commits.
+  const livePage = usePageStore(
+    useShallow((s): Page => (s.pageId === page.id && s.page ? s.page : page)),
+  );
+  useEffect(() => {
+    usePageStore.getState().setPageTree(page);
+  }, [page]);
 
   // Register inline bottom sheets so sheet actions can open them later.
   // Sheets are pre-registered (not opened) — the sheet action handler
@@ -93,6 +108,11 @@ export function PageStandardRenderer({ page }: PageProps): React.ReactElement {
       {header ? <Interpreter node={header} /> : null}
       <ScrollView
         style={{ flex: 1 }}
+        // Deliver taps to children even while the keyboard is open — otherwise a
+        // tap on an in-page action (e.g. an inline "Verify" beside a text field)
+        // is swallowed to dismiss the keyboard and the press never fires. With
+        // "handled", taps on non-interactive areas still dismiss the keyboard.
+        keyboardShouldPersistTaps="handled"
         // Bottom safe-area inset + a base buffer so the last item clears the home
         // indicator with breathing room. Applied to every scroll page by default.
         contentContainerStyle={{ paddingBottom: insets.bottom + sdui.spacing.lg }}
@@ -102,7 +122,7 @@ export function PageStandardRenderer({ page }: PageProps): React.ReactElement {
           ) : undefined
         }
       >
-        {page.items.map((node, i) => (
+        {livePage.items.map((node, i) => (
           <GutterItem key={node.id ?? `item-${i}`} node={node}>
             <Interpreter node={node} />
           </GutterItem>

--- a/packages/sdui-runtime/src/pages/PageStickyFooter/PageStickyFooter.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageStickyFooter/PageStickyFooter.renderer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
 import {
   BackHandler,
   KeyboardAvoidingView,
@@ -17,6 +17,7 @@ import { usePageRefresh } from "../../hooks/usePageRefresh.js";
 import { useAppStateSession } from "../../hooks/useAppStateSession.js";
 import { usePageStore } from "../../state/usePageStore.js";
 import { useShallow } from "zustand/react/shallow";
+import { useRoute, useFocusEffect } from "@react-navigation/native";
 
 interface PageProps {
   page: Page;
@@ -49,15 +50,22 @@ export function PageStickyFooterRenderer({
   const unregister = useBottomSheetStore((s) => s.unregister);
   const { refreshing, onRefresh } = usePageRefresh(page.on_refresh);
 
-  // Live page from the store so reload_section / replace_node / append_items
-  // re-render (the layout otherwise renders straight from the prop). See
-  // PageStandard for the full rationale.
+  // Per-instance store entry (keyed by route.key) so reload_section /
+  // replace_node / append_items re-render without clobbering other stacked
+  // screens. See PageStandard for the full rationale.
+  const instanceKey = useRoute().key;
   const livePage = usePageStore(
-    useShallow((s): Page => (s.pageId === page.id && s.page ? s.page : page)),
+    useShallow((s): Page => s.pagesByKey[instanceKey] ?? page),
   );
   useEffect(() => {
-    usePageStore.getState().setPageTree(page);
-  }, [page]);
+    usePageStore.getState().setPageTree(page, instanceKey);
+    return () => usePageStore.getState().dropPage(instanceKey);
+  }, [page, instanceKey]);
+  useFocusEffect(
+    useCallback(() => {
+      usePageStore.getState().activatePage(instanceKey);
+    }, [instanceKey]),
+  );
 
   // Read header/footer from the LIVE page so a section reload that swaps a slot
   // node (e.g. the KYC verify step revealing the footer) re-renders. `keyboard_

--- a/packages/sdui-runtime/src/pages/PageStickyFooter/PageStickyFooter.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageStickyFooter/PageStickyFooter.renderer.tsx
@@ -15,6 +15,8 @@ import { useActionEngine } from "../../action-engine/useActionEngine.js";
 import { useBottomSheetStore } from "../../bottom-sheet/useBottomSheetStore.js";
 import { usePageRefresh } from "../../hooks/usePageRefresh.js";
 import { useAppStateSession } from "../../hooks/useAppStateSession.js";
+import { usePageStore } from "../../state/usePageStore.js";
+import { useShallow } from "zustand/react/shallow";
 
 interface PageProps {
   page: Page;
@@ -46,6 +48,16 @@ export function PageStickyFooterRenderer({
   const register = useBottomSheetStore((s) => s.register);
   const unregister = useBottomSheetStore((s) => s.unregister);
   const { refreshing, onRefresh } = usePageRefresh(page.on_refresh);
+
+  // Live page from the store so reload_section / replace_node / append_items
+  // re-render (the layout otherwise renders straight from the prop). See
+  // PageStandard for the full rationale.
+  const livePage = usePageStore(
+    useShallow((s): Page => (s.pageId === page.id && s.page ? s.page : page)),
+  );
+  useEffect(() => {
+    usePageStore.getState().setPageTree(page);
+  }, [page]);
 
   const pageData = page.data as
     | { header?: unknown; footer?: unknown; keyboard_aware?: boolean }
@@ -108,13 +120,16 @@ export function PageStickyFooterRenderer({
   const bodyContent = (
     <ScrollView
       style={styles.bodyScroll}
+      // Deliver taps to children while the keyboard is open (e.g. an inline
+      // field action) instead of swallowing the first tap to dismiss it.
+      keyboardShouldPersistTaps="handled"
       refreshControl={
         page.on_refresh ? (
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
         ) : undefined
       }
     >
-      {page.items.map((node, i) => (
+      {livePage.items.map((node, i) => (
         <GutterItem key={node.id ?? `item-${i}`} node={node}>
           <Interpreter node={node} />
         </GutterItem>

--- a/packages/sdui-runtime/src/pages/PageStickyFooter/PageStickyFooter.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageStickyFooter/PageStickyFooter.renderer.tsx
@@ -59,12 +59,17 @@ export function PageStickyFooterRenderer({
     usePageStore.getState().setPageTree(page);
   }, [page]);
 
-  const pageData = page.data as
+  // Read header/footer from the LIVE page so a section reload that swaps a slot
+  // node (e.g. the KYC verify step revealing the footer) re-renders. `keyboard_
+  // aware` is a static layout flag, so the prop is fine for it.
+  const pageData = livePage.data as
     | { header?: unknown; footer?: unknown; keyboard_aware?: boolean }
     | undefined;
   const header = pageData?.header;
   const footer = pageData?.footer;
-  const keyboardAware = pageData?.keyboard_aware ?? false;
+  const keyboardAware =
+    (page.data as { keyboard_aware?: boolean } | undefined)?.keyboard_aware ??
+    false;
 
   // Register inline bottom sheets (do not open) — see PageStandard for details.
   useEffect(() => {

--- a/packages/sdui-runtime/src/pages/_shared/usePageScaffold.ts
+++ b/packages/sdui-runtime/src/pages/_shared/usePageScaffold.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from "react";
 import { BackHandler } from "react-native";
 import { useShallow } from "zustand/react/shallow";
+import { useRoute, useFocusEffect } from "@react-navigation/native";
 import type { Page, Node, Action } from "@one-impression/sdk-native-sdui";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";
 import { useAppStateSession } from "../../hooks/useAppStateSession.js";
@@ -50,20 +51,34 @@ export function usePageScaffold(page: Page): PageScaffold {
   const register = useBottomSheetStore((s) => s.register);
   const unregister = useBottomSheetStore((s) => s.unregister);
 
-  // Live page: store-backed for THIS screen (so reload/append/replace flow back
+  // This screen's unique instance key (route.key) — so two instances of the
+  // same page id keep separate store entries and don't clobber each other.
+  const instanceKey = useRoute().key;
+
+  // Live page: this instance's store entry (so reload/append/replace flow back
   // in), prop fallback before the mount-sync commits or during a nav transition.
   const livePage = usePageStore(
-    useShallow((s): Page => (s.pageId === page.id && s.page ? s.page : page)),
+    useShallow((s): Page => s.pagesByKey[instanceKey] ?? page),
   );
   const loadingUiZones = usePageStore((s) => s.loadingUiZones);
 
   const { refreshing, onRefresh } = usePageRefresh(livePage.on_refresh);
 
-  // Sync the server page into the store on mount / prop change, so action
-  // handlers (reload merge, append_items, replace_node) flow back to the layout.
+  // Register this instance + make it active on mount / prop change; drop it on
+  // unmount so backgrounded trees don't leak. Action handlers (reload merge,
+  // append_items, replace_node) target the active instance and flow back here.
   useEffect(() => {
-    usePageStore.getState().setPageTree(page);
-  }, [page]);
+    usePageStore.getState().setPageTree(page, instanceKey);
+    return () => usePageStore.getState().dropPage(instanceKey);
+  }, [page, instanceKey]);
+
+  // Re-claim active focus on navigation back — so this screen's actions target
+  // its own (cached, content-carrying) tree, not whatever was pushed on top.
+  useFocusEffect(
+    useCallback(() => {
+      usePageStore.getState().activatePage(instanceKey);
+    }, [instanceKey]),
+  );
 
   // Page lifecycle: on_load (once) / on_dismount (unmount).
   useEffect(() => {

--- a/packages/sdui-runtime/src/sdui-node/SduiErrorBoundary.tsx
+++ b/packages/sdui-runtime/src/sdui-node/SduiErrorBoundary.tsx
@@ -3,12 +3,18 @@ import type { ReactNode } from "react";
 
 interface Props {
   nodeId: string;
-  fallback: ReactNode;
+  /**
+   * Render the fallback for a caught render error. Receives the error so dev
+   * fallbacks can surface the message (a static node can't — only schema-parse
+   * fallbacks had the message before, render-throws showed a bare label).
+   */
+  renderFallback: (error?: Error) => ReactNode;
   children: ReactNode;
 }
 
 interface State {
   hasError: boolean;
+  error?: Error;
 }
 
 export class SduiErrorBoundary extends React.Component<Props, State> {
@@ -17,8 +23,8 @@ export class SduiErrorBoundary extends React.Component<Props, State> {
     this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError(): State {
-    return { hasError: true };
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
   }
 
   componentDidCatch(error: Error): void {
@@ -31,7 +37,7 @@ export class SduiErrorBoundary extends React.Component<Props, State> {
 
   render(): ReactNode {
     if (this.state.hasError) {
-      return this.props.fallback;
+      return this.props.renderFallback(this.state.error);
     }
     return this.props.children;
   }

--- a/packages/sdui-runtime/src/sdui-node/SduiNode.tsx
+++ b/packages/sdui-runtime/src/sdui-node/SduiNode.tsx
@@ -132,7 +132,9 @@ export function SduiNode<TSchema extends z.ZodTypeAny>(
   return (
     <SduiErrorBoundary
       nodeId={props.id}
-      fallback={<SduiFallback nodeId={props.id} nodeType={props.type} />}
+      renderFallback={(error) => (
+        <SduiFallback nodeId={props.id} nodeType={props.type} error={error} />
+      )}
     >
       {viewportManaged ? (
         // Managed surface owns the view lifecycle (real visibility) — render the

--- a/packages/sdui-runtime/src/snippets/PageFooterWithCheckbox/PageFooterWithCheckbox.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/PageFooterWithCheckbox/PageFooterWithCheckbox.renderer.tsx
@@ -22,10 +22,17 @@ export function PageFooterWithCheckboxRenderer(node: Node): React.ReactElement {
         <Box padding={16}>
           <Stack direction="column" gap={12}>
             <Interpreter node={v.checkbox} />
-            <Stack direction="row" gap={12} justify="flex-end">
-              {v.secondary_button && <Interpreter node={v.secondary_button} />}
-              {v.primary_button && <Interpreter node={v.primary_button} />}
-            </Stack>
+            {/* With a secondary action the two buttons sit in a right-aligned
+                row; with only a primary CTA it spans full width (the standard
+                footer action), matching the plain page_footer bar. */}
+            {v.secondary_button ? (
+              <Stack direction="row" gap={12} justify="flex-end">
+                <Interpreter node={v.secondary_button} />
+                {v.primary_button && <Interpreter node={v.primary_button} />}
+              </Stack>
+            ) : (
+              v.primary_button && <Interpreter node={v.primary_button} />
+            )}
           </Stack>
         </Box>
       )}

--- a/packages/sdui-runtime/src/state/__tests__/usePageStore.test.ts
+++ b/packages/sdui-runtime/src/state/__tests__/usePageStore.test.ts
@@ -138,6 +138,28 @@ test("usePageStore.replaceNode replaces a node in the loaded page", () => {
   assert.deepEqual(replaced.data, { fresh: true });
 });
 
+test("usePageStore keeps a separate entry per instance key (no clobber on push)", () => {
+  resetStore();
+  const s = usePageStore.getState();
+  // Home feed mounts (key kHome) with content.
+  s.setPageTree(page([leaf("home-card")]), "kHome");
+  // A detail page pushes on top (key kDetail) — must NOT clobber home's entry.
+  s.setPageTree(page([leaf("detail-body")]), "kDetail");
+  const st = usePageStore.getState();
+  assert.equal(st.activeKey, "kDetail");
+  assert.equal(st.pagesByKey["kHome"]?.items[0]?.id, "home-card", "home survives");
+  assert.equal(st.pagesByKey["kDetail"]?.items[0]?.id, "detail-body");
+  // Navigating back re-activates home with its own (intact) tree.
+  usePageStore.getState().activatePage("kHome");
+  const back = usePageStore.getState();
+  assert.equal(back.activeKey, "kHome");
+  assert.equal(back.page?.items[0]?.id, "home-card", "back-nav restores home content");
+  // Dropping the detail instance leaves home intact.
+  usePageStore.getState().dropPage("kDetail");
+  assert.equal(usePageStore.getState().pagesByKey["kDetail"], undefined);
+  assert.equal(usePageStore.getState().pagesByKey["kHome"]?.items[0]?.id, "home-card");
+});
+
 test("usePageStore.replaceNode reaches the page footer slot", () => {
   resetStore();
   const p = page([leaf("a")]);

--- a/packages/sdui-runtime/src/state/__tests__/usePageStore.test.ts
+++ b/packages/sdui-runtime/src/state/__tests__/usePageStore.test.ts
@@ -138,6 +138,34 @@ test("usePageStore.replaceNode replaces a node in the loaded page", () => {
   assert.deepEqual(replaced.data, { fresh: true });
 });
 
+test("usePageStore.replaceNode reaches the page footer slot", () => {
+  resetStore();
+  const p = page([leaf("a")]);
+  (p as unknown as { data: Record<string, unknown> }).data = {
+    footer: leaf("kyc-footer"),
+  };
+  usePageStore.getState().setPageTree(p);
+  usePageStore.getState().replaceNode("kyc-footer", leaf("kyc-footer", { fresh: true }));
+  const updated = usePageStore.getState().page!;
+  const footer = (updated.data as { footer: Node }).footer;
+  assert.deepEqual(footer.data, { fresh: true });
+  // body items untouched
+  assert.equal(updated.items[0]?.id, "a");
+});
+
+test("usePageStore.replaceNode reaches a node nested inside the footer slot", () => {
+  resetStore();
+  const p = page([leaf("a")]);
+  (p as unknown as { data: Record<string, unknown> }).data = {
+    footer: container("footer-bar", [leaf("submit-btn")]),
+  };
+  usePageStore.getState().setPageTree(p);
+  usePageStore.getState().replaceNode("submit-btn", leaf("submit-btn", { fresh: true }));
+  const footer = (usePageStore.getState().page!.data as { footer: Node }).footer;
+  const inner = (footer.data as { items: Node[] }).items[0] as Node;
+  assert.deepEqual(inner.data, { fresh: true });
+});
+
 test("usePageStore.replaceNode is a no-op (with warning) when id not found", () => {
   resetStore();
   const warnings: unknown[][] = [];

--- a/packages/sdui-runtime/src/state/usePageStore.ts
+++ b/packages/sdui-runtime/src/state/usePageStore.ts
@@ -37,10 +37,20 @@ export interface AppendItemsOptions {
 }
 
 export interface PageStoreState {
-  /** Current page identifier. */
+  /** Current (focused) page id — mirrors the active instance, for handlers. */
   pageId: string | null;
-  /** The full SDUI page envelope, when one is loaded. */
+  /** The full SDUI page envelope for the focused instance, when one is loaded. */
   page: Page | null;
+  /** The focused instance's key (navigation route.key). */
+  activeKey: string | null;
+  /**
+   * Live page tree PER instance, keyed by navigation route.key. The store is a
+   * stack-aware cache, not a single page: each mounted screen keeps its own
+   * entry, so pushing another page never clobbers a backgrounded one (a feed
+   * survives a detail push + back) and two instances of the same page id don't
+   * collide. `page`/`pageId`/`activeKey` mirror whichever instance is focused.
+   */
+  pagesByKey: Record<string, Page>;
   /** Sections map keyed by section ID. */
   sections: Record<string, PageSection>;
   /** Whether the full page is loading. */
@@ -60,8 +70,17 @@ export interface PageStoreState {
 export interface PageStoreActions {
   /** Set the current page and its initial sections. */
   setPage: (pageId: string, sections: Record<string, PageSection>) => void;
-  /** Set the full SDUI page envelope (used by the page loader on initial fetch). */
-  setPageTree: (page: Page) => void;
+  /**
+   * Register a page instance and make it the focused (active) one. `instanceKey`
+   * is the navigation `route.key` — unique per push — so two instances of the
+   * SAME page id (e.g. two campaign details on the stack) keep separate trees.
+   * Defaults to `page.id` for legacy callers / tests.
+   */
+  setPageTree: (page: Page, instanceKey?: string) => void;
+  /** Re-focus an already-registered instance (on navigation back). */
+  activatePage: (instanceKey: string) => void;
+  /** Drop an instance's cached tree (on screen unmount) to avoid leaks. */
+  dropPage: (instanceKey: string) => void;
   /** Replace a section's data entirely (used for reload/refresh). */
   replaceSection: (sectionId: string, data: unknown) => void;
   /** Append data to a section (used for pagination/infinite scroll). */
@@ -115,6 +134,8 @@ export interface PageStoreActions {
 const initialState: PageStoreState = {
   pageId: null,
   page: null,
+  activeKey: null,
+  pagesByKey: {},
   sections: {},
   loading: false,
   error: null,
@@ -223,14 +244,60 @@ function appendItemsInTree(
   return [out, matched, mutated];
 }
 
+/**
+ * Keep the per-id cache in sync whenever the focused `page` is mutated, so a
+ * backgrounded screen reads its latest tree (with merged/replaced/appended
+ * content) when it regains focus.
+ */
+function syncCache(
+  state: PageStoreState,
+  nextPage: Page,
+): Pick<PageStoreState, "pagesByKey"> {
+  if (!state.activeKey) return { pagesByKey: state.pagesByKey };
+  return { pagesByKey: { ...state.pagesByKey, [state.activeKey]: nextPage } };
+}
+
 export const usePageStore = create<PageStoreState & PageStoreActions>((set) => ({
   ...initialState,
 
   setPage: (pageId, sections) =>
     set({ pageId, sections, loading: false, error: null }),
 
-  setPageTree: (page) =>
-    set({ page, pageId: page.id, loading: false, error: null }),
+  setPageTree: (page, instanceKey) =>
+    set((state) => {
+      const key = instanceKey ?? page.id;
+      return {
+        page,
+        pageId: page.id,
+        activeKey: key,
+        pagesByKey: { ...state.pagesByKey, [key]: page },
+        loading: false,
+        error: null,
+      };
+    }),
+
+  activatePage: (instanceKey) =>
+    set((state) => {
+      const cached = state.pagesByKey[instanceKey];
+      // Re-focus a known instance: make it the active target + mirror its cached
+      // tree (with whatever content it accumulated) back into page/pageId.
+      if (!cached) return { activeKey: instanceKey };
+      return { activeKey: instanceKey, page: cached, pageId: cached.id };
+    }),
+
+  dropPage: (instanceKey) =>
+    set((state) => {
+      if (!(instanceKey in state.pagesByKey)) return {};
+      const nextPages = { ...state.pagesByKey };
+      delete nextPages[instanceKey];
+      // If the dropped instance was active, clear the mirror (a sibling screen
+      // re-activates itself on focus).
+      const wasActive = state.activeKey === instanceKey;
+      return {
+        pagesByKey: nextPages,
+        ...(wasActive ? { activeKey: null, page: null, pageId: null } : {}),
+      };
+    }),
 
   mergeUiZones: (partial) =>
     set((state) => {
@@ -242,7 +309,8 @@ export const usePageStore = create<PageStoreState & PageStoreActions>((set) => (
         ? { ...(state.page.data ?? {}), ...partial.data }
         : state.page.data;
       const nextItems = partial.items ?? state.page.items;
-      return { page: { ...state.page, data: nextData, items: nextItems } };
+      const nextPage = { ...state.page, data: nextData, items: nextItems };
+      return { page: nextPage, ...syncCache(state, nextPage) };
     }),
 
   setUiZonesLoading: (uiZones, loading) =>
@@ -306,7 +374,8 @@ export const usePageStore = create<PageStoreState & PageStoreActions>((set) => (
         next,
       );
       if (matched) {
-        return { page: { ...state.page, items: nextItems } };
+        const nextPage = { ...state.page, items: nextItems };
+        return { page: nextPage, ...syncCache(state, nextPage) };
       }
       // The target may live in a page SLOT (the sticky header / footer node),
       // which is held on `page.data` outside `items`. Section actions must reach
@@ -321,9 +390,11 @@ export const usePageStore = create<PageStoreState & PageStoreActions>((set) => (
           next,
         );
         if (slotMatched) {
-          return {
-            page: { ...state.page, data: { ...data, [slot]: nextSlot[0] } },
+          const nextPage = {
+            ...state.page,
+            data: { ...data, [slot]: nextSlot[0] },
           };
+          return { page: nextPage, ...syncCache(state, nextPage) };
         }
       }
       console.warn(

--- a/packages/sdui-runtime/src/state/usePageStore.ts
+++ b/packages/sdui-runtime/src/state/usePageStore.ts
@@ -305,13 +305,31 @@ export const usePageStore = create<PageStoreState & PageStoreActions>((set) => (
         targetId,
         next,
       );
-      if (!matched) {
-        console.warn(
-          `[usePageStore.replaceNode] no node with id "${targetId}" in page "${state.page.id}"`,
-        );
-        return {};
+      if (matched) {
+        return { page: { ...state.page, items: nextItems } };
       }
-      return { page: { ...state.page, items: nextItems } };
+      // The target may live in a page SLOT (the sticky header / footer node),
+      // which is held on `page.data` outside `items`. Section actions must reach
+      // those too — e.g. a verify step that swaps the page's sticky footer.
+      const data = (state.page.data ?? {}) as Record<string, unknown>;
+      for (const slot of ["footer", "header"] as const) {
+        const slotNode = data[slot] as Node | undefined;
+        if (!slotNode) continue;
+        const [nextSlot, slotMatched] = replaceNodeInTree(
+          [slotNode],
+          targetId,
+          next,
+        );
+        if (slotMatched) {
+          return {
+            page: { ...state.page, data: { ...data, [slot]: nextSlot[0] } },
+          };
+        }
+      }
+      console.warn(
+        `[usePageStore.replaceNode] no node with id "${targetId}" in page "${state.page.id}"`,
+      );
+      return {};
     }),
 
   appendItems: (targetId, items, options = {}) =>

--- a/packages/sdui-runtime/src/ui_components/Button/Button.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Button/Button.renderer.tsx
@@ -7,7 +7,7 @@ import {
   buttonVariantColors,
 } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
-import { Interpreter } from "../../interpreter/index.js";
+import { IconGlyph } from "../../icon-store/IconGlyph.js";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";
 
 /**
@@ -52,7 +52,20 @@ export function ButtonRenderer(node: Node): React.ReactElement {
             node.on_click ? () => actionEngine.dispatch(node.on_click!) : undefined
           }
         >
-          {v.icon_left && <Interpreter node={v.icon_left} />}
+          {/* icon_left / icon_right are bare { name, color?, size? } specs, NOT
+              nodes — render them with IconGlyph directly (the same icon-store
+              path InfoRow uses), which resolves a default size/colour and feeds
+              the parsed SVG concrete dimensions. Routing the bare spec through
+              the Interpreter crashed resolveRenderer (`type.includes(...)` on an
+              absent `type`); routing it through the node IconRenderer left the
+              glyph dimensionless. */}
+          {v.icon_left && (
+            <IconGlyph
+              name={v.icon_left.name}
+              color={v.icon_left.color}
+              size={v.icon_left.size}
+            />
+          )}
           {/* label is TextSchema ({ text, color?, font_size? }), not a Node —
               ButtonComponentSchema types it that way, so render it directly
               instead of routing through the Interpreter (which requires a
@@ -74,7 +87,13 @@ export function ButtonRenderer(node: Node): React.ReactElement {
           >
             {v.label.text}
           </DSText>
-          {v.icon_right && <Interpreter node={v.icon_right} />}
+          {v.icon_right && (
+            <IconGlyph
+              name={v.icon_right.name}
+              color={v.icon_right.color}
+              size={v.icon_right.size}
+            />
+          )}
         </DSButton>
         );
       }}


### PR DESCRIPTION
Consolidates all the SDUI-runtime fixes needed for the creator KYC + social-connect surfaces into one branch (supersedes #269, #270, and the standard-page-reload-keyboard / replace-section-reaches-footer branches).

## What's in here (5 fixes + tests)
1. **`submit` → path-direct** — the submit action was stranded on the old `endpoint` contract (always undefined now), so every form submit silently no-op'd. Now uses `resolveRequestUrl` + `buildBffHeaders` like `bff_call`/`reload`. (Fixes the KYC "Verify does nothing".)
2. **Button icon rendering** — `icon_left`/`icon_right` (bare specs) rendered via `IconGlyph` instead of being routed through the Interpreter (which crashed on the absent `type`). Plus dev-fallback now surfaces render-error messages.
3. **Standard/sticky pages re-render on section reload** + `keyboardShouldPersistTaps="handled"` so in-page actions fire while the keyboard is open.
4. **`replace_section` reaches header/footer slots** (not just `items`) + `page_footer_with_checkbox` full-width CTA — so the KYC verify step can swap the sticky footer.
5. **Per-instance page store (keyed by `route.key`)** — the store was single-page, so pushing a detail clobbered the feed behind it → permanent skeleton on back. Each navigation instance now keeps its own tree.

## Tests
`submit.test.ts` (4), page-store no-clobber + footer-slot reach tests; full suite: 21 state + 83 handler tests pass. Build green. 5 patch changesets.

Verified on-device: KYC verify→GST list→sticky footer→Submit→kyc/view; home feed card→detail→back (no skeleton); social-connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)