### PR TITLE
fix(sdui-runtime): single-source gutter/gap model + section-header, chip & first-item polish

### DIFF
--- a/.changeset/sdui-gutter-consistency.md
+++ b/.changeset/sdui-gutter-consistency.md
@@ -1,0 +1,11 @@
+---
+"@one-impression/sdui-runtime": patch
+---
+
+Single-source the gutter/gap model across pages and sheets, and refine section-header + chip + first-item spacing:
+
+- Spacing is page-owned: `GutterItem` owns each item's horizontal gutter and vertical inter-item gap (incl. per-type `GAP_OVERRIDES` / extra-top / bottom-reduction), so snippets no longer carry competing margins.
+- Route-based bottom sheet (`SduiSheetScreen`) now wraps its items in `GutterItem`, matching page layouts.
+- First item rule: a full-bleed banner sits flush at the top (`marginTop: 0`); any other first item gets a standard `md` top inset. Applied on pages, feed tabs, and sheets.
+- Section headers: extra `md` top / reduced (`md − sm`) bottom for a clear break that hugs its content; title defaults to semibold.
+- `group_chips`: outer vertical padding removed (`gap` owns inter-row spacing for wrapped rows; outer spacing is the page gutter); scroll inset uses the page gutter token.

--- a/packages/sdui-runtime/src/bottom-sheet/BottomSheetHost.tsx
+++ b/packages/sdui-runtime/src/bottom-sheet/BottomSheetHost.tsx
@@ -7,6 +7,7 @@ import type { BottomSheetModalMethods } from "@gorhom/bottom-sheet/lib/typescrip
 import { useBottomSheetStore, type SheetEntry } from "./useBottomSheetStore.js";
 import { BottomSheetContext } from "./BottomSheetContext.js";
 import { Interpreter } from "../interpreter/Interpreter.js";
+import { GutterItem } from "../layout/page-gutter.js";
 
 const SIZE_TO_SNAP: Record<string, string[]> = {
   small: ["25%"],
@@ -54,8 +55,14 @@ function BottomSheetHostSheet({
     >
       <BottomSheetScrollView>
         <BottomSheetContext.Provider value={{ insideSheet: true }}>
+          {/* Wrap each item in GutterItem so sheet content shares the SAME
+              gutter + inter-item gap model as page layouts (PageStandard /
+              PageStickyFooter). Without this the sheet sat outside the
+              page-gutter system and relied on each snippet's own margins. */}
           {sheet.items.map((node, i) => (
-            <Interpreter key={node.id ?? i} node={node} />
+            <GutterItem key={node.id ?? i} node={node}>
+              <Interpreter node={node} />
+            </GutterItem>
           ))}
         </BottomSheetContext.Provider>
       </BottomSheetScrollView>

--- a/packages/sdui-runtime/src/bottom-sheet/BottomSheetHost.tsx
+++ b/packages/sdui-runtime/src/bottom-sheet/BottomSheetHost.tsx
@@ -7,7 +7,6 @@ import type { BottomSheetModalMethods } from "@gorhom/bottom-sheet/lib/typescrip
 import { useBottomSheetStore, type SheetEntry } from "./useBottomSheetStore.js";
 import { BottomSheetContext } from "./BottomSheetContext.js";
 import { Interpreter } from "../interpreter/Interpreter.js";
-import { GutterItem } from "../layout/page-gutter.js";
 
 const SIZE_TO_SNAP: Record<string, string[]> = {
   small: ["25%"],
@@ -55,14 +54,8 @@ function BottomSheetHostSheet({
     >
       <BottomSheetScrollView>
         <BottomSheetContext.Provider value={{ insideSheet: true }}>
-          {/* Wrap each item in GutterItem so sheet content shares the SAME
-              gutter + inter-item gap model as page layouts (PageStandard /
-              PageStickyFooter). Without this the sheet sat outside the
-              page-gutter system and relied on each snippet's own margins. */}
           {sheet.items.map((node, i) => (
-            <GutterItem key={node.id ?? i} node={node}>
-              <Interpreter node={node} />
-            </GutterItem>
+            <Interpreter key={node.id ?? i} node={node} />
           ))}
         </BottomSheetContext.Provider>
       </BottomSheetScrollView>

--- a/packages/sdui-runtime/src/layout/page-gutter.tsx
+++ b/packages/sdui-runtime/src/layout/page-gutter.tsx
@@ -56,12 +56,22 @@ export const GAP_OVERRIDES: Record<string, SpacingToken> = {
 /**
  * Per-type EXTRA top margin, ADDED on top of `resolveRowGap` (so the margin is
  * asymmetric). For types that should separate more strongly from what precedes
- * them than from their own content below — a section header gets an extra md
+ * them than from their own content below — a section header gets an extra sm
  * above, so a new section reads as a stronger break while the header→content gap
  * below stays the row gap.
  */
 export const GAP_TOP_OVERRIDES: Record<string, SpacingToken> = {
-  "sdui.snippet.section_header": "md",
+  "sdui.snippet.section_header": "sm",
+};
+
+/**
+ * Per-type bottom-margin REDUCTION, SUBTRACTED from `resolveRowGap` (floored at
+ * 0). For types that should hug the content directly below them — a section
+ * header trims its bottom gap by sm so it sits closer to its own section's
+ * content, complementing the extra space GAP_TOP_OVERRIDES gives it above.
+ */
+export const GAP_BOTTOM_REDUCTIONS: Record<string, SpacingToken> = {
+  "sdui.snippet.section_header": "sm",
 };
 
 /** Should this node bleed to the container edges (skip the horizontal gutter)? */
@@ -102,22 +112,57 @@ export function resolveRowGapTop(node: Node): number {
 }
 
 /**
+ * The BOTTOM margin (px): the row gap minus any per-type bottom reduction
+ * (`GAP_BOTTOM_REDUCTIONS`), floored at 0.
+ */
+export function resolveRowGapBottom(node: Node): number {
+  const reduce = GAP_BOTTOM_REDUCTIONS[node.type];
+  const reducePx = reduce !== undefined ? (resolveSpacing(reduce) ?? 0) : 0;
+  return Math.max(0, resolveRowGap(node) - reducePx);
+}
+
+/** Banner snippet type — the first-item flush-top rule keys off this. */
+const BANNER_SNIPPET_TYPE = "sdui.snippet.banner_image";
+// First-item top inset — a standard md gap when the first item isn't a flush
+// full-bleed banner (which gets 0).
+const FIRST_ITEM_TOP = resolveSpacing("md") ?? 12;
+
+/**
+ * Top margin for an item given its position. The FIRST item (index 0) is
+ * special:
+ *  - a full-bleed banner sits FLUSH against the top (0) — a cover image meets
+ *    the screen / nav-header edge with no gap;
+ *  - any other first item gets a standard `md` top inset.
+ * Non-first items use the normal row-gap-top (incl. per-type extra-top override).
+ */
+export function resolveTopMargin(node: Node, index?: number): number {
+  if (index === 0) {
+    if (node.type === BANNER_SNIPPET_TYPE && isFullBleed(node)) return 0;
+    return FIRST_ITEM_TOP;
+  }
+  return resolveRowGapTop(node);
+}
+
+/**
  * Wrap one top-level item in the page's horizontal gutter + vertical margin.
- * The margin is the row gap on both sides, plus any per-type extra-top override
- * (so e.g. a section header sits with more space above than below). Gutter is
- * dropped for full-bleed items. Adjacent items' margins sum (RN doesn't
- * collapse). Page layouts / the sheet call this per item.
+ * Bottom = row gap (minus any per-type reduction); top = `resolveTopMargin`,
+ * which applies the first-item rule when `index` is 0 and otherwise the row-gap
+ * top (incl. per-type extra-top). Gutter is dropped for full-bleed items.
+ * Adjacent items' margins sum (RN doesn't collapse). Page layouts / the sheet
+ * call this per item, passing the item's `index`.
  */
 export function GutterItem({
   node,
+  index,
   children,
 }: {
   node: Node;
+  index?: number;
   children: React.ReactNode;
 }): React.ReactElement {
   const gutter = !isFullBleed(node) && styles.gutter;
-  const bottom = resolveRowGap(node);
-  const top = resolveRowGapTop(node);
+  const bottom = resolveRowGapBottom(node);
+  const top = resolveTopMargin(node, index);
   return (
     <View style={[gutter, { marginTop: top, marginBottom: bottom }]}>
       {children}

--- a/packages/sdui-runtime/src/layout/page-gutter.tsx
+++ b/packages/sdui-runtime/src/layout/page-gutter.tsx
@@ -46,9 +46,12 @@ export const FULL_BLEED_TYPES = new Set<string>([]);
  * breathing more. Use `'none'` to butt against the previous item.
  */
 export const GAP_OVERRIDES: Record<string, SpacingToken> = {
-  // Section headers break sections — give them a full gutter (12) per side
-  // instead of the default 6, so they separate more strongly.
-  "sdui.snippet.section_header": "md",
+  // Section headers break sections — give them a clearly larger gap per side
+  // (xl = 24, so ~30px once an adjacent item's default 6 is added) than the
+  // default 6, so a section reads as a distinct break. This is the single,
+  // page-owned source of section-header spacing now that the snippet no longer
+  // carries its own bottom margin.
+  "sdui.snippet.section_header": "xl",
 };
 
 /** Should this node bleed to the container edges (skip the horizontal gutter)? */

--- a/packages/sdui-runtime/src/layout/page-gutter.tsx
+++ b/packages/sdui-runtime/src/layout/page-gutter.tsx
@@ -53,6 +53,17 @@ export const GAP_OVERRIDES: Record<string, SpacingToken> = {
   "sdui.snippet.section_header": "md",
 };
 
+/**
+ * Per-type EXTRA top margin, ADDED on top of `resolveRowGap` (so the margin is
+ * asymmetric). For types that should separate more strongly from what precedes
+ * them than from their own content below — a section header gets an extra md
+ * above, so a new section reads as a stronger break while the header→content gap
+ * below stays the row gap.
+ */
+export const GAP_TOP_OVERRIDES: Record<string, SpacingToken> = {
+  "sdui.snippet.section_header": "md",
+};
+
 /** Should this node bleed to the container edges (skip the horizontal gutter)? */
 export function isFullBleed(node: Node): boolean {
   const flag = (node as { full_bleed?: unknown }).full_bleed;
@@ -79,10 +90,23 @@ export function resolveRowGap(node: Node): number {
 }
 
 /**
- * Wrap one top-level item in the page's horizontal gutter + symmetric vertical
- * margin (both sides). Gutter is dropped for full-bleed items. Adjacent items'
- * margins sum (RN doesn't collapse), so default items sit a full gutter apart
- * and the page edges get the half. Page layouts / the sheet call this per item.
+ * The TOP margin (px) for this item: the row gap (`resolveRowGap`) plus any
+ * per-type extra-top override (`GAP_TOP_OVERRIDES`). The bottom margin stays
+ * `resolveRowGap`, so types like the section header sit asymmetrically — more
+ * space above than below.
+ */
+export function resolveRowGapTop(node: Node): number {
+  const extra = GAP_TOP_OVERRIDES[node.type];
+  const extraPx = extra !== undefined ? (resolveSpacing(extra) ?? 0) : 0;
+  return resolveRowGap(node) + extraPx;
+}
+
+/**
+ * Wrap one top-level item in the page's horizontal gutter + vertical margin.
+ * The margin is the row gap on both sides, plus any per-type extra-top override
+ * (so e.g. a section header sits with more space above than below). Gutter is
+ * dropped for full-bleed items. Adjacent items' margins sum (RN doesn't
+ * collapse). Page layouts / the sheet call this per item.
  */
 export function GutterItem({
   node,
@@ -92,6 +116,11 @@ export function GutterItem({
   children: React.ReactNode;
 }): React.ReactElement {
   const gutter = !isFullBleed(node) && styles.gutter;
-  const v = resolveRowGap(node);
-  return <View style={[gutter, { marginTop: v, marginBottom: v }]}>{children}</View>;
+  const bottom = resolveRowGap(node);
+  const top = resolveRowGapTop(node);
+  return (
+    <View style={[gutter, { marginTop: top, marginBottom: bottom }]}>
+      {children}
+    </View>
+  );
 }

--- a/packages/sdui-runtime/src/layout/page-gutter.tsx
+++ b/packages/sdui-runtime/src/layout/page-gutter.tsx
@@ -46,12 +46,11 @@ export const FULL_BLEED_TYPES = new Set<string>([]);
  * breathing more. Use `'none'` to butt against the previous item.
  */
 export const GAP_OVERRIDES: Record<string, SpacingToken> = {
-  // Section headers break sections — give them a clearly larger gap per side
-  // (xl = 24, so ~30px once an adjacent item's default 6 is added) than the
-  // default 6, so a section reads as a distinct break. This is the single,
+  // Section headers break sections — give them a full gutter (md = 12) per side
+  // instead of the default 6, so they separate more strongly. This is the single,
   // page-owned source of section-header spacing now that the snippet no longer
   // carries its own bottom margin.
-  "sdui.snippet.section_header": "xl",
+  "sdui.snippet.section_header": "md",
 };
 
 /** Should this node bleed to the container edges (skip the horizontal gutter)? */

--- a/packages/sdui-runtime/src/navigation/SduiSheetScreen.tsx
+++ b/packages/sdui-runtime/src/navigation/SduiSheetScreen.tsx
@@ -8,8 +8,10 @@ import BottomSheet, {
   type BottomSheetFooterProps,
 } from "@gorhom/bottom-sheet";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { resolveSpacing } from "@one-impression/ui-native";
 import type { Action, Node } from "@one-impression/sdk-native-sdui";
 import { Interpreter } from "../interpreter/index.js";
+import { GutterItem, PAGE_GUTTER_TOKEN } from "../layout/page-gutter.js";
 import { useActionEngine } from "../action-engine/useActionEngine.js";
 import { useBffConfig } from "../action-engine/useBffConfig.js";
 import { BottomSheetContext } from "../bottom-sheet/BottomSheetContext.js";
@@ -243,16 +245,26 @@ export function SduiSheetScreen({
             {sheet.header ? <Interpreter node={sheet.header} /> : null}
             <BottomSheetScrollView
               contentContainerStyle={[
-                styles.content,
+                // No horizontal padding here — each item's GutterItem owns the
+                // page gutter, so sheet content aligns with page layouts.
+                styles.scrollBody,
                 // Reserve room so the last item isn't hidden behind the pinned footer.
                 sheet.footer && styles.contentWithFooter,
               ]}
             >
               {!sheet.header && sheet.title ? (
-                <Text style={styles.title}>{sheet.title}</Text>
+                <Text style={[styles.title, styles.titleInset]}>
+                  {sheet.title}
+                </Text>
               ) : null}
+              {/* Wrap each item in GutterItem so sheet content shares the page's
+                  gutter + inter-item gap model (incl. the section_header
+                  GAP_OVERRIDES). The route-based sheet was outside that system,
+                  so its section headers got no vertical gap. */}
               {sheet.items.map((node, i) => (
-                <Interpreter key={node.id ?? i} node={node} />
+                <GutterItem key={node.id ?? i} node={node}>
+                  <Interpreter node={node} />
+                </GutterItem>
               ))}
             </BottomSheetScrollView>
           </>
@@ -262,9 +274,16 @@ export function SduiSheetScreen({
   );
 }
 
+const PAGE_GUTTER_PX = resolveSpacing(PAGE_GUTTER_TOKEN) ?? 12;
+
 const styles = StyleSheet.create({
-  content: { paddingHorizontal: 16, paddingBottom: 32 },
+  // Loading branch — skeleton/title/subtitle aren't GutterItem-wrapped, so inset
+  // them at the page gutter to match the loaded content's alignment.
+  content: { paddingHorizontal: PAGE_GUTTER_PX, paddingBottom: 32 },
+  // Loaded content branch — each item's GutterItem owns the horizontal inset.
+  scrollBody: { paddingBottom: 32 },
   contentWithFooter: { paddingBottom: 96 },
   title: { fontSize: 18, fontWeight: "700", paddingTop: 12 },
+  titleInset: { paddingHorizontal: PAGE_GUTTER_PX },
   subtitle: { fontSize: 13, color: "#666", paddingBottom: 8 },
 });

--- a/packages/sdui-runtime/src/navigation/SduiSheetScreen.tsx
+++ b/packages/sdui-runtime/src/navigation/SduiSheetScreen.tsx
@@ -262,7 +262,7 @@ export function SduiSheetScreen({
                   GAP_OVERRIDES). The route-based sheet was outside that system,
                   so its section headers got no vertical gap. */}
               {sheet.items.map((node, i) => (
-                <GutterItem key={node.id ?? i} node={node}>
+                <GutterItem key={node.id ?? i} node={node} index={i}>
                   <Interpreter node={node} />
                 </GutterItem>
               ))}

--- a/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageFeed/PageFeed.renderer.tsx
@@ -84,8 +84,8 @@ export function PageFeedRenderer({ page }: PageProps): React.ReactElement {
   ).current;
 
   const renderItem = useCallback(
-    ({ item }: { item: Node }) => (
-      <GutterItem node={item}>
+    ({ item, index }: { item: Node; index: number }) => (
+      <GutterItem node={item} index={index}>
         <Interpreter node={item} />
       </GutterItem>
     ),

--- a/packages/sdui-runtime/src/pages/PageStandard/PageStandard.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageStandard/PageStandard.renderer.tsx
@@ -129,7 +129,7 @@ export function PageStandardRenderer({ page }: PageProps): React.ReactElement {
         }
       >
         {livePage.items.map((node, i) => (
-          <GutterItem key={node.id ?? `item-${i}`} node={node}>
+          <GutterItem key={node.id ?? `item-${i}`} node={node} index={i}>
             <Interpreter node={node} />
           </GutterItem>
         ))}

--- a/packages/sdui-runtime/src/pages/PageStickyFooter/PageStickyFooter.renderer.tsx
+++ b/packages/sdui-runtime/src/pages/PageStickyFooter/PageStickyFooter.renderer.tsx
@@ -143,7 +143,7 @@ export function PageStickyFooterRenderer({
       }
     >
       {livePage.items.map((node, i) => (
-        <GutterItem key={node.id ?? `item-${i}`} node={node}>
+        <GutterItem key={node.id ?? `item-${i}`} node={node} index={i}>
           <Interpreter node={node} />
         </GutterItem>
       ))}

--- a/packages/sdui-runtime/src/snippets/GroupChips/GroupChips.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/GroupChips/GroupChips.renderer.tsx
@@ -1,9 +1,17 @@
 import React from "react";
 import { ScrollView, StyleSheet, View } from "react-native";
+import { resolveSpacing } from "@one-impression/ui-native";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { GroupChipsSchema } from "@one-impression/sdk-native-sdui";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
+import { PAGE_GUTTER_TOKEN } from "../../layout/page-gutter.js";
+
+// A full-bleed scroll row opts out of the page's GutterItem, so it must supply
+// its own leading/trailing inset — but at the SAME value the page gutter uses,
+// so the first chip aligns with every other (gutter-wrapped) snippet. Source it
+// from the shared page-gutter token rather than a standalone number.
+const PAGE_GUTTER_PX = resolveSpacing(PAGE_GUTTER_TOKEN) ?? 12;
 
 export function GroupChipsRenderer(node: Node): React.ReactElement {
   return (
@@ -59,7 +67,8 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     // Leading/trailing inset so the first/last chip don't sit flush against the
     // screen edge. A horizontal scroll row is typically caller-gutter-less (it
-    // scrolls edge-to-edge), so the inset lives on the scroll content itself.
-    paddingHorizontal: 16,
+    // scrolls edge-to-edge), so the inset lives on the scroll content itself —
+    // at the page gutter value so it aligns with gutter-wrapped snippets.
+    paddingHorizontal: PAGE_GUTTER_PX,
   },
 });

--- a/packages/sdui-runtime/src/snippets/GroupChips/GroupChips.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/GroupChips/GroupChips.renderer.tsx
@@ -55,16 +55,18 @@ export function GroupChipsRenderer(node: Node): React.ReactElement {
 }
 
 const styles = StyleSheet.create({
+  // No outer vertical padding — the chip block's outer vertical spacing is owned
+  // by the page gutter (GutterItem row gap). `gap` provides the spacing BETWEEN
+  // chips; for the wrap variant RN applies it as the row gap between wrapped
+  // lines too (sm = 8), so multi-row chip groups keep vertical breathing room.
   wrapRow: {
     flexDirection: "row",
     flexWrap: "wrap",
     gap: 8,
-    paddingVertical: 8,
   },
   scrollRow: {
     flexDirection: "row",
     gap: 8,
-    paddingVertical: 8,
     // Leading/trailing inset so the first/last chip don't sit flush against the
     // screen edge. A horizontal scroll row is typically caller-gutter-less (it
     // scrolls edge-to-edge), so the inset lives on the scroll content itself —

--- a/packages/sdui-runtime/src/snippets/SectionHeader/SectionHeader.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/SectionHeader/SectionHeader.renderer.tsx
@@ -30,7 +30,7 @@ export function SectionHeaderRenderer(node: Node): React.ReactElement {
               <Text
                 color={v.title.color}
                 size={v.title.font_size ?? "lg"}
-                weight={v.title.font_weight}
+                weight={v.title.font_weight ?? "sdui.font-weight.semibold"}
               >
                 {v.title.text}
               </Text>

--- a/packages/sdui-runtime/src/snippets/SectionHeader/SectionHeader.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/SectionHeader/SectionHeader.renderer.tsx
@@ -19,7 +19,12 @@ export function SectionHeaderRenderer(node: Node): React.ReactElement {
       load_events={node.load_events}
     >
       {(v) => (
-        <Box mb="md">
+        // No own bottom margin — vertical spacing is owned by the container's
+        // gutter system (the page layout / bottom sheet wrap each item in
+        // `GutterItem`, which applies `GAP_OVERRIDES["sdui.snippet.section_header"]`).
+        // Keeping it here too would double the gap on pages and leave the snippet
+        // as a second, competing source of truth.
+        <Box>
           <Stack direction="row" align="center" justify="space-between">
             <Stack direction="column" gap={2}>
               <Text


### PR DESCRIPTION
Single-sources the SDUI spacing model in the runtime so pages **and** the route-based bottom sheet derive gutter + inter-item gap from one place (`GutterItem`), and refines section-header / chip / first-item spacing.

## What changed
- **Gutter/gap is page-owned** — `GutterItem` owns horizontal gutter + vertical inter-item gap (incl. per-type `GAP_OVERRIDES`, extra-top, and bottom-reduction). Snippets stop carrying competing margins.
- **Route-based sheet** (`SduiSheetScreen`) wraps items in `GutterItem`, matching `PageStandard` / `PageStickyFooter`.
- **First-item rule** — a full-bleed banner at index 0 sits flush (`marginTop: 0`); any other first item gets a standard `md` top inset. Wired through `PageStandard`, `PageStickyFooter`, `PageFeed`, and `SduiSheetScreen` (each passes the item `index`).
- **Section headers** — extra `md` top / reduced (`md − sm`) bottom so a section reads as a clear break that hugs its content; title defaults to semibold.
- **group_chips** — outer vertical padding removed (`gap` owns wrapped-row spacing; outer spacing is the page gutter); scroll inset uses the page gutter token.

Changeset included → publishes `@one-impression/sdui-runtime@4.0.2` (patch).

Verified on-device (creator app, staging-shaped mock) across the campaign detail page, feed tabs, and the apply sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)