### PR TITLE
feat(sdui): creator form primitives — date_input, show_when, select_trigger, horizontal select, Input fixes

### DIFF
--- a/.changeset/creator-form-primitives.md
+++ b/.changeset/creator-form-primitives.md
@@ -1,0 +1,11 @@
+---
+"@one-impression/sdui-runtime": minor
+"@one-impression/ui-native": minor
+---
+
+Form primitives for multi-field creator forms:
+
+- **`DateField` (ui-native)** — a tappable date input with a self-contained, pure-JS calendar popover (month grid + year list, no native date-picker module), so it renders in any RN/Expo client without a prebuild. ISO `YYYY-MM-DD` value, min/max bounds.
+- **`date_input` renderer (sdui-runtime)** — form-store-bound date field over `DateField`; the data schema is renderer-owned (emitted as raw wire, like the form `submit` action and `validations`).
+- **`show_when` conditional visibility (sdui-runtime)** — a base-node rule (`{ field, equals | not_equals | in | truthy }`) evaluated against a sibling field in the same form; the gated node renders only while the rule holds, and a hidden form field is dropped from validation so it can't block submit. Wired at the interpreter via `ConditionalGate`.
+- **Tab icon fix (sdui-runtime)** — `Tab.renderer` now renders its icon through `IconGlyph` (was a bare `DSIcon` with no glyph child), so footer tab icons resolve from the icon manifest.

--- a/.changeset/creator-form-primitives.md
+++ b/.changeset/creator-form-primitives.md
@@ -3,9 +3,15 @@
 "@one-impression/ui-native": minor
 ---
 
-Form primitives for multi-field creator forms:
+Form primitives + fixes for multi-field creator forms:
 
-- **`DateField` (ui-native)** — a tappable date input with a self-contained, pure-JS calendar popover (month grid + year list, no native date-picker module), so it renders in any RN/Expo client without a prebuild. ISO `YYYY-MM-DD` value, min/max bounds.
-- **`date_input` renderer (sdui-runtime)** — form-store-bound date field over `DateField`; the data schema is renderer-owned (emitted as raw wire, like the form `submit` action and `validations`).
-- **`show_when` conditional visibility (sdui-runtime)** — a base-node rule (`{ field, equals | not_equals | in | truthy }`) evaluated against a sibling field in the same form; the gated node renders only while the rule holds, and a hidden form field is dropped from validation so it can't block submit. Wired at the interpreter via `ConditionalGate`.
-- **Tab icon fix (sdui-runtime)** — `Tab.renderer` now renders its icon through `IconGlyph` (was a bare `DSIcon` with no glyph child), so footer tab icons resolve from the icon manifest.
+**New**
+- **`DateField` (ui-native)** + **`date_input` (sdui-runtime)** — a form-bound date field backed by a self-contained pure-JS calendar popover (month grid + year list, no native module). ISO `YYYY-MM-DD` value, min/max bounds.
+- **`show_when` conditional visibility (sdui-runtime)** — a base-node rule (`{ field, equals | not_equals | in | truthy }`) evaluated against a sibling field; the gated node renders only while the rule holds, and a hidden form field drops out of validation. Wired at the interpreter via `ConditionalGate`.
+- **`single_select_input` `layout: "horizontal"` (sdui-runtime)** — lays the radio options out as equal-width columns in a row (default stays vertical).
+
+**Fixes**
+- **`Tab.renderer`** renders its icon via `IconGlyph` (was a bare `DSIcon` with no glyph child), so footer tab icons resolve from the manifest.
+- **`Form.renderer`** renders the raw field nodes (not the schema-parsed `v.fields`), preserving per-field wire extensions like `show_when`.
+- **`select_trigger`** renders as an input-styled, tap-to-open field (label + bordered box + value/placeholder + chevron) and shows multi-select (`string[]`) values via `value_display`.
+- **`Input` floating label** — the real placeholder shows only once the label floats (empty + resting no longer overlaps the placeholder); tapping the resting label now focuses the field (the label is a pressable that focuses the input). Inputs gain a small `sm` top margin.

--- a/packages/sdui-runtime/src/interpreter/ConditionalGate.tsx
+++ b/packages/sdui-runtime/src/interpreter/ConditionalGate.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, type ComponentType } from "react";
+import type { Node } from "@one-impression/sdk-native-sdui";
+import { useFormStore } from "../state/useFormStore.js";
+import { useFormId } from "../form/index.js";
+import { evaluateShowWhen, type ShowWhen } from "./show-when.js";
+
+/**
+ * Gates a node's render on its `show_when` rule (see {@link evaluateShowWhen}).
+ * Mounted by the Interpreter ONLY for nodes that carry `show_when`, so the
+ * form-store subscription is paid only where conditional visibility is used.
+ *
+ * When the node is a form field and becomes hidden, its error is cleared so a
+ * stale (e.g. `required`) error can't block the form's validity gate — the
+ * hidden field simply drops out of validation. The value is left intact, so
+ * toggling the field back on restores what the user had typed.
+ */
+export function ConditionalGate({
+  node,
+  Renderer,
+}: {
+  node: Node;
+  Renderer: ComponentType<Node>;
+}): React.ReactElement | null {
+  const rule = (node as { show_when?: ShowWhen }).show_when as ShowWhen;
+  const explicitFormId =
+    rule.form_id ?? (node.data as { form_id?: string } | undefined)?.form_id;
+  const formId = useFormId(explicitFormId);
+
+  const controllingValue = useFormStore((s) =>
+    formId ? s.forms[formId]?.values[rule.field] : undefined,
+  );
+  const setErrors = useFormStore((s) => s.setErrors);
+
+  // Fail open: can't resolve the form → show the field rather than hide it.
+  const visible = formId ? evaluateShowWhen(rule, controllingValue) : true;
+
+  const fieldName = (node.data as { field_name?: string } | undefined)?.field_name;
+  useEffect(() => {
+    if (!visible && formId && fieldName) {
+      setErrors(formId, { [fieldName]: null });
+    }
+  }, [visible, formId, fieldName, setErrors]);
+
+  if (!visible) return null;
+  return <Renderer {...node} />;
+}

--- a/packages/sdui-runtime/src/interpreter/Interpreter.tsx
+++ b/packages/sdui-runtime/src/interpreter/Interpreter.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { resolveRenderer } from "../registries/node-registry.js";
 import { Fallback } from "./Fallback.js";
+import { ConditionalGate } from "./ConditionalGate.js";
 
 interface InterpreterProps {
   node: Node;
@@ -10,13 +11,22 @@ interface InterpreterProps {
 /**
  * The SDUI dispatcher. Reads node.type, looks up the renderer
  * from registries, falls back to <Fallback> on unknown types.
+ *
+ * A node carrying `show_when` is wrapped in <ConditionalGate>, which renders it
+ * only while its rule holds (and drops a hidden form field out of validation).
+ * Whether a node has `show_when` is a stable wire property, so the branch is
+ * consistent across renders — the gate's hooks mount only where needed.
  */
 export function Interpreter({ node }: InterpreterProps): React.ReactElement {
   const Renderer = resolveRenderer(node.type);
 
-  if (Renderer) {
-    return <Renderer {...node} />;
+  if (!Renderer) {
+    return <Fallback type={node.type} />;
   }
 
-  return <Fallback type={node.type} />;
+  if ((node as { show_when?: unknown }).show_when) {
+    return <ConditionalGate node={node} Renderer={Renderer} />;
+  }
+
+  return <Renderer {...node} />;
 }

--- a/packages/sdui-runtime/src/interpreter/show-when.ts
+++ b/packages/sdui-runtime/src/interpreter/show-when.ts
@@ -1,0 +1,43 @@
+import type { FormFieldValue } from "../state/useFormStore.js";
+
+/**
+ * `show_when` — a base-node visibility rule evaluated against another field's
+ * value in the SAME form. Lets the wire hide/show a node based on form state
+ * (e.g. hide the WhatsApp-number field while the "same as my phone" toggle is
+ * on) without a server round-trip. Read raw off the node (a wire extension, like
+ * `full_bleed`); the gateway emits it, the interpreter honours it.
+ *
+ * Exactly one predicate is expected; checked in priority order. An empty/unknown
+ * rule resolves to visible (fail-open — never hide a field on a malformed rule).
+ */
+export interface ShowWhen {
+  /** Controlling field's `field_name` (same form). */
+  field: string;
+  /** Form id; falls back to the node's / enclosing form's id when omitted. */
+  form_id?: string;
+  /** Visible when the controlling value strictly equals this. */
+  equals?: FormFieldValue;
+  /** Visible when the controlling value does NOT equal this. */
+  not_equals?: FormFieldValue;
+  /** Visible when the controlling value is one of these. */
+  in?: FormFieldValue[];
+  /** Visible when the controlling value is truthy (`true`) / falsy (`false`). */
+  truthy?: boolean;
+}
+
+export function evaluateShowWhen(
+  rule: ShowWhen,
+  value: FormFieldValue | undefined,
+): boolean {
+  // `hasOwnProperty` (not a truthiness check) so `equals: false` / `equals: 0`
+  // are honoured as real predicates rather than skipped.
+  if (Object.prototype.hasOwnProperty.call(rule, "equals")) {
+    return value === rule.equals;
+  }
+  if (Object.prototype.hasOwnProperty.call(rule, "not_equals")) {
+    return value !== rule.not_equals;
+  }
+  if (rule.in) return rule.in.includes(value as FormFieldValue);
+  if (rule.truthy !== undefined) return rule.truthy ? !!value : !value;
+  return true;
+}

--- a/packages/sdui-runtime/src/registries/snippets.ts
+++ b/packages/sdui-runtime/src/registries/snippets.ts
@@ -53,6 +53,7 @@ import { InputRenderer } from "../snippets/Input/index.js";
 import { ToggleInputRenderer } from "../snippets/ToggleInput/index.js";
 import { SingleSelectInputRenderer } from "../snippets/SingleSelectInput/index.js";
 import { MultiSelectInputRenderer } from "../snippets/MultiSelectInput/index.js";
+import { DateInputRenderer } from "../snippets/DateInput/index.js";
 import { UploadFileRenderer } from "../snippets/UploadFile/index.js";
 
 // Chip
@@ -117,6 +118,7 @@ export const snippetRegistry: Record<string, (node: Node) => React.ReactElement>
   "sdui.snippet.toggle_input": ToggleInputRenderer,
   "sdui.snippet.single_select_input": SingleSelectInputRenderer,
   "sdui.snippet.multi_select_input": MultiSelectInputRenderer,
+  "sdui.snippet.date_input": DateInputRenderer,
   "sdui.snippet.upload_file": UploadFileRenderer,
 
   // Chip (1)

--- a/packages/sdui-runtime/src/snippets/DateInput/DateInput.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/DateInput/DateInput.renderer.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { z } from "zod";
+import type { Node } from "@one-impression/sdk-native-sdui";
+import { DateField } from "@one-impression/ui-native";
+import { SduiNode } from "../../sdui-node/index.js";
+import { useFormField, useFormId } from "../../form/index.js";
+import type { ValidationRule } from "../../validation/index.js";
+
+/**
+ * `date_input` — a form-bound date field. Renders the ui-native `DateField`
+ * (a pure-JS calendar popover, no native module) and binds its ISO `YYYY-MM-DD`
+ * value into `useFormStore` by `(form_id, field_name)`, exactly like the text /
+ * select inputs. The data schema is defined here (renderer-owned) rather than in
+ * `sdk-native-sdui`, so the gateway emits it as raw wire — the same posture the
+ * form `submit` action and `validations` already use.
+ */
+const LabelSchema = z
+  .object({
+    text: z.string().optional(),
+    color: z.string().optional(),
+    font_size: z.number().optional(),
+    font_weight: z.string().optional(),
+  })
+  .passthrough();
+
+export const DateInputDataSchema = z
+  .object({
+    form_id: z.string().optional(),
+    field_name: z.string().optional(),
+    /** ISO `YYYY-MM-DD` default. */
+    value: z.string().optional(),
+    label: LabelSchema.optional(),
+    placeholder: z.object({ text: z.string().optional() }).passthrough().optional(),
+    required: z.boolean().optional(),
+    disabled: z.boolean().optional(),
+    /** ISO `YYYY-MM-DD` selectable bounds. */
+    min_date: z.string().optional(),
+    max_date: z.string().optional(),
+    // Validation rules are evaluated by useFormField; kept loose here (the rule
+    // shape lives in the validation module, read raw off the wire).
+    validations: z.array(z.any()).optional(),
+  })
+  .passthrough();
+
+export function DateInputRenderer(node: Node): React.ReactElement {
+  // Form binding reads the raw wire (form_id / field_name / validations), the
+  // same split the other input renderers use; presentation reads the parsed `v`.
+  const data = node.data as
+    | { form_id?: string; field_name?: string; value?: string; validations?: ValidationRule[] }
+    | undefined;
+  const formId = useFormId(data?.form_id);
+  const field = useFormField<string>(
+    formId,
+    data?.field_name,
+    data?.value ?? "",
+    data?.validations,
+  );
+  const errorText = field.touched ? field.error ?? undefined : undefined;
+
+  return (
+    <SduiNode
+      data={node.data}
+      schema={DateInputDataSchema}
+      id={node.id}
+      on_load={node.on_load}
+      on_view={node.on_view}
+      on_dismount={node.on_dismount}
+      view_events={node.view_events}
+      load_events={node.load_events}
+    >
+      {(v) => (
+        <DateField
+          label={
+            v.label?.text ? `${v.label.text}${v.required ? " *" : ""}` : undefined
+          }
+          value={field.value || undefined}
+          placeholder={v.placeholder?.text}
+          error={!!errorText}
+          helperText={errorText}
+          disabled={v.disabled}
+          minDate={v.min_date}
+          maxDate={v.max_date}
+          onOpen={field.markTouched}
+          onChange={field.setValue}
+        />
+      )}
+    </SduiNode>
+  );
+}

--- a/packages/sdui-runtime/src/snippets/DateInput/index.ts
+++ b/packages/sdui-runtime/src/snippets/DateInput/index.ts
@@ -1,0 +1,1 @@
+export { DateInputRenderer, DateInputDataSchema } from "./DateInput.renderer.js";

--- a/packages/sdui-runtime/src/snippets/Form/Form.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/Form/Form.renderer.tsx
@@ -51,12 +51,24 @@ export function FormRenderer(node: Node): React.ReactElement {
       view_events={node.view_events}
       load_events={node.load_events}
     >
-      {(v) => (
-        // Provide the form id to nested fields (id-only; state lives in the store).
-        <FormIdContext.Provider value={formId}>
-          <FormInner fields={v.fields} submitButton={v.submit_button} />
-        </FormIdContext.Provider>
-      )}
+      {(v) => {
+        // Render the RAW field nodes, not the schema-parsed `v.fields`: the
+        // FormSchema strips per-field wire extensions (e.g. `show_when`) that
+        // the Interpreter needs to gate visibility. Each field is still
+        // validated by its own renderer's SduiNode, so nothing is lost.
+        const rawData = node.data as
+          | { fields?: Node[]; submit_button?: Node }
+          | undefined;
+        return (
+          // Provide the form id to nested fields (id-only; state lives in the store).
+          <FormIdContext.Provider value={formId}>
+            <FormInner
+              fields={rawData?.fields ?? v.fields}
+              submitButton={rawData?.submit_button ?? v.submit_button}
+            />
+          </FormIdContext.Provider>
+        );
+      }}
     </SduiNode>
   );
 }

--- a/packages/sdui-runtime/src/snippets/SingleSelectInput/SingleSelectInput.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/SingleSelectInput/SingleSelectInput.renderer.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from "react";
+import { View } from "react-native";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { SingleSelectInputSchema } from "@one-impression/sdk-native-sdui";
 import { Box, Stack, Text, SelectableItem as DSSelectableItem } from "@one-impression/ui-native";
@@ -17,7 +18,15 @@ interface OptionData {
 
 export function SingleSelectInputRenderer(node: Node): React.ReactElement {
   const data = node.data as
-    | { form_id?: string; field_name?: string; selected_value?: string; validations?: ValidationRule[] }
+    | {
+        form_id?: string;
+        field_name?: string;
+        selected_value?: string;
+        validations?: ValidationRule[];
+        /** "horizontal" lays the options out as equal-width columns in a row;
+         *  default (unset) stacks them vertically. Read raw (wire extension). */
+        layout?: string;
+      }
     | undefined;
   const formId = useFormId(data?.form_id);
   const field = useFormField<string>(
@@ -51,6 +60,7 @@ export function SingleSelectInputRenderer(node: Node): React.ReactElement {
           onSelect={(value) => field.setValue(value)}
           onTouched={field.markTouched}
           onChange={node.data?.on_change}
+          layout={data?.layout}
         />
       )}
     </SduiNode>
@@ -67,6 +77,7 @@ function SingleSelectInputInner({
   onSelect,
   onTouched,
   onChange,
+  layout,
 }: {
   label?: { text?: string; color?: string; font_size?: number; font_weight?: string };
   options: Node[];
@@ -80,8 +91,11 @@ function SingleSelectInputInner({
   onSelect: (value: string) => void;
   onTouched: () => void;
   onChange?: unknown;
+  /** "horizontal" → equal-width columns in a row; default stacks vertically. */
+  layout?: string;
 }): React.ReactElement {
   const actionEngine = useActionEngine();
+  const horizontal = layout === "horizontal" || layout === "row";
 
   // Render the selectable options directly (rather than via the generic
   // Interpreter) so selection is store-driven: `selected` is computed from the
@@ -106,12 +120,11 @@ function SingleSelectInputInner({
           {label.text}{required ? " *" : ""}
         </Text>
       )}
-      <Stack direction="column" gap={8}>
+      <Stack direction={horizontal ? "row" : "column"} gap={8}>
         {options?.map((option: Node, i: number) => {
           const o = (option.data ?? {}) as unknown as OptionData;
-          return (
+          const item = (
             <DSSelectableItem
-              key={option.id || o.value || i}
               label={o.label?.text ?? o.value}
               description={o.subtitle?.text}
               selected={selectedValue === o.value}
@@ -120,6 +133,16 @@ function SingleSelectInputInner({
               rounded="md"
               onPress={() => handlePress(o.value)}
             />
+          );
+          // Horizontal: each option flexes to an equal-width column.
+          return horizontal ? (
+            <View key={option.id || o.value || i} style={{ flex: 1 }}>
+              {item}
+            </View>
+          ) : (
+            <React.Fragment key={option.id || o.value || i}>
+              {item}
+            </React.Fragment>
           );
         })}
       </Stack>

--- a/packages/sdui-runtime/src/ui_components/SelectTrigger/SelectTrigger.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/SelectTrigger/SelectTrigger.renderer.tsx
@@ -1,19 +1,24 @@
 import React from "react";
-import { Pressable } from "react-native";
+import { Pressable, StyleSheet, Text as RNText, View } from "react-native";
 import type { Node } from "@one-impression/sdk-native-sdui";
-import { Stack, Text, Icon as DSIcon } from "@one-impression/ui-native";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";
 import { useFormField, useFormId } from "../../form/index.js";
 
 /**
- * select_trigger — a generic, form-aware dropdown trigger. Displays the current
- * value of a form field (optionally mapped to a rich label via `value_display`)
- * and fires its `on_click` (typically a `sheet` action that opens a picker whose
- * body is a `single_select_input` bound to the SAME field). No picker logic of
- * its own — presentation + options are 100% wire/BFF-driven. Reusable for any
- * field (country, currency, timezone, …).
+ * select_trigger — a generic, form-aware picker trigger styled as a read-only
+ * INPUT. It looks like a text field (label + bordered box + value/placeholder +
+ * chevron) but it has NO editing behaviour: tapping anywhere fires its
+ * `on_click` (typically a `sheet` action that opens a picker whose body is a
+ * single/multi `*_select_input` bound to the SAME field) instead of focusing a
+ * keyboard. It displays the current value of its form field (single-select →
+ * string, multi-select → string[], each id mapped via `value_display`).
  *
- * Wire `data`: { form_id, field_name, default_value?, value_display?, trailing_icon?, placeholder? }
+ * This is the "input with a custom click action, default input behaviour
+ * suppressed" pattern: same visual grammar as `Input` / `DateField`, but a tap
+ * is an action, not a focus.
+ *
+ * Wire `data`: { form_id, field_name, label?, default_value?, value_display?,
+ *                placeholder?, required? }
  * A runtime node type (not yet in the SDK) — read raw; promote with the rest.
  */
 export function SelectTriggerRenderer(node: Node): React.ReactElement {
@@ -21,10 +26,11 @@ export function SelectTriggerRenderer(node: Node): React.ReactElement {
     | {
         form_id?: string;
         field_name?: string;
+        label?: { text?: string };
         default_value?: string;
         value_display?: Record<string, string>;
-        trailing_icon?: string;
         placeholder?: string;
+        required?: boolean;
       }
     | undefined;
 
@@ -36,28 +42,55 @@ export function SelectTriggerRenderer(node: Node): React.ReactElement {
   );
   const actionEngine = useActionEngine();
 
-  // The bound value is a string for single-select fields, a string[] for
-  // multi-select. Map each id to its rich label via `value_display` and join;
-  // fall back to the placeholder when empty.
+  // Single-select → string, multi-select → string[]. Map each id to its rich
+  // label via `value_display`; an empty value renders the placeholder (greyed).
   const mapLabel = (v: string): string => data?.value_display?.[v] ?? v;
   const value = field.value;
-  const display = Array.isArray(value)
-    ? value.length
-      ? value.map(mapLabel).join(", ")
-      : data?.placeholder ?? ""
-    : mapLabel(value) || data?.placeholder || "";
+  const selectedText = Array.isArray(value)
+    ? value.map(mapLabel).join(", ")
+    : mapLabel(value);
+  const isEmpty = Array.isArray(value) ? value.length === 0 : !value;
+
+  const labelText = data?.label?.text
+    ? `${data.label.text}${data?.required ? " *" : ""}`
+    : undefined;
 
   return (
-    <Pressable
-      onPress={() => node.on_click && actionEngine.dispatch(node.on_click)}
-      hitSlop={6}
-    >
-      <Stack direction="row" align="center" gap={4}>
-        <Text size={14} color="#222">{display}</Text>
-        {data?.trailing_icon ? (
-          <DSIcon name={data.trailing_icon} size={14} color="#999" />
-        ) : null}
-      </Stack>
-    </Pressable>
+    <View style={styles.container}>
+      {labelText ? <RNText style={styles.label}>{labelText}</RNText> : null}
+      <Pressable
+        onPress={() => node.on_click && actionEngine.dispatch(node.on_click)}
+        style={styles.field}
+      >
+        <RNText
+          style={[styles.value, isEmpty && styles.placeholder]}
+          numberOfLines={1}
+        >
+          {isEmpty ? data?.placeholder ?? "Select" : selectedText}
+        </RNText>
+        <RNText style={styles.chevron}>▾</RNText>
+      </Pressable>
+    </View>
   );
 }
+
+// Mirrors the ui-native Input / DateField field styling so a select trigger
+// sits flush with the text inputs around it in a form.
+const styles = StyleSheet.create({
+  container: { width: "100%" },
+  label: { fontSize: 13, color: "#57534E", marginBottom: 6 },
+  field: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    borderWidth: 1,
+    borderColor: "#D6D3D1",
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    backgroundColor: "#FFFFFF",
+  },
+  value: { flex: 1, fontSize: 14, color: "#1C1917" },
+  placeholder: { color: "#78716C" },
+  chevron: { fontSize: 14, color: "#78716C", marginLeft: 8 },
+});

--- a/packages/sdui-runtime/src/ui_components/SelectTrigger/SelectTrigger.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/SelectTrigger/SelectTrigger.renderer.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Pressable, StyleSheet, Text as RNText, View } from "react-native";
+import { sdui } from "@one-impression/tokens-creator/react-native";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";
 import { useFormField, useFormId } from "../../form/index.js";
@@ -78,19 +79,19 @@ export function SelectTriggerRenderer(node: Node): React.ReactElement {
 // sits flush with the text inputs around it in a form.
 const styles = StyleSheet.create({
   container: { width: "100%" },
-  label: { fontSize: 13, color: "#57534E", marginBottom: 6 },
+  label: { fontSize: 13, color: sdui.color.neutralMedium, marginBottom: 6 },
   field: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
     borderWidth: 1,
-    borderColor: "#D6D3D1",
+    borderColor: sdui.color.neutralWeak,
     borderRadius: 8,
     paddingHorizontal: 12,
     paddingVertical: 12,
-    backgroundColor: "#FFFFFF",
+    backgroundColor: sdui.color.neutralInverse,
   },
-  value: { flex: 1, fontSize: 14, color: "#1C1917" },
-  placeholder: { color: "#78716C" },
-  chevron: { fontSize: 14, color: "#78716C", marginLeft: 8 },
+  value: { flex: 1, fontSize: 14, color: sdui.color.neutralStrong },
+  placeholder: { color: sdui.color.neutralMedium },
+  chevron: { fontSize: 14, color: sdui.color.neutralMedium, marginLeft: 8 },
 });

--- a/packages/sdui-runtime/src/ui_components/SelectTrigger/SelectTrigger.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/SelectTrigger/SelectTrigger.renderer.tsx
@@ -29,18 +29,23 @@ export function SelectTriggerRenderer(node: Node): React.ReactElement {
     | undefined;
 
   const formId = useFormId(data?.form_id);
-  const field = useFormField<string>(
+  const field = useFormField<string | string[]>(
     formId,
     data?.field_name,
     data?.default_value ?? "",
   );
   const actionEngine = useActionEngine();
 
-  const display =
-    (data?.value_display && data.value_display[field.value]) ||
-    field.value ||
-    data?.placeholder ||
-    "";
+  // The bound value is a string for single-select fields, a string[] for
+  // multi-select. Map each id to its rich label via `value_display` and join;
+  // fall back to the placeholder when empty.
+  const mapLabel = (v: string): string => data?.value_display?.[v] ?? v;
+  const value = field.value;
+  const display = Array.isArray(value)
+    ? value.length
+      ? value.map(mapLabel).join(", ")
+      : data?.placeholder ?? ""
+    : mapLabel(value) || data?.placeholder || "";
 
   return (
     <Pressable

--- a/packages/sdui-runtime/src/ui_components/Tab/Tab.renderer.tsx
+++ b/packages/sdui-runtime/src/ui_components/Tab/Tab.renderer.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useContext } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { TabComponentSchema } from "@one-impression/sdk-native-sdui";
-import { Tab as DSTab, Icon as DSIcon } from "@one-impression/ui-native";
+import { Tab as DSTab } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
+import { IconGlyph } from "../../icon-store/IconGlyph.js";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";
 import { TabBarActiveContext } from "../../state/TabBarActiveContext.js";
 
@@ -54,7 +55,7 @@ export function TabRenderer(node: Node): React.ReactElement {
           onPress={onPress}
           icon={
             v.icon ? (
-              <DSIcon
+              <IconGlyph
                 name={v.icon.name}
                 size={v.icon.size}
                 color={v.icon.color}

--- a/packages/ui-native/src/index.ts
+++ b/packages/ui-native/src/index.ts
@@ -61,6 +61,10 @@ export type { CardProps } from './primitives/Card';
 export { Input } from './primitives/Input';
 export type { InputProps } from './primitives/Input';
 
+// DateField
+export { DateField } from './primitives/DateField';
+export type { DateFieldProps } from './primitives/DateField';
+
 // Chip
 export { Chip } from './primitives/Chip';
 export type { ChipProps } from './primitives/Chip';

--- a/packages/ui-native/src/primitives/DateField/DateField.tsx
+++ b/packages/ui-native/src/primitives/DateField/DateField.tsx
@@ -1,0 +1,371 @@
+import React, { useMemo, useState } from "react";
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text as RNText,
+  View,
+} from "react-native";
+import { resolveRadius } from "../../theme/resolvers";
+
+/**
+ * DateField — a tappable date input with a self-contained, pure-JS calendar
+ * popover (no native date-picker module, so it renders in any RN/Expo client
+ * without a prebuild). The field shows the selected date (or a placeholder) and
+ * a label/helper/error in the same visual grammar as `Input`; tapping it opens a
+ * month-grid calendar with month arrows + a year list (so a far-back date like a
+ * DOB is reachable in a couple of taps). The value is an ISO `YYYY-MM-DD` string.
+ */
+export interface DateFieldProps {
+  label?: string;
+  /** ISO `YYYY-MM-DD`. */
+  value?: string;
+  placeholder?: string;
+  error?: boolean;
+  helperText?: string;
+  disabled?: boolean;
+  /** ISO `YYYY-MM-DD` lower bound (inclusive). Days before are not selectable. */
+  minDate?: string;
+  /** ISO `YYYY-MM-DD` upper bound (inclusive). Days after are not selectable. */
+  maxDate?: string;
+  onChange: (iso: string) => void;
+  /** Called when the picker opens — use to mark the field touched. */
+  onOpen?: () => void;
+}
+
+const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+const MONTHS_SHORT = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+const pad = (n: number): string => (n < 10 ? `0${n}` : `${n}`);
+const toIso = (y: number, m: number, d: number): string =>
+  `${y}-${pad(m + 1)}-${pad(d)}`;
+
+interface Ymd {
+  y: number;
+  m: number; // 0-11
+  d: number;
+}
+
+function parseIso(iso?: string): Ymd | null {
+  if (!iso) return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+  if (!match) return null;
+  return { y: Number(match[1]), m: Number(match[2]) - 1, d: Number(match[3]) };
+}
+
+function formatDisplay(iso: string): string {
+  const p = parseIso(iso);
+  if (!p) return iso;
+  return `${p.d} ${MONTHS_SHORT[p.m]} ${p.y}`;
+}
+
+/** ISO-string compare works lexically for `YYYY-MM-DD`. */
+function isOutOfRange(iso: string, minDate?: string, maxDate?: string): boolean {
+  if (minDate && iso < minDate) return true;
+  if (maxDate && iso > maxDate) return true;
+  return false;
+}
+
+function Calendar({
+  value,
+  minDate,
+  maxDate,
+  onSelect,
+}: {
+  value?: string;
+  minDate?: string;
+  maxDate?: string;
+  onSelect: (iso: string) => void;
+}): React.ReactElement {
+  // Open on the selected date, else the max bound (DOB lands near "today"), else
+  // the min bound, else the current month.
+  const anchor =
+    parseIso(value) ?? parseIso(maxDate) ?? parseIso(minDate) ?? (() => {
+      const now = new Date();
+      return { y: now.getFullYear(), m: now.getMonth(), d: now.getDate() };
+    })();
+  const [viewY, setViewY] = useState(anchor.y);
+  const [viewM, setViewM] = useState(anchor.m);
+  const [yearOpen, setYearOpen] = useState(false);
+
+  const selected = parseIso(value);
+
+  const cells = useMemo(() => {
+    const firstWeekday = new Date(viewY, viewM, 1).getDay();
+    const daysInMonth = new Date(viewY, viewM + 1, 0).getDate();
+    const out: (number | null)[] = [];
+    for (let i = 0; i < firstWeekday; i += 1) out.push(null);
+    for (let d = 1; d <= daysInMonth; d += 1) out.push(d);
+    while (out.length % 7 !== 0) out.push(null);
+    return out;
+  }, [viewY, viewM]);
+
+  const stepMonth = (delta: number): void => {
+    let m = viewM + delta;
+    let y = viewY;
+    if (m < 0) {
+      m = 11;
+      y -= 1;
+    } else if (m > 11) {
+      m = 0;
+      y += 1;
+    }
+    setViewM(m);
+    setViewY(y);
+  };
+
+  // Year list bounds — derive from min/max when present, else a sensible window.
+  const minYear = parseIso(minDate)?.y ?? 1920;
+  const maxYear = parseIso(maxDate)?.y ?? new Date().getFullYear();
+  const years = useMemo(() => {
+    const out: number[] = [];
+    for (let y = maxYear; y >= minYear; y -= 1) out.push(y);
+    return out;
+  }, [minYear, maxYear]);
+
+  if (yearOpen) {
+    return (
+      <View>
+        <RNText style={styles.calTitle}>Select year</RNText>
+        <ScrollView style={styles.yearScroll}>
+          <View style={styles.yearGrid}>
+            {years.map((y) => (
+              <Pressable
+                key={y}
+                style={[styles.yearCell, y === viewY && styles.yearCellActive]}
+                onPress={() => {
+                  setViewY(y);
+                  setYearOpen(false);
+                }}
+              >
+                <RNText
+                  style={[styles.yearText, y === viewY && styles.yearTextActive]}
+                >
+                  {y}
+                </RNText>
+              </Pressable>
+            ))}
+          </View>
+        </ScrollView>
+      </View>
+    );
+  }
+
+  return (
+    <View>
+      <View style={styles.calHeader}>
+        <Pressable onPress={() => stepMonth(-1)} hitSlop={8} style={styles.navBtn}>
+          <RNText style={styles.navText}>‹</RNText>
+        </Pressable>
+        <Pressable onPress={() => setYearOpen(true)} hitSlop={6}>
+          <RNText style={styles.calTitle}>
+            {MONTHS[viewM]} {viewY} ▾
+          </RNText>
+        </Pressable>
+        <Pressable onPress={() => stepMonth(1)} hitSlop={8} style={styles.navBtn}>
+          <RNText style={styles.navText}>›</RNText>
+        </Pressable>
+      </View>
+      <View style={styles.weekRow}>
+        {WEEKDAYS.map((w) => (
+          <RNText key={w} style={styles.weekday}>
+            {w}
+          </RNText>
+        ))}
+      </View>
+      <View style={styles.grid}>
+        {cells.map((d, i) => {
+          if (d === null) return <View key={`b${i}`} style={styles.dayCell} />;
+          const iso = toIso(viewY, viewM, d);
+          const disabled = isOutOfRange(iso, minDate, maxDate);
+          const isSel =
+            !!selected &&
+            selected.y === viewY &&
+            selected.m === viewM &&
+            selected.d === d;
+          return (
+            <Pressable
+              key={iso}
+              disabled={disabled}
+              style={styles.dayCell}
+              onPress={() => onSelect(iso)}
+            >
+              <View style={[styles.dayInner, isSel && styles.dayInnerActive]}>
+                <RNText
+                  style={[
+                    styles.dayText,
+                    isSel && styles.dayTextActive,
+                    disabled && styles.dayTextDisabled,
+                  ]}
+                >
+                  {d}
+                </RNText>
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+export function DateField({
+  label,
+  value,
+  placeholder,
+  error = false,
+  helperText,
+  disabled = false,
+  minDate,
+  maxDate,
+  onChange,
+  onOpen,
+}: DateFieldProps): React.ReactElement {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <View style={styles.container}>
+      {label ? <RNText style={styles.label}>{label}</RNText> : null}
+      <Pressable
+        disabled={disabled}
+        onPress={() => {
+          if (disabled) return;
+          onOpen?.();
+          setOpen(true);
+        }}
+        style={[
+          styles.field,
+          { borderRadius: resolveRadius("md") },
+          error && styles.fieldError,
+          disabled && styles.fieldDisabled,
+        ]}
+      >
+        <RNText style={[styles.fieldValue, !value && styles.fieldPlaceholder]}>
+          {value ? formatDisplay(value) : placeholder ?? "Select date"}
+        </RNText>
+        <RNText style={styles.fieldIcon}>▾</RNText>
+      </Pressable>
+      {helperText ? (
+        <RNText style={[styles.helper, error && styles.helperError]}>
+          {helperText}
+        </RNText>
+      ) : null}
+      <Modal
+        visible={open}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setOpen(false)}
+      >
+        <Pressable style={styles.backdrop} onPress={() => setOpen(false)}>
+          <Pressable style={styles.popover} onPress={() => undefined}>
+            <Calendar
+              value={value}
+              minDate={minDate}
+              maxDate={maxDate}
+              onSelect={(iso) => {
+                onChange(iso);
+                setOpen(false);
+              }}
+            />
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </View>
+  );
+}
+
+DateField.displayName = "DateField";
+
+const styles = StyleSheet.create({
+  container: { width: "100%" },
+  label: { fontSize: 13, color: "#57534E", marginBottom: 6 },
+  field: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    borderWidth: 1,
+    borderColor: "#D6D3D1",
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    backgroundColor: "#FFFFFF",
+  },
+  fieldError: { borderColor: "#DC2626" },
+  fieldDisabled: { backgroundColor: "#F5F5F4", borderColor: "#E7E5E4" },
+  fieldValue: { fontSize: 14, color: "#1C1917" },
+  fieldPlaceholder: { color: "#78716C" },
+  fieldIcon: { fontSize: 14, color: "#78716C" },
+  helper: { fontSize: 12, color: "#78716C", marginTop: 4 },
+  helperError: { color: "#DC2626" },
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  popover: {
+    width: "100%",
+    maxWidth: 340,
+    backgroundColor: "#FFFFFF",
+    borderRadius: 16,
+    padding: 16,
+  },
+  calHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 12,
+  },
+  calTitle: { fontSize: 16, fontWeight: "600", color: "#1C1917" },
+  navBtn: {
+    width: 36,
+    height: 36,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  navText: { fontSize: 24, color: "#1C1917" },
+  weekRow: { flexDirection: "row" },
+  weekday: {
+    flex: 1,
+    textAlign: "center",
+    fontSize: 12,
+    color: "#A8A29E",
+    paddingVertical: 4,
+  },
+  grid: { flexDirection: "row", flexWrap: "wrap" },
+  dayCell: {
+    width: `${100 / 7}%`,
+    aspectRatio: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  dayInner: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  dayInnerActive: { backgroundColor: "#7C3AED" },
+  dayText: { fontSize: 14, color: "#1C1917" },
+  dayTextActive: { color: "#FFFFFF", fontWeight: "600" },
+  dayTextDisabled: { color: "#D6D3D1" },
+  yearScroll: { maxHeight: 280 },
+  yearGrid: { flexDirection: "row", flexWrap: "wrap" },
+  yearCell: {
+    width: `${100 / 3}%`,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  yearCellActive: {},
+  yearText: { fontSize: 16, color: "#1C1917" },
+  yearTextActive: { color: "#7C3AED", fontWeight: "700" },
+});

--- a/packages/ui-native/src/primitives/DateField/DateField.tsx
+++ b/packages/ui-native/src/primitives/DateField/DateField.tsx
@@ -7,6 +7,7 @@ import {
   Text as RNText,
   View,
 } from "react-native";
+import { sdui } from "@one-impression/tokens-creator/react-native";
 import { resolveRadius } from "../../theme/resolvers";
 
 /**
@@ -286,26 +287,31 @@ DateField.displayName = "DateField";
 
 const styles = StyleSheet.create({
   container: { width: "100%" },
-  label: { fontSize: 13, color: "#57534E", marginBottom: 6 },
+  label: { fontSize: 13, color: sdui.color.neutralMedium, marginBottom: 6 },
   field: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
     borderWidth: 1,
-    borderColor: "#D6D3D1",
+    borderColor: sdui.color.neutralWeak,
     paddingHorizontal: 12,
     paddingVertical: 12,
-    backgroundColor: "#FFFFFF",
+    backgroundColor: sdui.color.neutralInverse,
   },
-  fieldError: { borderColor: "#DC2626" },
-  fieldDisabled: { backgroundColor: "#F5F5F4", borderColor: "#E7E5E4" },
-  fieldValue: { fontSize: 14, color: "#1C1917" },
-  fieldPlaceholder: { color: "#78716C" },
-  fieldIcon: { fontSize: 14, color: "#78716C" },
-  helper: { fontSize: 12, color: "#78716C", marginTop: 4 },
-  helperError: { color: "#DC2626" },
+  fieldError: { borderColor: sdui.color.negative },
+  fieldDisabled: {
+    backgroundColor: sdui.color.stateNeutralBg,
+    borderColor: sdui.color.neutralSubtle,
+  },
+  fieldValue: { fontSize: 14, color: sdui.color.neutralStrong },
+  fieldPlaceholder: { color: sdui.color.neutralMedium },
+  fieldIcon: { fontSize: 14, color: sdui.color.neutralMedium },
+  helper: { fontSize: 12, color: sdui.color.neutralMedium, marginTop: 4 },
+  helperError: { color: sdui.color.negative },
   backdrop: {
     flex: 1,
+    // Modal scrim — an intentional translucent black overlay, not a palette
+    // colour (the token set has no scrim token).
     backgroundColor: "rgba(0,0,0,0.4)",
     justifyContent: "center",
     alignItems: "center",
@@ -314,7 +320,7 @@ const styles = StyleSheet.create({
   popover: {
     width: "100%",
     maxWidth: 340,
-    backgroundColor: "#FFFFFF",
+    backgroundColor: sdui.color.neutralInverse,
     borderRadius: 16,
     padding: 16,
   },
@@ -324,20 +330,20 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     marginBottom: 12,
   },
-  calTitle: { fontSize: 16, fontWeight: "600", color: "#1C1917" },
+  calTitle: { fontSize: 16, fontWeight: "600", color: sdui.color.neutralStrong },
   navBtn: {
     width: 36,
     height: 36,
     alignItems: "center",
     justifyContent: "center",
   },
-  navText: { fontSize: 24, color: "#1C1917" },
+  navText: { fontSize: 24, color: sdui.color.neutralStrong },
   weekRow: { flexDirection: "row" },
   weekday: {
     flex: 1,
     textAlign: "center",
     fontSize: 12,
-    color: "#A8A29E",
+    color: sdui.color.neutralMedium,
     paddingVertical: 4,
   },
   grid: { flexDirection: "row", flexWrap: "wrap" },
@@ -354,10 +360,10 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
-  dayInnerActive: { backgroundColor: "#7C3AED" },
-  dayText: { fontSize: 14, color: "#1C1917" },
-  dayTextActive: { color: "#FFFFFF", fontWeight: "600" },
-  dayTextDisabled: { color: "#D6D3D1" },
+  dayInnerActive: { backgroundColor: sdui.color.primary },
+  dayText: { fontSize: 14, color: sdui.color.neutralStrong },
+  dayTextActive: { color: sdui.color.neutralInverse, fontWeight: "600" },
+  dayTextDisabled: { color: sdui.color.neutralWeak },
   yearScroll: { maxHeight: 280 },
   yearGrid: { flexDirection: "row", flexWrap: "wrap" },
   yearCell: {
@@ -366,6 +372,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   yearCellActive: {},
-  yearText: { fontSize: 16, color: "#1C1917" },
-  yearTextActive: { color: "#7C3AED", fontWeight: "700" },
+  yearText: { fontSize: 16, color: sdui.color.neutralStrong },
+  yearTextActive: { color: sdui.color.primary, fontWeight: "700" },
 });

--- a/packages/ui-native/src/primitives/DateField/index.ts
+++ b/packages/ui-native/src/primitives/DateField/index.ts
@@ -1,0 +1,2 @@
+export { DateField } from "./DateField";
+export type { DateFieldProps } from "./DateField";

--- a/packages/ui-native/src/primitives/Input/Input.styles.ts
+++ b/packages/ui-native/src/primitives/Input/Input.styles.ts
@@ -4,6 +4,7 @@ import { sdui } from '@one-impression/tokens-creator/react-native';
 export const styles = StyleSheet.create({
   container: {
     gap: sdui.spacing.xs,
+    marginTop: sdui.spacing.sm,
   },
   // The bordered container row: holds [leading] [TextInput] [trailing]. Shared
   // control sizing (field token group) lives here so inputs, select rows, and

--- a/packages/ui-native/src/primitives/Input/Input.tsx
+++ b/packages/ui-native/src/primitives/Input/Input.tsx
@@ -1,9 +1,22 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { View, TextInput, Text as RNText, Animated, Easing } from 'react-native';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  View,
+  TextInput,
+  Text as RNText,
+  Animated,
+  Easing,
+  Pressable,
+} from 'react-native';
 import { sdui } from '@one-impression/tokens-creator/react-native';
 import type { InputProps } from './Input.types';
 import { styles } from './Input.styles';
 import { resolveRadius, resolveFontSize } from '../../theme/resolvers';
+
+// An animated, pressable label container: it carries the floating-label
+// animation (left/top) AND focuses the field on tap (the resting label sits over
+// the placeholder slot with zIndex, so `pointerEvents:none` passthrough is not
+// reliable on Android — pressing it to focus is).
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 /**
  * Input — a text input with label/helper/error, optional `leading`/`trailing`
@@ -101,6 +114,19 @@ const FloatingLabelInput = React.forwardRef<TextInput, InputProps>(
       }).start();
     }, [floated, anim]);
 
+    // Keep an internal handle to the TextInput (so the label can focus it) while
+    // still forwarding the ref to the caller.
+    const innerRef = useRef<TextInput | null>(null);
+    const setRefs = useCallback(
+      (node: TextInput | null) => {
+        innerRef.current = node;
+        if (typeof ref === 'function') ref(node);
+        else if (ref)
+          (ref as React.MutableRefObject<TextInput | null>).current = node;
+      },
+      [ref],
+    );
+
     // Resting label aligns with the text start — past any leading adornment.
     // Resting (placeholder): aligned with the text start — shifted past a
     // leading adornment so it doesn't overlap it. Floated: snaps to the field's
@@ -111,12 +137,15 @@ const FloatingLabelInput = React.forwardRef<TextInput, InputProps>(
       (leading ? leadingWidth + sdui.spacing.sm : 0);
     const floatedLeft = sdui.component.field.paddingX;
 
-    const labelStyle = {
+    // Positioning animates on the pressable container; type styling on the Text.
+    const labelPosStyle = {
       left: anim.interpolate({
         inputRange: [0, 1],
         outputRange: [restingLeft, floatedLeft],
       }),
       top: anim.interpolate({ inputRange: [0, 1], outputRange: [14, -10] }),
+    };
+    const labelTextStyle = {
       // Resting = body size (placeholder-equivalent); floated = caption size
       // (matches helper/error text). Token-driven so it tracks the type scale.
       fontSize: anim.interpolate({
@@ -133,13 +162,18 @@ const FloatingLabelInput = React.forwardRef<TextInput, InputProps>(
     return (
       <View style={styles.container}>
         <View style={styles.floatWrap}>
-          <Animated.Text
-            pointerEvents="none"
-            numberOfLines={1}
-            style={[styles.floatLabel, labelStyle]}
+          <AnimatedPressable
+            // The resting label sits over the placeholder slot, so a tap on it
+            // must focus the field (passthrough is unreliable on Android because
+            // the label is z-lifted for the floated notch). Pressing focuses.
+            onPress={() => innerRef.current?.focus()}
+            disabled={disabled}
+            style={[styles.floatLabel, labelPosStyle]}
           >
-            {label}
-          </Animated.Text>
+            <Animated.Text numberOfLines={1} style={labelTextStyle}>
+              {label}
+            </Animated.Text>
+          </AnimatedPressable>
           <View
             style={[
               styles.inputRow,
@@ -155,14 +189,17 @@ const FloatingLabelInput = React.forwardRef<TextInput, InputProps>(
               </View>
             )}
             <TextInput
-              ref={ref}
+              ref={setRefs}
               editable={!disabled}
               accessibilityLabel={label}
               style={[styles.input, { fontSize: resolveFontSize(size) ?? 14 }]}
               placeholderTextColor="#78716C"
-              // The label occupies the placeholder slot until it floats up.
-              placeholder={floated ? props.placeholder : undefined}
               {...props}
+              // The label occupies the placeholder slot while resting, so the
+              // real placeholder is shown ONLY once the label floats up (focus
+              // or value) — otherwise they overlap. Set AFTER {...props} so this
+              // wins over props.placeholder rather than being re-overridden.
+              placeholder={floated ? props.placeholder : undefined}
               onFocus={(e) => {
                 setFocused(true);
                 props.onFocus?.(e);


### PR DESCRIPTION
Form primitives + fixes for the creator profile form pages (Personal Details, About Content, About me).

## sdui-runtime
- **`date_input`** — form-bound date field over the new `DateField` (pure-JS calendar popover, no native module).
- **`show_when`** — base-node conditional visibility evaluated against a sibling form field (`ConditionalGate` at the interpreter); hidden fields drop out of validation.
- **`single_select_input` `layout: "horizontal"`** — equal-width column options.
- **`Tab.renderer`** → render icons via `IconGlyph` (footer tab icons resolve from the manifest).
- **`Form.renderer`** → render raw field nodes so per-field extensions like `show_when` survive the schema parse.
- **`select_trigger`** → input-styled, tap-to-open picker field; renders multi-select labels.

## ui-native
- **`DateField`** — new calendar date-picker primitive.
- **`Input` floating label** — placeholder shown only once the label floats (no empty-state overlap); tapping the resting label focuses the field; `sm` top margin.

All emitted as raw wire from the gateway where no SDK builder exists (same posture as the form `submit` action) — no `sdk-native-sdui` change. Verified end-to-end on-device against the mock BFF.