### PR TITLE
feat(sdui-runtime): search-in-bottomsheet primitives (local_key, reload_section $.local, reactive sheets)

### DIFF
--- a/.changeset/sheet-search.md
+++ b/.changeset/sheet-search.md
@@ -1,0 +1,9 @@
+---
+"@one-impression/sdui-runtime": minor
+---
+
+Search-in-bottomsheet primitives (powers type-to-search pickers, e.g. location):
+
+- **`Input.local_key`** — an input mirrors its current text into the local store under `local_key` on every change, so a (debounced) reload can read it via `{ ref: "$.local.<key>" }`. Standalone (form-unbound) inputs now also keep their own text, so a header search box is controllable.
+- **`reload_section` resolves `$.local` refs** — its request body now runs through `resolveRequestRefs` against the local store (like `bff_call`), so the typed value rides into the search request.
+- **Bottom-sheet content is reactive** — `SduiSheetScreen` registers its items in `usePageStore` (keyed by route, active instance) and renders the live tree, so `reload_section` / `replace_section` / `append_items` targeting a section INSIDE a sheet now update reactively (was local-state only).

--- a/packages/sdui-runtime/src/action-engine/handlers/reload-section.ts
+++ b/packages/sdui-runtime/src/action-engine/handlers/reload-section.ts
@@ -1,6 +1,8 @@
 import { ReloadSectionPayloadSchema } from "@one-impression/sdk-native-sdui";
 import type { Action } from "@one-impression/sdk-native-sdui";
 import type { ActionEngineConfig, ActionEngine } from "../types.js";
+import { resolveRequestRefs } from "../cond/resolve-request-refs.js";
+import { useLocalStore } from "../../state/useLocalStore.js";
 
 /**
  * reload_section — fetches a fresh node from the BFF and replaces the
@@ -11,7 +13,21 @@ export async function handleReloadSection(
   config: ActionEngineConfig,
   _engine: ActionEngine,
 ): Promise<void> {
-  const payload = ReloadSectionPayloadSchema.parse(action.payload);
+  // Resolve `{ ref: "$.local.*" }` in the request body against the local store
+  // BEFORE parse — so a search box's typed value (mirrored to the local store
+  // on change) rides into the request. Before parse because the body schema
+  // would otherwise reject a ref-object value.
+  const raw = (action.payload ?? {}) as Record<string, unknown>;
+  const bound =
+    "payload" in raw
+      ? {
+          ...raw,
+          payload: resolveRequestRefs(raw.payload, {
+            local: useLocalStore.getState().data,
+          }),
+        }
+      : raw;
+  const payload = ReloadSectionPayloadSchema.parse(bound);
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",

--- a/packages/sdui-runtime/src/navigation/SduiSheetScreen.tsx
+++ b/packages/sdui-runtime/src/navigation/SduiSheetScreen.tsx
@@ -9,7 +9,7 @@ import BottomSheet, {
 } from "@gorhom/bottom-sheet";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { resolveSpacing } from "@one-impression/ui-native";
-import type { Action, Node } from "@one-impression/sdk-native-sdui";
+import type { Action, Node, Page } from "@one-impression/sdk-native-sdui";
 import { Interpreter } from "../interpreter/index.js";
 import { GutterItem, PAGE_GUTTER_TOKEN } from "../layout/page-gutter.js";
 import { useActionEngine } from "../action-engine/useActionEngine.js";
@@ -22,6 +22,7 @@ import {
 import type { SduiRootParamList } from "./navigationRef.js";
 import { registerSurfaceReload } from "./surfaceRegistry.js";
 import { fetchSurfaceDocument } from "./fetchSurfaceDocument.js";
+import { usePageStore } from "../state/usePageStore.js";
 import { ListRowsSkeleton } from "../loaders/index.js";
 
 const SIZE_TO_SNAP: Record<string, string[]> = {
@@ -69,6 +70,20 @@ export function SduiSheetScreen({
   // resolves). Static sheets ignore this and read the registry directly.
   const [fetched, setFetched] = useState<SheetEntry | null>(null);
 
+  // Live items from the page store (keyed by this route) so a section reload
+  // INSIDE the sheet re-renders reactively. Falls back to the fetched items
+  // until the tree is registered (see the fetch handler).
+  const liveItems = usePageStore(
+    (s) => s.pagesByKey[route.key]?.items as Node[] | undefined,
+  );
+  // Drop this sheet's page-store entry on unmount so it doesn't linger.
+  useEffect(
+    () => () => {
+      if (isAddressable) usePageStore.getState().dropPage(route.key);
+    },
+    [isAddressable, route.key],
+  );
+
   // Fetch the sheet's own document path-direct. Used on open and by
   // reload-by-name. Maps the fetched JSON into the SheetEntry render shape.
   // `queryParams` (reload-by-name only) ride into the refetch so the document
@@ -100,6 +115,17 @@ export function SduiSheetScreen({
           on_open: doc.on_open,
           overlay_on_click: doc.overlay_on_click,
         });
+        // Register the items in the page store keyed by this route (which becomes
+        // the active instance), so reload_section / replace_section / append_items
+        // targeting a section INSIDE the sheet mutate reactively — the same model
+        // pages use. Without this the sheet renders from local state only and a
+        // section reload (e.g. live search results) never reaches it.
+        usePageStore
+          .getState()
+          .setPageTree(
+            { id: doc.id ?? sheetId, items: doc.items ?? [] } as Page,
+            route.key,
+          );
       })
       .catch((e: unknown) => {
         // eslint-disable-next-line no-console
@@ -261,7 +287,7 @@ export function SduiSheetScreen({
                   gutter + inter-item gap model (incl. the section_header
                   GAP_OVERRIDES). The route-based sheet was outside that system,
                   so its section headers got no vertical gap. */}
-              {sheet.items.map((node, i) => (
+              {(liveItems ?? sheet.items).map((node, i) => (
                 <GutterItem key={node.id ?? i} node={node} index={i}>
                   <Interpreter node={node} />
                 </GutterItem>

--- a/packages/sdui-runtime/src/snippets/Input/Input.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/Input/Input.renderer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import type { Node } from "@one-impression/sdk-native-sdui";
 import { InputSnippetSchema } from "@one-impression/sdk-native-sdui";
 import { Input as DSInput, Box, Icon as DSIcon, Stack, Text } from "@one-impression/ui-native";
@@ -6,6 +6,7 @@ import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
 import { useActionEngine } from "../../action-engine/useActionEngine.js";
 import { useFormField, useFormId } from "../../form/index.js";
+import { useLocalStore } from "../../state/useLocalStore.js";
 import type { ValidationRule } from "../../validation/index.js";
 
 /** Lightweight static shorthand for a leading/trailing slot. */
@@ -65,6 +66,10 @@ export function InputRenderer(node: Node): React.ReactElement {
         validations?: ValidationRule[];
         leading?: AdornmentSpec | Node;
         trailing?: AdornmentSpec | Node;
+        /** When set, the input writes its current text into the local store
+         *  under this key on every change — so a (typically debounced) reload
+         *  can read it via `{ ref: "$.local.<local_key>" }`. Powers search. */
+        local_key?: string;
       }
     | undefined;
   const formId = useFormId(data?.form_id);
@@ -76,6 +81,12 @@ export function InputRenderer(node: Node): React.ReactElement {
   );
 
   const errorText = field.touched ? field.error ?? undefined : undefined;
+
+  // Standalone inputs (no form binding — e.g. a sheet search box) keep their own
+  // text so they stay controllable; bound inputs read/write the form store.
+  const [standaloneValue, setStandaloneValue] = useState(data?.value ?? "");
+  const value = field.bound ? field.value : standaloneValue;
+  const setValue = field.bound ? field.setValue : setStandaloneValue;
 
   const leadingNode = adornmentNode(data?.leading);
   const trailingNode = adornmentNode(data?.trailing);
@@ -96,7 +107,7 @@ export function InputRenderer(node: Node): React.ReactElement {
         <InputInner
           inputType={v.input_type}
           placeholder={v.placeholder}
-          value={field.value}
+          value={value}
           label={v.label}
           required={v.required}
           disabled={v.disabled}
@@ -104,12 +115,13 @@ export function InputRenderer(node: Node): React.ReactElement {
           errorText={errorText}
           leading={leadingNode}
           trailing={trailingNode}
-          onChangeValue={field.setValue}
+          onChangeValue={setValue}
           onBlurField={field.markTouched}
           onChange={node.data?.on_change}
           onSubmit={node.data?.on_submit}
           onFocus={node.data?.on_focus}
           onBlur={node.data?.on_blur}
+          localKey={data?.local_key}
         />
       )}
     </SduiNode>
@@ -133,6 +145,7 @@ function InputInner({
   onSubmit,
   onFocus,
   onBlur,
+  localKey,
 }: {
   inputType?: string;
   placeholder?: { text?: string };
@@ -150,15 +163,20 @@ function InputInner({
   onSubmit?: unknown;
   onFocus?: unknown;
   onBlur?: unknown;
+  localKey?: string;
 }): React.ReactElement {
   const actionEngine = useActionEngine();
 
   const handleChange = useCallback(
     (text: string) => {
       onChangeValue(text);
+      // Mirror the text into the local store so a chained (debounced) reload can
+      // read it via `{ ref: "$.local.<localKey>" }` — synchronous, so the value
+      // is current before the reload fires.
+      if (localKey) useLocalStore.getState().set(localKey, text);
       if (onChange) actionEngine.dispatch(onChange as any);
     },
-    [actionEngine, onChange, onChangeValue],
+    [actionEngine, onChange, onChangeValue, localKey],
   );
 
   const handleSubmit = useCallback(() => {


### PR DESCRIPTION
Three small, reusable runtime primitives that make type-to-search bottomsheets fully BFF-driven (used first by the creator location picker):

- **`Input.local_key`** — input mirrors its text into the local store on change (so a debounced reload can read `{ ref: "$.local.<key>" }`); standalone/form-unbound inputs now keep their own text so a header search box is controllable.
- **`reload_section` resolves `$.local` refs** in its request body via `resolveRequestRefs` (same as `bff_call`), so the typed search value rides into the request.
- **Reactive bottom sheets** — `SduiSheetScreen` registers its items in `usePageStore` (active instance) and renders the live tree, so `reload_section`/`replace_section`/`append_items` targeting a section inside a sheet update reactively.

Verified end-to-end on-device: empty search sheet → type → debounced API call → results replace in-place → pick writes the form field + dismisses. Regression-checked the existing select sheets (languages/categories) — unchanged.