### PR TITLE
feat(sdui-runtime): vertical group_config children inherit page rhythm

### DIFF
--- a/.changeset/group-vertical-rhythm.md
+++ b/.changeset/group-vertical-rhythm.md
@@ -1,0 +1,5 @@
+---
+"@one-impression/sdui-runtime": minor
+---
+
+Vertical `group_config` children now inherit the page's per-item vertical rhythm by default, instead of a fixed `sm` gap. Spacing resolves in precedence: a child node's own `gap` (per-child, backend) → the group's `gap` (group-wide, backend) → the inherited page default (half-gutter). A plain (cardless) vertical group is now spacing-transparent — its children space exactly as if inlined at the page level (first child's top and last child's bottom are zeroed, since the group already sits in the page gutter). Horizontal groups are unchanged (they keep the uniform `Box` gap, default `sm`).

--- a/packages/sdui-runtime/src/layout/page-gutter.tsx
+++ b/packages/sdui-runtime/src/layout/page-gutter.tsx
@@ -169,3 +169,68 @@ export function GutterItem({
     </View>
   );
 }
+
+/**
+ * Per-side vertical margin (px) for a child INSIDE a vertical group_config — the
+ * same page rhythm a top-level item gets, but with the group's own `gap` slotted
+ * in as the MIDDLE fallback so a group can re-space all its children at once.
+ * Resolution order:
+ *   (1) child node `gap`   — backend per-instance override, on the child
+ *   (2) group `gap`        — backend override, on the group_config node
+ *   (3) per-type override / default — the inherited page rhythm (half-gutter = 6)
+ * Applied symmetrically (top + bottom) by `GroupGutterItem`, matching the page's
+ * per-side model so two default children sit a full gutter apart (6 + 6 = 12).
+ */
+export function resolveGroupRowGap(
+  node: Node,
+  groupGap?: string | number,
+): number {
+  const flag = (node as { gap?: unknown }).gap;
+  if (typeof flag === "string" || typeof flag === "number") {
+    // (1) per-child override — a spacing token (raw px tolerated)
+    return resolveSpacing(flag as SpacingToken | number) ?? DEFAULT_ROW_GAP_PX;
+  }
+  if (groupGap !== undefined) {
+    // (2) group-level override — applies to every child that doesn't set its own
+    return resolveSpacing(groupGap as SpacingToken | number) ?? DEFAULT_ROW_GAP_PX;
+  }
+  const override = GAP_OVERRIDES[node.type];
+  if (override !== undefined) return resolveSpacing(override) ?? DEFAULT_ROW_GAP_PX; // (3) per-type
+  return DEFAULT_ROW_GAP_PX; // (3) page default — inherited rhythm
+}
+
+/**
+ * Wrap one VERTICAL group_config child in the page's vertical rhythm. Margin is
+ * symmetric per side (top + bottom = `resolveGroupRowGap`), mirroring `GutterItem`,
+ * so children stack on the same rhythm as top-level page items. The FIRST child's
+ * top and the LAST child's bottom are zeroed: the group node itself sits inside a
+ * page `GutterItem` that owns the group's OUTER spacing, so a plain (cardless)
+ * group is spacing-transparent — its children space exactly as if inlined at the
+ * page level, with no doubled gutter at the group's edges. No horizontal gutter:
+ * the group owns horizontal layout (Box `direction` / `align` / `justify`).
+ */
+export function GroupGutterItem({
+  node,
+  index,
+  count,
+  groupGap,
+  children,
+}: {
+  node: Node;
+  index: number;
+  count: number;
+  groupGap?: string | number;
+  children: React.ReactNode;
+}): React.ReactElement {
+  const gap = resolveGroupRowGap(node, groupGap);
+  return (
+    <View
+      style={{
+        marginTop: index === 0 ? 0 : gap,
+        marginBottom: index === count - 1 ? 0 : gap,
+      }}
+    >
+      {children}
+    </View>
+  );
+}

--- a/packages/sdui-runtime/src/layout/page-gutter.tsx
+++ b/packages/sdui-runtime/src/layout/page-gutter.tsx
@@ -31,7 +31,12 @@ const GUTTER_PX = resolveSpacing(PAGE_GUTTER_TOKEN) ?? 12;
 // does not collapse margins (unlike CSS), so adjacent items' margins sum: two
 // default items sit a full gutter (6 + 6 = 12) apart, and the page's top/bottom
 // edges get the half (6).
-const DEFAULT_ROW_GAP_PX = GUTTER_PX / 2; // 6
+//
+// Exported + named because it encodes a layout policy ("default row gap is half
+// the page gutter"), not an incidental magic number: it is the fallback in every
+// branch of `resolveGroupRowGap`, so callers and tests can reference the policy
+// by name rather than re-deriving `GUTTER_PX / 2`.
+export const DEFAULT_ROW_GAP_PX = GUTTER_PX / 2; // half the page gutter
 
 const styles = StyleSheet.create({
   gutter: { paddingHorizontal: GUTTER_PX },

--- a/packages/sdui-runtime/src/layout/page-gutter.tsx
+++ b/packages/sdui-runtime/src/layout/page-gutter.tsx
@@ -208,6 +208,11 @@ export function resolveGroupRowGap(
  * group is spacing-transparent — its children space exactly as if inlined at the
  * page level, with no doubled gutter at the group's edges. No horizontal gutter:
  * the group owns horizontal layout (Box `direction` / `align` / `justify`).
+ *
+ * Precondition: rendered only from inside the group's `items.map(...)`, so
+ * `count` (= `items.length`) is ≥ 1 whenever this mounts. The last-child rule
+ * keys off `index === count - 1`; passing `count === 0` would leave a lone child's
+ * bottom margin un-zeroed, so callers must not invoke it for an empty group.
  */
 export function GroupGutterItem({
   node,

--- a/packages/sdui-runtime/src/snippets/GroupConfig/GroupConfig.renderer.tsx
+++ b/packages/sdui-runtime/src/snippets/GroupConfig/GroupConfig.renderer.tsx
@@ -4,6 +4,7 @@ import { GroupConfigSchema } from "@one-impression/sdk-native-sdui";
 import { Box, Card as DSCard } from "@one-impression/ui-native";
 import { SduiNode } from "../../sdui-node/index.js";
 import { Interpreter } from "../../interpreter/index.js";
+import { GroupGutterItem } from "../../layout/page-gutter.js";
 
 /** Friendly wire alignment values → RN flex values. */
 const ALIGN: Record<string, "flex-start" | "center" | "flex-end" | "stretch"> = {
@@ -27,7 +28,12 @@ const JUSTIFY: Record<
 /**
  * group_config — recursive layout group. `stacking` sets the axis; the extra
  * config below is read raw (wire extension, not yet in the schema):
- *   - `gap`       spacing token ("sm"/"md"/…) or number between items
+ *   - `gap`       spacing token ("sm"/"md"/…) or number between items. VERTICAL
+ *                 groups inherit the page's per-item vertical rhythm by default
+ *                 (so a plain group spaces like inlined page items); `gap` here
+ *                 re-spaces every child group-wide, and a child node's own `gap`
+ *                 overrides it per-child. HORIZONTAL groups use this as a uniform
+ *                 between-child gap (default `sm`).
  *   - `align`     cross-axis: start | center | end | stretch
  *   - `justify`   main-axis: start | center | end | between | around | evenly
  *   - `item_flex` "equal" → each item flexes to fill the axis evenly
@@ -38,7 +44,7 @@ const JUSTIFY: Record<
 export function GroupConfigRenderer(node: Node): React.ReactElement {
   const cfg = node.data as
     | {
-        gap?: number;
+        gap?: string | number;
         align?: string;
         justify?: string;
         item_flex?: string;
@@ -61,22 +67,41 @@ export function GroupConfigRenderer(node: Node): React.ReactElement {
       {(v) => {
         const horizontal = v.stacking === "horizontal";
         const equal = cfg?.item_flex === "equal";
+        const items = v.items ?? [];
         const content = (
           <Box
             direction={horizontal ? "row" : "column"}
-            gap={cfg?.gap ?? "sm"}
+            // Horizontal groups use the Box's uniform gap (vertical margin is
+            // meaningless on a row). Vertical groups inherit the page's per-item
+            // rhythm via GroupGutterItem instead — so spacing is overridable
+            // per-child and a plain group stays spacing-transparent.
+            gap={horizontal ? (cfg?.gap ?? "sm") : undefined}
             align={cfg?.align ? ALIGN[cfg.align] : undefined}
             justify={cfg?.justify ? JUSTIFY[cfg.justify] : undefined}
           >
-            {v.items?.map((item: Node, i: number) =>
-              equal ? (
-                <Box key={item.id || i} flex={1}>
+            {items.map((item: Node, i: number) => {
+              const key = item.id || i;
+              const inner = equal ? (
+                <Box flex={1}>
                   <Interpreter node={item} />
                 </Box>
               ) : (
-                <Interpreter key={item.id || i} node={item} />
-              ),
-            )}
+                <Interpreter node={item} />
+              );
+              return horizontal ? (
+                <React.Fragment key={key}>{inner}</React.Fragment>
+              ) : (
+                <GroupGutterItem
+                  key={key}
+                  node={item}
+                  index={i}
+                  count={items.length}
+                  groupGap={cfg?.gap}
+                >
+                  {inner}
+                </GroupGutterItem>
+              );
+            })}
           </Box>
         );
         // One card around the whole group (children stay plain).


### PR DESCRIPTION
Consolidation merge to main ahead of the SDUI resilience work. Group_config vertical children inherit the page's per-item rhythm (per-child / group-level / page-default gap precedence).

Note: playground demo files for this feature remain local WIP and are intentionally not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)